### PR TITLE
feat(blogging): add run script

### DIFF
--- a/contracts/freenet-microblogging/Makefile
+++ b/contracts/freenet-microblogging/Makefile
@@ -1,0 +1,43 @@
+# expected make version >= 3.82
+
+.ONESHELL:
+
+VIEW_DIR =./view
+VIEW_FILES=$(wildcard ./view/*)
+
+MODEL_DIR =./model
+MODEL_FILES=$(wildcard ./model/*)
+
+LOCUTUS_DIR=$(shell cd ../.. && pwd)
+
+view: $(VIEW_FILES)
+	cd $(LOCUTUS_DIR)
+	cd contracts/freenet-microblogging
+	cd $(VIEW_DIR)
+
+	CARGO_TARGET_DIR=./ bash compile_contract.sh
+	mv ./freenet_microblogging_view.wasm ../../../crates/http-gw/examples/
+
+	cd $(LOCUTUS_DIR)
+	cd crates/locutus-dev
+	cargo run --bin build_state -- --input-path ../../contracts/freenet-microblogging/view/web --output-file ../http-gw/examples/freenet_microblogging_view --contract-type view
+
+model: $(MODEL_FILES)
+	cd $(LOCUTUS_DIR)
+	cd contracts/freenet-microblogging
+	cd $(MODEL_DIR)
+
+	CARGO_TARGET_DIR=./ bash compile_contract.sh
+	mv ./freenet_microblogging_model.wasm ../../../crates/http-gw/examples/
+
+	cd $(LOCUTUS_DIR)
+	cd crates/locutus-dev
+	cargo run --bin build_state -- --input-path ../../contracts/freenet-microblogging/model/initial_state.json --output-file ../http-gw/examples/freenet_microblogging_model --contract-type model
+
+build: model view
+
+run: build
+	cargo run --example contract_browsing --features local
+
+insert_model_key_into_web:
+	bash insert_model_key_into_web.sh 

--- a/contracts/freenet-microblogging/insert_model_key_into_web.sh
+++ b/contracts/freenet-microblogging/insert_model_key_into_web.sh
@@ -1,0 +1,5 @@
+timeout 3 cargo run --example contract_browsing --features local 2> LOCUTUS_TMP | sleep 3
+LOCUTUS_BLOG_MODEL_KEY=$(cat LOCUTUS_TMP | grep -o 'loading model contract \w*' | grep -o '\w*$')
+cat view/state.html | sed "s/let MODEL_CONTRACT = .*/let MODEL_CONTRACT = '$LOCUTUS_BLOG_MODEL_KEY';/g" > ./view/web/state.html
+unset LOCUTUS_BLOG_MODEL_KEY
+rm LOCUTUS_TMP 


### PR DESCRIPTION
The only thing to note is that after refreshing model we need to change a contract key(`MODEL_CONTRACT`) manually for now. 
Since the model base changes rarely I don't think that's it's critical. We can waiting for more maturing infra maybe.  
But as a quick solution I can suggest solving that with the following automation script(can be additionally introduced): `running node(contract_browsing), grepping model key, and substitute that key inside state.html; stopping node; regenerate view, running node`. Or just run some bin which does that. I'm not sure about the right solution for now.