### PR TITLE
fix: Improve protocol version mismatch error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -868,20 +868,12 @@ impl P2pConnManager {
                 tracing::info!(%peer_id, "Connection failed: {:?}", error);
                 if self.check_version {
                     if let HandshakeError::TransportError(
-                        TransportError::ProtocolVersionMismatch { expected, actual },
+                        TransportError::ProtocolVersionMismatch { .. },
                     ) = &error
                     {
-                        tracing::error!(
-                            %peer_id,
-                            "Protocol version mismatch: expected {}, got {}",
-                            expected,
-                            actual
-                        );
-                        return Err(anyhow::anyhow!(
-                            "Protocol version mismatch: expected {}, got {}",
-                            expected,
-                            actual
-                        ));
+                        // The TransportError already has a user-friendly error message
+                        // Just propagate it without additional logging to avoid duplication
+                        return Err(error.into());
                     }
                 }
                 if let Some(mut r) = state.awaiting_connection.remove(&peer_id.addr) {

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -481,7 +481,16 @@ impl<S: Socket> UdpPacketsListener<S> {
                             }
                         }
                         Err((error, remote_addr)) => {
-                            tracing::error!(%error, ?remote_addr, "Failed to establish connection");
+                            // Only log non-version-mismatch errors at error level
+                            // Version mismatches have their own user-friendly error message
+                            match &error {
+                                TransportError::ProtocolVersionMismatch { .. } => {
+                                    tracing::info!(?remote_addr, "Connection failed due to version mismatch");
+                                }
+                                _ => {
+                                    tracing::error!(%error, ?remote_addr, "Failed to establish connection");
+                                }
+                            }
                             if let Some((_, result_sender)) = ongoing_connections.remove(&remote_addr) {
                                 let _ = result_sender.send(Err(error));
                             }

--- a/crates/core/src/transport/mod.rs
+++ b/crates/core/src/transport/mod.rs
@@ -48,7 +48,7 @@ pub(crate) enum TransportError {
     ConnectionClosed(SocketAddr),
     #[error("failed while establishing connection, reason: {cause}")]
     ConnectionEstablishmentFailure { cause: Cow<'static, str> },
-    #[error("wrong version of the protocol for gateway, expected {expected}, got {actual}")]
+    #[error("Version incompatibility with gateway\n  Your client version: {actual}\n  Gateway version: {expected}\n  \n  To fix this, update your Freenet client:\n    cargo install --force freenet --version {expected}\n  \n  Or if building from source:\n    git pull && cargo install --path crates/core")]
     ProtocolVersionMismatch {
         expected: String,
         actual: &'static str,


### PR DESCRIPTION
## Summary

This PR improves the error messages when there's a protocol version mismatch between a client and gateway, making them much clearer and more actionable.

## Changes

- **Clear error message**: Instead of the confusing "expected X, got Y" message, now shows:
  - Your client version 
  - Gateway version
  - Specific instructions on how to fix the issue
  
- **Reduced log noise**: Prevents duplicate error logging at multiple layers

- **Appropriate log levels**: Changed version mismatch logs from error to info level since it's an expected condition during updates

## Example of new error message

```
Version incompatibility with gateway
  Your client version: 0.1.22
  Gateway version: 0.1.23
  
  To fix this, update your Freenet client:
    cargo install --force freenet --version 0.1.23
  
  Or if building from source:
    git pull && cargo install --path crates/core
```

## Why this matters

During alpha testing, version mismatches are common as we update frequently. The previous error messages were confusing users because:
1. The "expected vs got" wording was backwards from the user's perspective
2. Multiple layers logged the same error
3. No guidance was provided on how to resolve the issue

This change makes it immediately clear what's wrong and how to fix it.

[AI-assisted debugging and comment]

🤖 Generated with [Claude Code](https://claude.ai/code)