### PR TITLE
Update api.rs

### DIFF
--- a/apps/freenet-email-app/web/src/api.rs
+++ b/apps/freenet-email-app/web/src/api.rs
@@ -675,7 +675,7 @@ pub(crate) async fn node_comms(
                                 crate::log::error(format!("FIXME: {err}"), None)
                             }
                             RequestError::DelegateError(DelegateError::Missing(key))
-                                if &key == IDENTITIES_KEY.get().unwrap() =>
+                                if &key == &IDENTITIES_KEY.get().unwrap() =>
                             {
                                 if let Err(e) =
                                     identity_management::create_delegate(&mut client).await


### PR DESCRIPTION
Error: 🚫 Building project failed: error[E0277]: can't compare `&freenet_stdlib::prelude::DelegateKey` with `freenet_stdlib::prelude::DelegateKey`
   --> web/src/api.rs:678:41
    |
678 | ...                   if &key == IDENTITIES_KEY.get().unwrap() =>
    |                               ^^ no implementation for `&freenet_stdlib::prelude::DelegateKey == freenet_stdlib::prelude::DelegateKey`
    |
    = help: the trait `PartialEq<freenet_stdlib::prelude::DelegateKey>` is not implemented for `&freenet_stdlib::prelude::DelegateKey`
    = help: the trait `PartialEq` is implemented for `freenet_stdlib::prelude::DelegateKey`
    = help: for that trait implementation, expected `freenet_stdlib::prelude::DelegateKey`, found `&freenet_stdlib::prelude::DelegateKey`
    = note: required for `&&freenet_stdlib::prelude::DelegateKey` to implement `PartialEq<&freenet_stdlib::prelude::DelegateKey>`