### PR TITLE
fix: use 'build:' instead of 'chore:' for release PR titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
         run: |
           PR_URL=$(gh pr create \
-            --title "chore: release ${{ needs.validate.outputs.version }}" \
+            --title "build: release ${{ needs.validate.outputs.version }}" \
             --body "**Automated release PR**
 
           - freenet: → **${{ needs.validate.outputs.version }}**


### PR DESCRIPTION
## Summary

Fixes release workflow to use 'build:' instead of 'chore:' for automated release PR titles.

## Problem

PR #1958 introduced 'chore: release X.Y.Z' as the PR title format, but CLAUDE.md:154-166 specifies that 'chore' is NOT an allowed Conventional Commits type. The CI will reject it.

Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci

## Solution

Change line 128 of release.yml from:
```yaml
--title "chore: release ${{ needs.validate.outputs.version }}"
```

To:
```yaml
--title "build: release ${{ needs.validate.outputs.version }}"
```

Using 'build:' is appropriate since release PRs update version numbers in Cargo.toml files (build configuration).

## Impact

- ✅ Release PRs will pass Conventional Commits CI check
- ✅ Automated releases can proceed without manual intervention

[AI-assisted debugging and comment]