### PR TITLE
fix(test): add delay for cross-node subscription propagation in test_multiple_clients_subscription

### DIFF
--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -1148,6 +1148,14 @@ async fn test_multiple_clients_subscription() -> TestResult {
             }
         }
 
+        // Wait for subscriptions to fully propagate across nodes before UPDATE
+        // Issue #2001: Race condition where UPDATE can start before cross-node subscriptions
+        // are fully registered. Even though we receive SubscribeResponse, the subscription
+        // may not have propagated through the ring to all nodes yet.
+        tracing::info!("All clients subscribed, waiting 5 seconds for cross-node propagation...");
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        tracing::info!("Proceeding with UPDATE operation");
+
         // Create a new to-do list by deserializing the current state, adding a task, and serializing it back
         let mut todo_list: test_utils::TodoList = serde_json::from_slice(wrapped_state.as_ref())
             .unwrap_or_else(|_| test_utils::TodoList {


### PR DESCRIPTION
## Summary

Addresses issue #2001 where `test_multiple_clients_subscription` has a 20-40% failure rate due to a race condition.

## Problem

The test was starting UPDATE operations before cross-node subscriptions had fully propagated through the ring. Even though `SubscribeResponse` is returned to the client, the subscription may not have propagated to all nodes yet, causing notifications to be missed by Client 3 (on a different node).

## Solution

Added a 5-second delay after all subscription confirmations are received, allowing time for subscriptions to propagate across nodes before the UPDATE operation begins.

## Test Results

Ran the test successfully after the fix was applied:
```
test test_multiple_clients_subscription ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 55.13s
```

## Note

This is a pragmatic short-term solution. The proper architectural fix would involve making SUBSCRIBE operations truly synchronous with acknowledgment from the target node. See [my comment on issue #2001](https://github.com/freenet/freenet-core/issues/2001#issuecomment-3451699945) for discussion of the architectural approach.

Fixes #2001

[AI-assisted debugging and comment]

🤖 Generated with [Claude Code](https://claude.com/claude-code)