### PR TITLE
fix: persist contract state after PUT merge in upsert_contract_state

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -300,6 +300,12 @@ impl ContractExecutor for Executor<Runtime> {
                 if updated_state.as_ref() == current_state.as_ref() {
                     Ok(UpsertResult::NoChange)
                 } else {
+                    // Persist the updated state before returning
+                    self.state_store
+                        .update(&key, updated_state.clone())
+                        .await
+                        .map_err(ExecutorError::other)?;
+
                     // todo: forward delta like we are doing with puts
                     tracing::warn!("Delta updates are not yet supported");
                     Ok(UpsertResult::Updated(updated_state))


### PR DESCRIPTION
## Why

When a peer receives a PUT request for a contract it already has cached, the updated state is computed correctly but never persisted to the state store. This causes the peer to continue serving stale cached state even after receiving and validating updates from the network.

## What Changed

**Fix**: Added `state_store.update()` call in `upsert_contract_state()` before returning `UpsertResult::Updated`
- Location: `crates/core/src/contract/executor/runtime.rs:303-307`
- Ensures peers persist merged state after validation, matching the pattern in `attempt_state_update()`

**Test**: Added `test_put_merge_persists_state()` integration test
- Tests scenario: PUT initial state → PUT updated state → GET from gateway
- Validates gateway serves merged updated state (not stale cache)
- Location: `crates/core/tests/operations.rs:540-783`

## Impact

- Fixes contract state not being persisted after PUT merge operations
- Peers will now serve updated contract state instead of stale cached versions  
- Affects all contract types when running in network mode

Fixes #1995

[AI-assisted debugging and comment]

🤖 Generated with [Claude Code](https://claude.com/claude-code)