### PR TITLE
ci: remove shared cache key to fix CI rebuild issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: success() || steps.test.conclusion == 'failure'
         with:
-          shared-key: "rust-cache"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build
@@ -69,7 +68,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "rust-cache"
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build


### PR DESCRIPTION
## Summary

Fixes #1929 by removing the `shared-key: "rust-cache"` parameter from both the `test_all` and `clippy_check` CI jobs.

## Why

The CI was rebuilding dependencies despite reporting cache hits because both jobs shared the same cache key but compiled with different configurations:

- **test_all**: uses `--no-default-features --features trace,websocket,redb`
- **clippy_check**: uses default features and different target binaries

When jobs shared the same cache, cached artifacts didn't match the current build configuration's fingerprint, forcing full rebuilds.

## What Changed

- Removed `shared-key: "rust-cache"` from `test_all` job (line 35)
- Removed `shared-key: "rust-cache"` from `clippy_check` job (line 72)

This allows `rust-cache` to automatically create job-specific cache keys based on job names, ensuring each job:
- Caches only its own build artifacts with correct feature flags
- Restores only matching artifacts on subsequent runs
- Eliminates unnecessary dependency rebuilds

## Expected Outcome

After this change:
- First run on main: Both jobs build from scratch, each saves its own cache
- Subsequent runs: Each job shows cache hit and does NOT rebuild dependencies
- PR runs: Restore cache from main branch with minimal rebuilds

@iduartgomez please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted debugging and comment]