### PR TITLE
fix: use conventional commit format for release PR titles

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -412,7 +412,7 @@ create_release_pr() {
     
     echo -n "  Creating auto-merge PR... "
     pr_number=$(gh pr create \
-        --title "🚀 Release $VERSION" \
+        --title "chore: release $VERSION" \
         --body "**Automated release PR**
 
 - freenet: → **$VERSION**  


### PR DESCRIPTION
## Why

The release script was creating PRs with titles like "🚀 Release 0.1.32" which fail the Conventional Commits CI check. This required manual intervention to fix PR titles during releases.

## What Changed

- Changed release.sh line 415 from `--title "🚀 Release $VERSION"` to `--title "chore: release $VERSION"`
- This ensures release PRs comply with conventional commits format automatically

## Testing

Future releases will create PRs that pass the Conventional Commits check without manual fixes.

[AI-assisted debugging and comment]