### PR TITLE
feat: enhance fdev query to show subscriptions and add update tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,12 +1948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-
-[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,7 +2264,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2290,7 +2284,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -2433,7 +2427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
 ]
@@ -2658,18 +2652,18 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -4326,9 +4320,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4368,18 +4362,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4959,9 +4953,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.3",
@@ -6191,7 +6185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6203,7 +6197,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6215,21 +6209,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.0",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6238,7 +6219,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6283,7 +6264,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -6294,8 +6275,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6308,30 +6289,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
-dependencies = [
- "windows-link 0.2.0",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
-dependencies = [
- "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -6608,7 +6571,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.16",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6619,9 +6582,9 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xattr"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -175,6 +175,16 @@ impl Operation for UpdateOp {
                     let has_subscribers = op_manager.ring.subscribers_of(key).is_some();
                     let should_handle_update = is_seeding || has_subscribers;
 
+                    tracing::info!(
+                        "UPDATE_RECEIVED: tx={} contract={:.8} from={} at={} seeding={} subscribers={}",
+                        id,
+                        key,
+                        sender.peer,
+                        target.peer,
+                        is_seeding,
+                        has_subscribers
+                    );
+
                     tracing::debug!(
                         tx = %id,
                         %key,
@@ -512,6 +522,27 @@ impl OpManager {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
+
+        // Trace update propagation for debugging
+        if !subscribers.is_empty() {
+            tracing::info!(
+                "UPDATE_PROPAGATION: contract={:.8} from={} targets={} count={}",
+                key,
+                sender,
+                subscribers
+                    .iter()
+                    .map(|s| format!("{:.8}", s.peer))
+                    .collect::<Vec<_>>()
+                    .join(","),
+                subscribers.len()
+            );
+        } else {
+            tracing::warn!(
+                "UPDATE_PROPAGATION: contract={:.8} from={} NO_TARGETS - update will not propagate",
+                key,
+                sender
+            );
+        }
 
         subscribers
     }

--- a/crates/fdev/src/query.rs
+++ b/crates/fdev/src/query.rs
@@ -8,6 +8,8 @@ use crate::{
 
 pub async fn query(base_cfg: BaseConfig) -> anyhow::Result<()> {
     let mut client = start_api_client(base_cfg).await?;
+
+    // Query for connected peers
     tracing::info!("Querying for connected peers");
     execute_command(
         freenet_stdlib::client_api::ClientRequest::NodeQueries(NodeQuery::ConnectedPeers),
@@ -34,7 +36,41 @@ pub async fn query(base_cfg: BaseConfig) -> anyhow::Result<()> {
         ]));
     }
 
+    println!("\n=== Connected Peers ===");
     table.printstd();
+
+    // Query for subscription info
+    tracing::info!("Querying for subscription info");
+    execute_command(
+        freenet_stdlib::client_api::ClientRequest::NodeQueries(NodeQuery::SubscriptionInfo),
+        &mut client,
+    )
+    .await?;
+
+    let HostResponse::QueryResponse(QueryResponse::NetworkDebug(info)) = client.recv().await?
+    else {
+        anyhow::bail!("Unexpected response from the host");
+    };
+
+    // Display application subscription info
+    println!("\n=== Application Subscriptions (WebSocket Clients) ===");
+    if !info.subscriptions.is_empty() {
+        let mut sub_table = Table::new();
+        sub_table.add_row(Row::new(vec![
+            Cell::new("Contract Key"),
+            Cell::new("Client ID"),
+        ]));
+
+        for sub in info.subscriptions {
+            sub_table.add_row(Row::new(vec![
+                Cell::new(&format!("{:.8}...", sub.contract_key)),
+                Cell::new(&sub.client_id.to_string()),
+            ]));
+        }
+        sub_table.printstd();
+    } else {
+        println!("No application subscriptions");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds visibility into subscription topology and update propagation to help debug issue #1848.

- Enhanced `fdev query` to display application subscriptions
- Added UPDATE_RECEIVED and UPDATE_PROPAGATION trace logging
- Logs show update flow through network with target peers  
- Warns when updates have no targets (isolated nodes)

## Changes

### fdev query enhancement
- Shows application subscriptions (WebSocket clients)
- Displays contract keys and client IDs for active subscriptions

### Update trace logging  
- `UPDATE_RECEIVED`: Logs when a node receives an update (with tx ID, contract, sender, receiver)
- `UPDATE_PROPAGATION`: Shows where updates propagate to (with list of target peers)
- Warns with `NO_TARGETS` when updates can't propagate due to missing subscriptions

## Testing

Enable trace logging to see update propagation:
```bash
RUST_LOG=info freenet network
fdev query  # See current subscriptions
```

The multi-machine-test can be used to verify update propagation patterns after these changes are merged.

## Related Issues

Helps debug #1848 by providing visibility into:
- Which clients subscribe to which contracts
- How updates propagate (or fail to propagate) through the network  
- When nodes become isolated with no subscription paths

🤖 Generated with [Claude Code](https://claude.ai/code)