### PR TITLE
Release v0.1.19

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,29 +1,75 @@
-## 📁 Organized Notes System
-
-All debugging notes have been reorganized into `claude.notes.local/` for better navigation:
-
-### [→ Go to Main Index](./claude.notes.local/index.md)
-
-### Quick Links
-
-- **[Current Focus: Connection Stability](./claude.notes.local/active/connection-stability-2025-06-25.md)**
-- **[Active Hypotheses](./claude.notes.local/active/hypotheses.md)**
-- **[Essential Commands](./claude.notes.local/reference/commands.md)**
-- **[Code Locations](./claude.notes.local/reference/code-locations.md)**
+- contract states are commutative monoids, they can be "merged" in any order to arrive at the same result. This may reduce some potential race conditions.
 
 ## Important Testing Notes
 
 ### Always Use Network Mode for Testing
-
 - **NEVER use local mode for testing** - it uses very different code paths
 - Local mode bypasses critical networking components that need to be tested
 - Always test with `freenet network` to ensure realistic behavior
 
-## Current Priority (2025-06-25)
+## Quick Reference - Essential Commands
 
-Per discussion with Nacho:
+### River Development
+```bash
+# Publish River (use this, not custom scripts)
+cd ~/code/freenet/river && RUST_MIN_STACK=16777216 cargo make publish-river-debug
 
-1. **Focus**: Connection stability to gateways
-2. **Goal**: 10+ minute stable connections
-3. **Method**: Create minimal transport test binary
-4. **Avoid**: Getting distracted by River/contract issues
+# Verify River build time (CRITICAL - only way to confirm new version is served)
+curl -s http://127.0.0.1:50509/v1/contract/web/BcfxyjCH4snaknrBoCiqhYc9UFvmiJvhsp5d4L5DuvRa/ | grep -o 'Built: [^<]*' | head -1
+```
+
+### Freenet Management
+```bash
+# Start Freenet
+./target/release/freenet network > freenet-debug.log 2>&1 &
+
+# Check status
+ps aux | grep freenet | grep -v grep | grep -v tail | grep -v journalctl
+
+# Monitor logs
+tail -f freenet-debug.log
+```
+
+## Detailed Documentation Files
+
+### Current Active Debugging
+- **Directory**: `freenet-invitation-bug.local/` (consolidated debugging)
+  - `README.md` - Overview and quick commands
+  - `river-notes/` - River-specific debugging documentation
+  - `contract-test/` - Minimal Rust test to reproduce PUT/GET issue
+  
+### River Invitation Bug (2025-01-18)
+- **Status**: CONFIRMED - Contract operations hang on live network, work in integration tests
+- **Root Cause**: Freenet node receives WebSocket requests but never responds
+- **Test Directory**: `freenet-invitation-bug.local/live-network-test/`
+- **Confirmed Findings**:
+  - River correctly sends PUT/GET requests via WebSocket
+  - Raw WebSocket test: Receives binary error response from server
+  - freenet-stdlib test: GET request sent but never receives response (2min timeout)
+  - Integration test `test_put_contract` passes when run in isolation
+  - Issue affects both PUT and GET operations
+- **Current Investigation**: Systematically debugging why Freenet node doesn't respond to contract operations
+- **See**: `freenet-invitation-bug.local/river-notes/invitation-bug-analysis-update.md`
+
+### Historical Analysis (Reference Only)
+- **Transport Layer Issues**: See lines 3-145 in previous version of this file (archived)
+- **River Testing Procedures**: See lines 97-145 in previous version of this file (archived)
+
+### CI Tools
+- **GitHub CI Monitoring**: `~/code/agent.scripts/wait-for-ci.sh [PR_NUMBER]`
+
+### Testing Tools
+- **Puppeteer Testing Guide**: `puppeteer-testing-guide.local.md` - Essential patterns for testing Dioxus apps with MCP Puppeteer tools
+- **Playwright Notes**: `playwright-notes.local.md` - Learnings and patterns for testing River with Playwright MCP tools
+
+## Key Code Locations
+- **River Room Creation**: `/home/ian/code/freenet/river/ui/src/components/room_list/create_room_modal.rs`
+- **River Room Synchronizer**: `/home/ian/code/freenet/river/ui/src/components/app/freenet_api/room_synchronizer.rs`
+- **River Room Data**: `/home/ian/code/freenet/river/ui/src/room_data.rs`
+
+## Organization Rules
+1. **Check this file first** for command reference and active debugging directories
+2. **Use standard commands** instead of creating custom scripts
+3. **Verify River build timestamps** after publishing
+4. **Create timestamped .local directories** for complex debugging sessions
+5. **Update this index** when adding new debugging directories or tools

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "0.12", features = ["json"] }
 http = "1.2"
 
 # internal
-freenet = { path = "../core", version = "0.1.18" }
+freenet = { path = "../core", version = "0.1.19" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
Simple version bump to v0.1.19 based on current main branch.

This includes all the fixes that have been merged to main, including:
- Hector's node monitor diagnostics (#1681)
- Toml dependency update to 0.9.2 (#1692)
- All other fixes and improvements since v0.1.18

This approach avoids the complex merge conflicts from trying to rebase old code.