### PR TITLE
fix: Phase 2 - Fix transaction ID mismatch for subscription responses (#1848)

### DIFF
--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -60,6 +60,12 @@ pub(crate) fn start_op(key: ContractKey) -> SubscribeOp {
     SubscribeOp { id, state }
 }
 
+/// Phase 2 fix for issue #1848: Allow subscribe with specific transaction ID
+pub(crate) fn start_op_with_id(key: ContractKey, id: Transaction) -> SubscribeOp {
+    let state = Some(SubscribeState::PrepareRequest { id, key });
+    SubscribeOp { id, state }
+}
+
 /// Request to subscribe to value changes from a contract.
 pub(crate) async fn request_subscribe(
     op_manager: &OpManager,


### PR DESCRIPTION
## Summary
Phase 2 fix for the update propagation architecture issue identified in #1848.

This PR fixes the root cause of "Timeout waiting for subscribe response" errors that prevented River chat from working.

## The Bug
The subscription timeout was caused by a transaction ID mismatch:
1. RequestRouter creates transaction ID `A` and registers client to wait for it
2. Subscribe operation creates its own transaction ID `B` internally
3. When operation completes, result is delivered with ID `B`
4. Client is waiting for ID `A`, never receives response → timeout

## The Fix
- Added `start_op_with_id()` to subscribe operations (matching pattern used by get/put/update)
- Pass RequestRouter's transaction ID to the subscribe operation
- Ensures result delivery uses the same ID the client is waiting for

## Test Results
✅ River chat test now passes:
- Room creation succeeds
- Subscription responses reach clients
- No more timeout errors

## Dependencies
This PR is based on #1850 (Phase 1). Once #1850 is merged, this can be rebased onto main.

## Related Issues
- Fixes the subscription timeout part of #1848 (Phase 2 of 3)
- Resolves timeout issues in freenet/river#33, freenet/river#34

[AI-assisted debugging and comment]

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>