### PR TITLE
chore: standardize freenet-stdlib to 0.1.24 across all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1429,7 +1429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2428,7 +2428,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2448,7 +2448,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2680,7 +2680,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4305,7 +4305,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5166,7 +5166,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6416,7 +6416,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/apps/freenet-email-app/Cargo.lock
+++ b/apps/freenet-email-app/Cargo.lock
@@ -1240,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c64fa03f4a083918c7e347be47122c223d8156f4c012a0fe8e89a643350f2d"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "bincode",
  "blake3",

--- a/apps/freenet-email-app/Cargo.toml
+++ b/apps/freenet-email-app/Cargo.toml
@@ -19,6 +19,6 @@ rsa = { version = "0.9.2", default-features = false, features = ["serde", "pem",
 serde = "1"
 serde_json = "1"
 
-# freenet-stdlib = { version = "0.1.14" }
-freenet-stdlib = { version = "0.1.14" }
+# freenet-stdlib = { version = "0.1.24" }
+freenet-stdlib = { version = "0.1.24" }
 freenet-aft-interface = { path = "../../modules/antiflood-tokens/interfaces" }

--- a/apps/freenet-microblogging/Cargo.lock
+++ b/apps/freenet-microblogging/Cargo.lock
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.13"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef791f340c26ee1dc720e8b68960fc405dfc3cd52fd2e9868da8f5d87233fb4f"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "bincode",
  "blake3",

--- a/apps/freenet-microblogging/Cargo.toml
+++ b/apps/freenet-microblogging/Cargo.toml
@@ -14,7 +14,7 @@ panic = 'abort'
 strip = true
 
 [workspace.dependencies]
-freenet-stdlib = { version = "0.1.14", default-features = false, features = ["contract"] }
+freenet-stdlib = { version = "0.1.24", default-features = false, features = ["contract"] }
 
 #[target.wasm32-unknown-unknown]
 #rustflags = ["-C", "link-arg=--import-memory"]

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -5288,9 +5288,9 @@ dependencies = [
 
 [[package]]
 name = "wmi"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120d8c2b6a7c96c27bf4a7947fd7f02d73ca7f5958b8bd72a696e46cb5521ee6"
+checksum = "d71d1d435f7745ba9ed55c43049d47b5fbd1104449beaa2afbc80a1e10a4a018"
 dependencies = [
  "chrono",
  "futures",

--- a/apps/freenet-ping/Cargo.toml
+++ b/apps/freenet-ping/Cargo.toml
@@ -4,7 +4,7 @@ members = ["contracts/ping", "app", "types"]
 
 [workspace.dependencies]
 # freenet-stdlib = { path = "./../../stdlib/rust", features = ["contract"] }
-freenet-stdlib = { version = "0.1.14" } 
+freenet-stdlib = { version = "0.1.24" } 
 freenet-ping-types = { path = "types", default-features = false }
 chrono = { version = "0.4", default-features = false }
 testresult = "0.4"
@@ -19,4 +19,3 @@ debug = false
 codegen-units = 1
 panic = 'abort'
 strip = true
-

--- a/apps/freenet-ping/app/Cargo.toml
+++ b/apps/freenet-ping/app/Cargo.toml
@@ -11,7 +11,7 @@ manual-tests = []
 anyhow = "1.0"
 chrono = { workspace = true, features = ["default"] }
 clap = { version = "4.5", features = ["derive"] }
-freenet-stdlib = { version = "0.1.22", features = ["net"] }
+freenet-stdlib = { version = "0.1.24", features = ["net"] }
 freenet-ping-types = { path = "../types", features = ["std", "clap"] }
 futures = "0.3.31"
 rand = "0.9.2"

--- a/modules/antiflood-tokens/Cargo.lock
+++ b/modules/antiflood-tokens/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.13"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef791f340c26ee1dc720e8b68960fc405dfc3cd52fd2e9868da8f5d87233fb4f"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/modules/antiflood-tokens/Cargo.toml
+++ b/modules/antiflood-tokens/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 bincode = { version = "1" }
 bs58 = "0.5"
 chrono = { version = "0.4", default-features = false }
-freenet-stdlib = { version = "0.1.14" }
+freenet-stdlib = { version = "0.1.24" }
 rsa = { version = "0.9", default-features = false, features = ["serde", "pem"] }
 serde = { version = "1" }
 serde_json = { version = "1" }

--- a/modules/identity-management/Cargo.lock
+++ b/modules/identity-management/Cargo.lock
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c64fa03f4a083918c7e347be47122c223d8156f4c012a0fe8e89a643350f2d"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "bincode",
  "blake3",

--- a/modules/identity-management/Cargo.toml
+++ b/modules/identity-management/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 p384 =  { version = "0.13", default-features = false, features = ["serde", "pem", "pkcs8", "arithmetic"] }
-freenet-stdlib = { version = "0.1.14" }
+freenet-stdlib = { version = "0.1.24" }
 serde = "1"
 serde_json = "1"
 

--- a/tests/test-app-1/Cargo.lock
+++ b/tests/test-app-1/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.14"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087695bd49a28e00d95260dec3ce66eec0955efd258b494d353f9d4e2ce93a22"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-app-1/Cargo.toml
+++ b/tests/test-app-1/Cargo.toml
@@ -14,4 +14,4 @@ panic = 'abort'
 strip = true
 
 [workspace.dependencies]
-freenet-stdlib = { version = "0.1.14", default-features = false }
+freenet-stdlib = { version = "0.1.24", default-features = false }

--- a/tests/test-contract-1/Cargo.lock
+++ b/tests/test-contract-1/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.14"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087695bd49a28e00d95260dec3ce66eec0955efd258b494d353f9d4e2ce93a22"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-contract-1/Cargo.toml
+++ b/tests/test-contract-1/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.1.14", features = ["contract"] }
+freenet-stdlib = { version = "0.1.24", features = ["contract"] }
 
 [features]
 default = ["freenet-main-contract"]

--- a/tests/test-contract-2/Cargo.lock
+++ b/tests/test-contract-2/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.14"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087695bd49a28e00d95260dec3ce66eec0955efd258b494d353f9d4e2ce93a22"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-contract-2/Cargo.toml
+++ b/tests/test-contract-2/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.1.14", features = ["contract"] }
+freenet-stdlib = { version = "0.1.24", features = ["contract"] }
 
 [features]
 default = ["freenet-main-contract"]

--- a/tests/test-contract-metering/Cargo.lock
+++ b/tests/test-contract-metering/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.14"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087695bd49a28e00d95260dec3ce66eec0955efd258b494d353f9d4e2ce93a22"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-contract-metering/Cargo.toml
+++ b/tests/test-contract-metering/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.1.14", features = ["contract"] }
+freenet-stdlib = { version = "0.1.24", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 
 [features]

--- a/tests/test-delegate-1/Cargo.lock
+++ b/tests/test-delegate-1/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.14"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087695bd49a28e00d95260dec3ce66eec0955efd258b494d353f9d4e2ce93a22"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-1/Cargo.toml
+++ b/tests/test-delegate-1/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.1.14", features = ["contract"]}
+freenet-stdlib = { version = "0.1.24", features = ["contract"]}
 serde = "1"
 serde_json = "1"
 bincode = "1"

--- a/tests/test-delegate-integration/Cargo.lock
+++ b/tests/test-delegate-integration/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.14"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087695bd49a28e00d95260dec3ce66eec0955efd258b494d353f9d4e2ce93a22"
+checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-integration/Cargo.toml
+++ b/tests/test-delegate-integration/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.1.14", features = ["contract"]}
+freenet-stdlib = { version = "0.1.24", features = ["contract"]}
 serde = "1"
 serde_json = "1"
 bincode = "1"


### PR DESCRIPTION
## Summary
- align all crates to freenet-stdlib 0.1.24 to match workspace
- refresh Cargo.lock files after the version bump
- validation: cargo check --workspace

Low-risk housekeeping to keep stdlib usage consistent across the workspace.