### PR TITLE
fix: advertise observed addresses for private joiners

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2097,16 +2097,22 @@ fn decode_msg(data: &[u8]) -> Result<NetMessage, ConnectionError> {
 fn is_publicly_routable(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(addr) => {
-            !(addr.is_private()
-                || addr.is_loopback()
-                || addr.is_link_local()
-                || addr.is_unspecified())
+            let octets = addr.octets();
+            let is_loopback = octets[0] == 127;
+            let is_link_local = octets[0] == 169 && octets[1] == 254;
+            let is_private = octets[0] == 10
+                || (octets[0] == 172 && (16..=31).contains(&octets[1]))
+                || (octets[0] == 192 && octets[1] == 168);
+            let is_unspecified = addr.octets() == [0, 0, 0, 0];
+            !(is_loopback || is_link_local || is_private || is_unspecified)
         }
         IpAddr::V6(addr) => {
-            !(addr.is_loopback()
-                || addr.is_unspecified()
-                || addr.is_unique_local()
-                || addr.is_unicast_link_local())
+            let segments = addr.segments();
+            let is_loopback = addr == std::net::Ipv6Addr::LOCALHOST;
+            let is_unspecified = addr == std::net::Ipv6Addr::UNSPECIFIED;
+            let is_unique_local = (segments[0] & 0xfe00) == 0xfc00;
+            let is_link_local = (segments[0] & 0xffc0) == 0xfe80;
+            !(is_loopback || is_unspecified || is_unique_local || is_link_local)
         }
     }
 }


### PR DESCRIPTION
## Summary
- normalize inbound handshake metadata so sender records are replaced with the socket we actually observe unless the envelope is ObservedAddress
- when relaying connect requests, treat loopback/private addresses the same as unspecified ones so we always produce ObservedAddress events for joiners that mis-advertise themselves
- add regression coverage that proves relays now emit observed addresses for private joiners and add reusable address classification helpers that respect the repo's MSRV

## Testing
- cargo test -p freenet relay_emits_observed_address_for_private_joiner
- cargo clippy --all-targets --all-features
