### PR TITLE
feat: attach compiled binaries to GitHub releases

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -6,6 +6,7 @@ on:
   merge_group:
   push:
     branches: [main]
+    tags: ['v*']
 
 jobs:
   build-x86_64:
@@ -74,3 +75,64 @@ jobs:
         with:
           name: binaries-arm64-fdev
           path: target/release/fdev
+
+  attach-to-release:
+    name: Attach binaries to GitHub release
+    runs-on: ubuntu-latest
+    needs: [build-x86_64, build-arm64]
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download x86_64 freenet binary
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-x86_64-freenet
+          path: artifacts/x86_64-freenet
+
+      - name: Download x86_64 fdev binary
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-x86_64-fdev
+          path: artifacts/x86_64-fdev
+
+      - name: Download ARM64 freenet binary
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-arm64-freenet
+          path: artifacts/arm64-freenet
+
+      - name: Download ARM64 fdev binary
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-arm64-fdev
+          path: artifacts/arm64-fdev
+
+      - name: Prepare release assets
+        run: |
+          # Create zip files for each binary with appropriate naming
+          cd artifacts/x86_64-freenet && zip ../../freenet-x86_64-linux.zip freenet && cd ../..
+          cd artifacts/x86_64-fdev && zip ../../fdev-x86_64-linux.zip fdev && cd ../..
+          cd artifacts/arm64-freenet && zip ../../freenet-aarch64-linux.zip freenet && cd ../..
+          cd artifacts/arm64-fdev && zip ../../fdev-aarch64-linux.zip fdev && cd ../..
+
+          # Display the created files
+          ls -lh *.zip
+
+      - name: Upload binaries to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Extract the tag name (e.g., v0.1.30)
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+
+          # Upload all zip files to the release
+          gh release upload "$TAG_NAME" \
+            freenet-x86_64-linux.zip \
+            fdev-x86_64-linux.zip \
+            freenet-aarch64-linux.zip \
+            fdev-aarch64-linux.zip \
+            --repo ${{ github.repository }} \
+            --clobber


### PR DESCRIPTION
Resolves #1930

## Summary

Modifies the cross-compile workflow to automatically attach compiled binaries to GitHub releases when version tags are pushed.

## Changes

- **Trigger on tags**: Added `tags: ['v*']` to workflow triggers
- **New job `attach-to-release`**:
  - Runs after both build jobs complete
  - Only executes when triggered by a version tag
  - Downloads all 4 build artifacts
  - Creates properly named zip files
  - Uploads to GitHub release

## Binary Naming

- `freenet-x86_64-linux.zip` - freenet binary for x86_64 Linux
- `fdev-x86_64-linux.zip` - fdev binary for x86_64 Linux  
- `freenet-aarch64-linux.zip` - freenet binary for ARM64 Linux
- `fdev-aarch64-linux.zip` - fdev binary for ARM64 Linux

## Benefits

✅ **Permanent storage**: Release assets stored indefinitely (vs 90-day artifact expiry)  
✅ **User convenience**: Pre-built binaries available without cargo install  
✅ **Free storage**: Doesn't count against Actions storage quota  
✅ **Future installer**: Enables rustup-style one-line installer (as mentioned by @sanity)  
✅ **Backward compatibility**: Normal PR/push workflows unaffected  

## How It Works

1. When a release tag (e.g., `v0.1.31`) is pushed, the workflow triggers
2. Build jobs compile binaries for x86_64 and ARM64
3. The `attach-to-release` job downloads all artifacts
4. Binaries are zipped with descriptive names
5. Assets are uploaded to the GitHub release using gh CLI

## Testing

This change can be tested on the next release. The workflow will:
- Build binaries as usual for PRs and main branch pushes
- Additionally attach binaries to releases when tags are pushed

[AI-assisted debugging and comment]