### PR TITLE
Use the name Locutus consistently in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 A distributed, decentralized, key-value store in which keys are cryptographic contracts which determine what values are valid under that key.
 
-The store is observable, allowing applications built on Freenet2 to listen for changes to values and be notified immediately. The cryptographic contracts are specified in web assembly.
+The store is observable, allowing applications built on Locutus to listen for changes to values and be notified immediately. The cryptographic contracts are specified in web assembly.
 
 This key-value store serves as a foundation for decentralized, scalable, and trustless alternatives to centralized services, including email, instant messaging, and social networks, many of which rely on closed proprietary protocols.
 
-Freenet2 is implemented in Rust on top of the libp2p library and will be available across all major operating systems, Desktop and mobile.
+Locutus is implemented in Rust on top of the libp2p library and will be available across all major operating systems, Desktop and mobile.
 
 ### Value
 
 The Internet has grown increasingly centralized over the past 25 years, such that a handful of companies now effectively control the Internet infrastructure. This happened because building decentralized applications is much more difficult than building their centralized equivalents.
 
-Freenet2's purpose is to make it easy to build decentralized services and also to provide reference implementations of the most popular services such as email and instant messaging.
+Locutus's purpose is to make it easy to build decentralized services and also to provide reference implementations of the most popular services such as email and instant messaging.
 
-We're building Freenet2 on the Rust implementation of libp2p meaning our developers will contribute improvements to this project, including code, testing, and more general feedback. benefitting systems built on libp2p, including FileCoin.
+We're building Locutus on the Rust implementation of libp2p meaning our developers will contribute improvements to this project, including code, testing, and more general feedback. benefitting systems built on libp2p, including FileCoin.
 
 Our "chainless" smart contract approach will result in learnings for IPFS-native applications and FileCoin's smart contract initiative.
 
@@ -22,8 +22,5 @@ Lastly, our deployment of a libp2p application to the major mobile platforms wil
 
 ### Status
 
-Freenet2 is currently in development with an initial release planned for Q1 2022.
+Locutus is currently in development with an initial release planned for Q1 2022.
 
-### Naming
-
-"Locutus" is the development codename for this project which is also known as "Freenet2".


### PR DESCRIPTION
Remove Freenet2 naming, as was the outcome of the discussion: The focus is different and the name Freenet2 gets people to think that this is a compatible re-implementation in a different language instead of a different project that supports the goals of the Freenet Project nonprofit.