### PR TITLE
fix: change default WebSocket port to 7509 to avoid Windows firewall blocking

### DIFF
--- a/apps/freenet-email-app/README.md
+++ b/apps/freenet-email-app/README.md
@@ -170,7 +170,7 @@ After building the app, what remains is to run the local node and the web app. T
 During the development process, changes inside the web app will be automatically reloaded if it is running.
 
 If you, instead, want to access the published app via the `build` command, go to your browser and write an URL like (with the node running):
-`http://localhost:50509/contract/web/5zrr81Nbvk6PjkrXjXXFpDfrNZZvhx2JCc7BZTBHUKDo/`
+`http://localhost:7509/contract/web/5zrr81Nbvk6PjkrXjXXFpDfrNZZvhx2JCc7BZTBHUKDo/`
 
 The hash may be different and you can get it when you run the build command.
 

--- a/apps/freenet-email-app/web/src/api.rs
+++ b/apps/freenet-email-app/web/src/api.rs
@@ -46,7 +46,7 @@ impl WebApi {
     fn new() -> Result<Self, String> {
         use futures::{SinkExt, StreamExt};
         let conn = web_sys::WebSocket::new(
-            "ws://localhost:50509/v1/contract/command?encodingProtocol=native",
+            "ws://localhost:7509/v1/contract/command?encodingProtocol=native",
         )
         .unwrap();
         let (send_host_responses, host_responses) = futures::channel::mpsc::unbounded();

--- a/apps/freenet-microblogging/README.md
+++ b/apps/freenet-microblogging/README.md
@@ -68,7 +68,7 @@ that, run the following command:
    ```
 2. Browse to the following URL to load the microblogging web, note that the hash may be different:
    ```
-   http://127.0.0.1:50509/contract/web/9zaPEBmmMAF3eKy7NnuPUit2j1annxtVY226DWGLzEFN/
+   http://127.0.0.1:7509/contract/web/9zaPEBmmMAF3eKy7NnuPUit2j1annxtVY226DWGLzEFN/
    ```
 
 The hash may be different and you can get it when you run the build command.

--- a/apps/freenet-ping/app/src/main.rs
+++ b/apps/freenet-ping/app/src/main.rs
@@ -15,7 +15,7 @@ use ping_client::{
 
 #[derive(clap::Parser)]
 struct Args {
-    #[clap(long, default_value = "localhost:50509")]
+    #[clap(long, default_value = "localhost:7509")]
     host: String,
     #[clap(long, default_value = "info")]
     log_level: tracing::level_filters::LevelFilter,

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -612,7 +612,7 @@ pub struct WebsocketApiArgs {
     #[serde(rename = "ws-api-address", skip_serializing_if = "Option::is_none")]
     pub address: Option<IpAddr>,
 
-    /// Port to expose the websocket on, default is 50509
+    /// Port to expose the websocket on, default is 7509
     #[arg(long, env = "WS_API_PORT")]
     #[serde(rename = "ws-api-port", skip_serializing_if = "Option::is_none")]
     pub ws_api_port: Option<u16>,
@@ -660,7 +660,7 @@ const fn default_local_address() -> IpAddr {
 
 #[inline]
 const fn default_http_gateway_port() -> u16 {
-    50509
+    7509
 }
 
 #[derive(clap::Parser, Default, Debug, Clone, Serialize, Deserialize)]

--- a/crates/fdev/README.md
+++ b/crates/fdev/README.md
@@ -175,7 +175,7 @@ To push a state delta to an existing contract (identified by its Base58 key):
 fdev execute update <BASE58_CONTRACT_KEY> \
     --delta path/to/delta \
     [--address 127.0.0.1 \
-     --port 50509 \
+     --port 7509 \
      --release]
 ```
 
@@ -539,7 +539,7 @@ To push a state delta to an existing contract (identified by its Base58 key):
 fdev execute update <BASE58_CONTRACT_KEY> \
     --delta path/to/delta.json \
     [--address 127.0.0.1 \
-     --port 50509 \
+     --port 7509 \
      --release]
 ```
 

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -28,7 +28,7 @@ pub struct BaseConfig {
     #[arg(value_enum, default_value_t=OperationMode::Local, env = "MODE")]
     pub mode: OperationMode,
     /// The port of the running local freenet node websocket API.
-    #[arg(short, long, default_value = "50509", env = "WS_API_PORT")]
+    #[arg(short, long, default_value = "7509", env = "WS_API_PORT")]
     pub(crate) port: u16,
     /// The ip address of freenet node to publish the contract to. If the node is running in local mode,
     /// The default value is `127.0.0.1`.

--- a/crates/fdev/src/wasm_runtime.rs
+++ b/crates/fdev/src/wasm_runtime.rs
@@ -65,7 +65,7 @@ pub struct ExecutorConfig {
     #[arg(short, long, default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub(crate) address: IpAddr,
     /// The port of the running local freenet node.
-    #[arg(short, long, default_value = "50509")]
+    #[arg(short, long, default_value = "7509")]
     pub(crate) port: u16,
     /// Node operation mode.
     #[clap(value_enum, default_value_t = OperationMode::Local, env = "MODE")]

--- a/docker/freenet-node/Dockerfile.yml
+++ b/docker/freenet-node/Dockerfile.yml
@@ -41,7 +41,7 @@ COPY freenet-node-startup.sh /usr/local/bin/freenet-node-startup.sh
 RUN chmod +x /usr/local/bin/freenet-node-startup.sh
 
 # Expose default WebSocket API port
-EXPOSE 50509
+EXPOSE 7509
 
 # Use the startup script as the entrypoint
 CMD ["/usr/local/bin/freenet-node-startup.sh"]

--- a/docker/freenet-node/docker-compose.yml
+++ b/docker/freenet-node/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile.yml
     image: freenet-node:latest
     environment:
-      - WS_API_PORT=50509
+      - WS_API_PORT=7509
     network_mode: host
     volumes:
       - freenet-data:/root/.cache/freenet

--- a/docker/freenet-node/freenet-node-startup.sh
+++ b/docker/freenet-node/freenet-node-startup.sh
@@ -9,4 +9,4 @@ NODE_DIR="${BASE_DIR}/node"
 freenet network \
   --config-dir "$BASE_DIR" \
   --data-dir "$NODE_DIR" \
-  --ws-api-port "${WS_API_PORT:-50509}"
+  --ws-api-port "${WS_API_PORT:-7509}"

--- a/scripts/FREENET-NODE-SETUP-GUIDE.md
+++ b/scripts/FREENET-NODE-SETUP-GUIDE.md
@@ -59,7 +59,7 @@ The `freenet-setup.sh` script supports two modes:
 ```
 
 - **<name>**: Unique name for your node or gateway.
-- **[ws-api-port]**: Optional WebSocket API port (default: 50509).
+- **[ws-api-port]**: Optional WebSocket API port (default: 7509).
 
 ### Examples
 

--- a/scripts/freenet-node-setup.sh
+++ b/scripts/freenet-node-setup.sh
@@ -4,12 +4,12 @@
 # Check if required parameters are provided
 if [ -z "$1" ]; then
     echo "Usage: $0 <name> [ws-api-port]"
-    echo "Example: $0 my-node 50509"
+    echo "Example: $0 my-node 7509"
     exit 1
 fi
 
 NAME="$1"
-WS_API_PORT="${3:-50509}"
+WS_API_PORT="${3:-7509}"
 
 # Base Setup
 FREENET_DIR=~/freenet


### PR DESCRIPTION
## Summary

Changes the default WebSocket port from 50509 to 7509 to fix Windows firewall blocking.

## Problem

The default port 50509 falls within Windows 10/11's excluded port range (50000-50059), preventing Freenet nodes from starting on Windows systems. Windows also reserves additional ranges up to 52013+, making port 51509 (suggested earlier) also problematic.

## Solution

Port 7509 was chosen because it:
- Is outside Windows dynamic port range (49152-65535)
- Is outside all Windows reserved ranges mentioned in issue comments
- Maintains similar number pattern (ends in 509) for familiarity
- Is in registered ports range (1024-49151), commonly available

## Changes

Updated default port from 50509 to 7509 across **13 files**:

**Core Configuration:**
- `crates/core/src/config/mod.rs` - main port constant and documentation
- `crates/fdev/src/config.rs` - fdev CLI default
- `crates/fdev/src/wasm_runtime.rs` - wasm runtime default

**Documentation:**
- `scripts/FREENET-NODE-SETUP-GUIDE.md`
- `crates/fdev/README.md` (2 occurrences)
- `apps/freenet-microblogging/README.md`
- `apps/freenet-email-app/README.md`

**Scripts & Docker:**
- `scripts/freenet-node-setup.sh`
- `docker/freenet-node/freenet-node-startup.sh`
- `docker/freenet-node/docker-compose.yml`
- `docker/freenet-node/Dockerfile.yml`

**Example Applications:**
- `apps/freenet-email-app/web/src/api.rs`
- `apps/freenet-ping/app/src/main.rs`

## Testing

- ✅ Build successful (`cargo build --release`)
- ✅ No remaining references to port 50509
- ✅ All 13 files correctly updated

## Backward Compatibility

Users can continue using port 50509 (on non-Windows) via:
```bash
# Environment variable
WS_API_PORT=50509 freenet network

# Command line
freenet network --ws-api-port 50509

# Config file
ws-api-port = 50509
```

## Coordinated Release

**⚠️ IMPORTANT**: This PR should be released in coordination with freenet/river PR (incoming), which updates River to use the new default port 7509.

Fixes #1751

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Ian Clarke <sanity@users.noreply.github.com>