### PR TITLE
Split new/init like Cargo, Dioxus, and others

### DIFF
--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -38,6 +38,7 @@ pub struct BaseConfig {
 
 #[derive(clap::Subcommand, Clone)]
 pub enum SubCommand {
+    Init(InitPackageConfig),
     New(NewPackageConfig),
     Build(BuildToolConfig),
     Inspect(crate::inspect::InspectConfig),
@@ -191,11 +192,31 @@ fn parse_version(src: &str) -> Result<Version, String> {
     Version::parse(src).map_err(|e| e.to_string())
 }
 
+/// Initialize a new Freenet contract and/or app in the CWD by default.
+#[derive(clap::Parser, Clone)]
+pub struct InitPackageConfig {
+    #[arg(id = "type", value_enum)]
+    pub(crate) kind: ContractKind,
+    #[arg(short, long, value_name = "PATH", value_hint = clap::ValueHint::DirPath)]
+    pub(crate) path: Option<PathBuf>,
+}
+
+impl From<NewPackageConfig> for InitPackageConfig {
+    fn from(NewPackageConfig { kind, path }: NewPackageConfig) -> Self {
+        Self {
+            kind,
+            path: path.into(),
+        }
+    }
+}
+
 /// Create a new Freenet contract and/or app.
 #[derive(clap::Parser, Clone)]
 pub struct NewPackageConfig {
     #[arg(id = "type", value_enum)]
     pub(crate) kind: ContractKind,
+    #[arg(value_name = "PATH", value_hint = clap::ValueHint::DirPath)]
+    pub(crate) path: PathBuf,
 }
 
 #[derive(clap::ValueEnum, Clone)]

--- a/crates/fdev/src/main.rs
+++ b/crates/fdev/src/main.rs
@@ -51,7 +51,8 @@ fn main() -> anyhow::Result<()> {
             }
             SubCommand::Build(build_tool_config) => build_package(build_tool_config, &cwd),
             SubCommand::Inspect(inspect_config) => inspect(inspect_config),
-            SubCommand::New(new_pckg_config) => create_new_package(new_pckg_config),
+            SubCommand::Init(init_pckg_config) => create_new_package(init_pckg_config),
+            SubCommand::New(new_pckg_config) => create_new_package(new_pckg_config.into()),
             SubCommand::Publish(publish_config) => put(publish_config, config.additional).await,
             SubCommand::Execute(cmd_config) => match cmd_config.command {
                 config::NodeCommand::Put(put_config) => put(put_config, config.additional).await,


### PR DESCRIPTION
Cargo and Dioxus' support creating a new folder for new projects as well as initializing in the current working directory. Deno supports both as well but under the "init" subcommand.

I mainly added this feature for ergonomics but also because it's easy to implement.