### PR TITLE
Compiles on windows

### DIFF
--- a/crates/locutus-stdlib/Cargo.toml
+++ b/crates/locutus-stdlib/Cargo.toml
@@ -33,15 +33,15 @@ xz2 = { version = "0.1", optional = true }
 # internal
 locutus-macros = { path = "../locutus-macros", version = "0.0.3" }
 
-[target.'cfg(target_family = "unix")'.dependencies]
+[target.'cfg(any(unix, windows))'.dependencies]
 tokio = { version = "1", optional = true, features = ["macros", "parking_lot", "rt-multi-thread", "sync", "time"] }
 tokio-tungstenite = { version = "0.18", optional = true } 
 
-[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 serde-wasm-bindgen = { version = "0.5", optional = true }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
 
-[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.web-sys]
+[target.'cfg(target_family = "wasm")'.dependencies.web-sys]
 version = "0.3"
 features = [
   "BinaryType",
@@ -54,7 +54,7 @@ features = [
 ]
 optional = true
 
-[target.'cfg(target_family = "unix")'.dev-dependencies]
+[target.'cfg(any(unix, windows))'.dev-dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 bincode = "1"
 wasmer = { version = "3", features = [ "sys-default"] }

--- a/crates/locutus-stdlib/src/buf.rs
+++ b/crates/locutus-stdlib/src/buf.rs
@@ -336,7 +336,7 @@ pub fn initiate_buffer(capacity: u32) -> i64 {
     buffer as i64
 }
 
-#[cfg(all(test, target_family = "unix"))]
+#[cfg(all(test, any(unix, windows)))]
 mod test {
     use super::*;
     use wasmer::{

--- a/crates/locutus-stdlib/src/client_api.rs
+++ b/crates/locutus-stdlib/src/client_api.rs
@@ -12,22 +12,14 @@
 //!               (In order to use this client from JS/Typescript refer to the Typescript std lib).
 mod client_events;
 
-#[cfg(target_family = "unix")]
+#[cfg(any(unix, windows))]
 mod regular;
-#[cfg(target_family = "unix")]
+#[cfg(any(unix, windows))]
 pub use regular::*;
 
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-))]
+#[cfg(target_family = "wasm")]
 mod browser;
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-))]
+#[cfg(target_family = "wasm")]
 pub use browser::*;
 
 pub use client_events::*;
@@ -42,7 +34,7 @@ pub enum Error {
     Serialization(#[from] rmp_serde::encode::Error),
     #[error("channel closed")]
     ChannelClosed,
-    #[cfg(target_family = "unix")]
+    #[cfg(any(unix, windows))]
     #[error(transparent)]
     ConnectionError(#[from] tokio_tungstenite::tungstenite::Error),
     #[cfg(target_family = "wasm")]

--- a/crates/locutus-stdlib/src/contract_interface.rs
+++ b/crates/locutus-stdlib/src/contract_interface.rs
@@ -557,7 +557,7 @@ impl std::fmt::Display for Contract<'_> {
     }
 }
 
-#[cfg(all(any(test, feature = "testing"), target_family = "unix"))]
+#[cfg(all(any(test, feature = "testing"), any(unix, windows)))]
 impl<'a> arbitrary::Arbitrary<'a> for Contract<'static> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let contract: ContractCode = u.arbitrary()?;
@@ -837,7 +837,7 @@ impl<'a> DerefMut for StateSummary<'a> {
     }
 }
 
-#[cfg(all(any(test, feature = "testing"), target_family = "unix"))]
+#[cfg(all(any(test, feature = "testing"), any(unix, windows)))]
 impl<'a> arbitrary::Arbitrary<'a> for StateSummary<'static> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let data: Vec<u8> = u.arbitrary()?;
@@ -941,7 +941,7 @@ impl PartialEq for ContractCode<'_> {
 
 impl Eq for ContractCode<'_> {}
 
-#[cfg(all(any(test, feature = "testing"), target_family = "unix"))]
+#[cfg(all(any(test, feature = "testing"), any(unix, windows)))]
 impl<'a> arbitrary::Arbitrary<'a> for ContractCode<'static> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let data: Vec<u8> = u.arbitrary()?;
@@ -971,7 +971,7 @@ impl std::fmt::Display for ContractCode<'_> {
 #[serde_as]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Hash)]
 #[cfg_attr(
-    all(any(test, feature = "testing"), target_family = "unix"),
+    all(any(test, feature = "testing"), any(unix, windows)),
     derive(arbitrary::Arbitrary)
 )]
 #[repr(transparent)]
@@ -1032,7 +1032,7 @@ impl Display for ContractInstanceId {
 #[serde_as]
 #[derive(Debug, Eq, Clone, Serialize, Deserialize)]
 #[cfg_attr(
-    all(any(test, feature = "testing"), target_family = "unix"),
+    all(any(test, feature = "testing"), any(unix, windows)),
     derive(arbitrary::Arbitrary)
 )]
 pub struct ContractKey {
@@ -1691,7 +1691,7 @@ pub(crate) mod wasm_interface {
     conversion!(Result<StateDelta<'static>, ContractError>: ResultKind::StateDelta);
 }
 
-#[cfg(all(test, target_family = "unix"))]
+#[cfg(all(test, any(unix, windows)))]
 mod test {
     use super::*;
     use once_cell::sync::Lazy;

--- a/crates/locutus-stdlib/src/lib.rs
+++ b/crates/locutus-stdlib/src/lib.rs
@@ -1,21 +1,12 @@
 //! Standard library provided by the Freenet project to be able to write Locutus-compatible contracts.
 #[doc(hidden)]
 pub mod buf;
-#[cfg(all(
-    feature = "net",
-    any(
-        all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ),
-        target_family = "unix"
-    )
-))]
+#[cfg(all(feature = "net", any(unix, windows, target_family = "wasm")))]
 pub mod client_api;
 mod contract_interface;
 mod delegate_interface;
 pub(crate) mod global;
+#[cfg(target_family = "wasm")]
 pub mod time;
 mod versioning;
 #[cfg(feature = "archive")]


### PR DESCRIPTION
Changed unix conditionals to match windows as well.
Removed the `time` module from the public interface of `locutus_stdlib` when not on wasm platforms.
If the `time` module is ever needed we can just directly use the implementation from `locutus_runtime`.