### PR TITLE
docs: fix license information in crate READMEs

### DIFF
--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -22,8 +22,6 @@ For detailed build instructions and development setup, see the [GitHub repositor
 
 ## License
 
-Licensed under either:
-- Apache License, Version 2.0
-- MIT License
+Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
 
-at your option.
+See [LICENSE.md](https://github.com/freenet/freenet-core/blob/main/LICENSE.md) for details.

--- a/crates/fdev/README.md
+++ b/crates/fdev/README.md
@@ -27,8 +27,6 @@ For detailed usage instructions and development setup, see the [GitHub repositor
 
 ## License
 
-Licensed under either:
-- Apache License, Version 2.0
-- MIT License
+Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).
 
-at your option.
+See [LICENSE.md](https://github.com/freenet/freenet-core/blob/main/LICENSE.md) for details.


### PR DESCRIPTION
## Summary

Corrects the license information in both `freenet` and `fdev` crate READMEs from incorrect Apache-2.0/MIT to the correct GNU Affero General Public License v3.0 (AGPL-3.0).

## Changes

- Updated `crates/core/README.md` to specify AGPL-3.0 license
- Updated `crates/fdev/README.md` to specify AGPL-3.0 license
- Both now link to LICENSE.md for full details

## Context

The project is licensed under AGPL-3.0, not Apache/MIT. The READMEs added in PR #1964 had incorrect license information that needed to be corrected before the next crate publish.

[AI-assisted debugging and comment]

🤖 Generated with [Claude Code](https://claude.com/claude-code)