### PR TITLE
Release v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1443,7 +1443,7 @@ dependencies = [
  "clap",
  "dashmap",
  "either",
- "freenet 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freenet",
  "freenet-stdlib",
  "futures 0.3.31",
  "glob",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1626,79 +1626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "freenet"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230f9c96c74188d7f2af44ae23a84967fdad164ad0469cd466f6fc9615864483"
-dependencies = [
- "aes-gcm",
- "ahash",
- "anyhow",
- "arc-swap",
- "asynchronous-codec",
- "axum",
- "bincode",
- "blake3",
- "bs58",
- "byteorder",
- "bytes 1.10.1",
- "cache-padded",
- "chacha20poly1305",
- "chrono",
- "clap",
- "cookie",
- "crossbeam",
- "ctrlc",
- "dashmap",
- "delegate",
- "directories",
- "either",
- "flatbuffers",
- "freenet-stdlib",
- "futures 0.3.31",
- "headers",
- "hickory-resolver",
- "itertools 0.14.0",
- "notify",
- "once_cell",
- "opentelemetry 0.29.1",
- "opentelemetry-jaeger",
- "opentelemetry-otlp",
- "ordered-float 5.0.0",
- "parking_lot",
- "pav_regression",
- "pkcs8",
- "rand 0.8.5",
- "redb",
- "reqwest",
- "rsa",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "stretto",
- "tar",
- "thiserror 2.0.12",
- "time",
- "tokio",
- "tokio-tungstenite 0.26.2",
- "toml",
- "tower-http",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
- "ulid",
- "unsigned-varint",
- "wasmer",
- "wasmer-compiler-singlepass",
- "wasmer-middlewares",
- "winapi",
- "wmi",
- "xz2",
-]
-
-[[package]]
 name = "freenet-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,7 +1643,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "freenet 0.1.5",
+ "freenet",
  "freenet-ping-types",
  "freenet-stdlib",
  "futures 0.3.31",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -38,7 +38,7 @@ reqwest = { version = "0.12", features = ["json"] }
 http = "1.2"
 
 # internal
-freenet = { version = "0.1.5"}
+freenet = { path = "../core", version = "0.1.6"}
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
Bump version to 0.1.6 for release after fixing critical production issues with decryption errors and subscription handling.