### PR TITLE
Restore test_three_node_network_connectivity as minimal failing test for peer connectivity bug

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -192,9 +192,11 @@ impl Operation for ConnectOp {
                             skip_forwards = ?skip_forwards,
                             "Got queried for new connections from joiner",
                         );
+                        // Use the full skip_connections set to avoid recommending peers
+                        // that the joiner is already connected to (including the gateway itself)
                         if let Some(desirable_peer) = op_manager.ring.closest_to_location(
                             *ideal_location,
-                            HashSet::from([joiner.peer.clone()]),
+                            skip_connections.iter().cloned().collect(),
                         ) {
                             tracing::debug!(
                                 tx = %id,


### PR DESCRIPTION
## Summary

This PR restores `test_three_node_network_connectivity` and fixes a critical bug in peer recommendation that was preventing peer-to-peer mesh formation.

## Changes

### 1. Restored Test (commit ba64098)
Restored `test_three_node_network_connectivity` from commit 24a6b7c1. This test verifies full mesh connectivity in a 3-node network (1 gateway + 2 peers).

### 2. Critical Bug Fix: Peer Recommendation Skip-List (commit 18a750e)

**Problem:** In `connect.rs:197`, when handling `FindOptimalPeer` requests, the gateway was only skipping the joiner peer:
```rust
HashSet::from([joiner.peer.clone()])
```

This caused the gateway to repeatedly recommend itself or already-connected peers, preventing mesh formation.

**Fix:** Use the full skip_connections set:
```rust
skip_connections.iter().cloned().collect()
```

**History:** This fix was originally in commit 24a6b7c1 (branch `fix/connection-maintenance-skip-list`) but was never merged to main. This PR reapplies that critical fix.

### 3. Test Configuration Improvements (commit 18a750e)

- Set `min_connections=2` and `max_connections=2` (realistic for 3-node network, default is 25)
- Increased peer startup delays (12s, 17s) to allow `aggressive_initial_connections()` (10s) to complete
- Adjusted test timing to account for staggered startup

## Current Status

**Test Status:** ❌ Still failing

The skip-list fix was necessary but not sufficient. After applying it:
- ✅ Gateway: 2 connections (to both peers)
- ❌ Peer1: 1 connection (only to gateway)
- ❌ Peer2: 1 connection (only to gateway)

Peers successfully connect to the gateway but don't discover each other.

## Investigation Summary

Systematic debugging revealed:

1. **min_connections=25** was too high but configuring it to 2 didn't solve the issue
2. **Timing issues** with `aggressive_initial_connections()` blocking for 10s - addressed with delays
3. **Skip-list bug** (now fixed) - gateway was recommending already-connected peers
4. **Remaining issue** - Even with skip-list fix, peers don't attempt peer-to-peer connections

## Next Steps

Further investigation needed to understand why:
- Topology manager isn't triggering additional connection attempts
- OR connection attempts are being made but failing
- OR the connection_maintenance loop has additional issues

The test provides a minimal reproducer for the peer connectivity bug and the skip-list fix addresses one known issue, but more work is needed.

## Related Issues

- #1904 - test_three_node_network_connectivity was removed
- #1889 - Original topology manager bug  
- #1900 - Ubertest infrastructure (merged)
- #1903 - Select! channel starvation fix (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted debugging and comment]