### PR TITLE
update broken link. point to dev tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To learn more about Locutus as a developer read [The Locutus Book](https://docs.
 
 ## Status
 
-Locutus is currently under development. Using our [development guide](https://docs.freenet.org/dev-guide.html), developers can experiment with building decentralized applications using our SDK and testing them locally. 
+Locutus is currently under development. Using our [development guide](https://docs.freenet.org/tutorial.html), developers can experiment with building decentralized applications using our SDK and testing them locally.
 
 ## Applications
 


### PR DESCRIPTION
Small change to README. Replace broken link to development guide with a link to the tutorial page of the docs site. This seems like the logical replacement since it is the first link that is listed under the "Developer Guide" section on the sidebar menu of the docs site where the `dev-guide.html` lived.