### PR TITLE
fix: don't clobber freenet.toml if project exists

### DIFF
--- a/crates/fdev/src/new_package.rs
+++ b/crates/fdev/src/new_package.rs
@@ -22,6 +22,12 @@ pub fn create_new_package(config: InitPackageConfig) -> anyhow::Result<()> {
     let path = path
         .or_else(|| env::current_dir().ok())
         .context("Valid path for creating a new package")?;
+    if path.join("freenet.toml").exists() {
+        anyhow::bail!(
+            "A Freenet project already exists in directory: {}",
+            path.display()
+        );
+    }
     match kind {
         ContractKind::WebApp => create_view_package(&path),
         ContractKind::Contract => create_regular_contract(&path),


### PR DESCRIPTION
Running `fdev init` or `fdev new` twice with different project types clobbers `freenet.toml`. Try:

```shell
fdev init web-app
fdev init contract
```

Prior to this small patch, the second command would overwrite freenet.toml.