### PR TITLE
fix: keep listener ports out of Windows exclusion range

### DIFF
--- a/crates/core/src/config/port_allocation.rs
+++ b/crates/core/src/config/port_allocation.rs
@@ -44,13 +44,10 @@ fn pick_port_from_safe_windows_ranges() -> Option<u16> {
     }
 
     candidates.shuffle(&mut rng());
-    for port in candidates.into_iter().take(MAX_SAFE_PORT_ATTEMPTS) {
-        if port_is_free(port) {
-            return Some(port);
-        }
-    }
-
-    None
+    candidates
+        .into_iter()
+        .take(MAX_SAFE_PORT_ATTEMPTS)
+        .find(|port| port_is_free(*port))
 }
 
 fn port_is_free(port: u16) -> bool {


### PR DESCRIPTION
## Summary\n- detect Windows/WSL installs and prefer known-safe high UDP port ranges (still allowing 31337) before falling back to OS-assigned ephemerals so the default listener no longer lands inside Windows' excluded bands\n- add lightweight WSL detection helpers, range randomization, and a regression test that ensures the selector only returns values in the curated ranges\n\nFixes #2058\n\n## Testing\n- cargo test --lib config::port_allocation\n- cargo clippy --all-targets --all-features