### PR TITLE
chore: release 0.1.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,7 +1558,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "axum 0.8.6",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.32"
+version = "0.1.33"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -39,7 +39,7 @@ reqwest = { version = "0.12", features = ["json"] }
 http = "1.2"
 
 # internal
-freenet = { path = "../core", version = "0.1.32" }
+freenet = { path = "../core", version = "0.1.33" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
**Automated release PR**

- freenet: → **0.1.33**  
- fdev: → **0.3.11**

## Changes since 0.1.32
- **#1993**: fix: cap pending connection backlog

This PR will auto-merge once GitHub CI passes.

[AI-assisted debugging and comment]