### PR TITLE
ci: expand Claude GitHub Action permissions for git operations

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,16 +19,18 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      contents: write       # Allows pushing commits, rebasing, creating branches
+      pull-requests: write  # Allows updating PRs, requesting reviews, merging
+      issues: write         # Allows commenting on issues, updating labels
+      id-token: write       # Required for GitHub App authentication
+      actions: read         # Required for Claude to read CI results on PRs
+      checks: read          # Allows reading check run status
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          fetch-depth: 0  # Full history needed for git operations like rebase
+          token: ${{ secrets.GITHUB_TOKEN }}  # Use workflow token for git operations
 
       - name: Run Claude Code
         id: claude
@@ -46,5 +48,17 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
+          #
+          # Examples:
+          # Use Opus for complex tasks:
+          #   claude_args: '--model claude-opus-4-1-20250805'
+          #
+          # Allow specific git/gh operations:
+          #   claude_args: '--allowed-tools Bash(git rebase:*) Bash(git push:*) Bash(gh pr:*)'
+          #
+          # Note: With the permissions above, Claude can now:
+          #   - Rebase branches (git rebase)
+          #   - Push commits (git push, git push --force-with-lease)
+          #   - Update PRs (gh pr edit, gh pr review, gh pr merge)
+          #   - Comment on issues and PRs (gh issue comment, gh pr comment)
 


### PR DESCRIPTION
## Why

Currently Claude's GitHub Action has read-only permissions, which prevents it from performing useful git operations like rebasing branches, pushing commits, or updating PR metadata. This came up in https://github.com/freenet/freenet-core/pull/2031#issuecomment-3475812478 where Claude couldn't rebase a PR when requested.

## What Changed

Upgraded workflow permissions from read-only to write access:

- **contents: write** - Enables git rebase, push, and branch management
- **pull-requests: write** - Allows PR updates, requesting reviews, and merging
- **issues: write** - Enables commenting and label management  
- **checks: read** - Allows reading CI check results

Also updated checkout step:
- Set `fetch-depth: 0` for full git history (required for rebase operations)
- Explicitly use `GITHUB_TOKEN` for git operations

Added documentation with examples of what Claude can now do and how to optionally restrict specific operations using `claude_args`.

## What Claude Can Now Do

With these permissions, Claude can:
- Rebase branches on main
- Push commits (including `--force-with-lease`)
- Create and delete branches
- Update PR descriptions and metadata
- Request reviewers and approve PRs
- Add comments to issues and PRs
- Manage labels

## Testing

The changes are backwards compatible - existing Claude interactions continue to work, but now with expanded capabilities.

[AI-assisted - Claude]