### PR TITLE
fix: add secondary pub_key check to prevent self-connections during early init

### DIFF
--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -148,11 +148,23 @@ impl ConnectionManager {
     /// Will panic if the node checking for this condition has no location assigned.
     pub fn should_accept(&self, location: Location, peer_id: &PeerId) -> bool {
         // Don't accept connections from ourselves
+        // Primary check: compare full PeerId (address-based equality)
         if let Some(own_id) = self.get_peer_key() {
             if &own_id == peer_id {
-                tracing::warn!(%peer_id, "should_accept: rejecting self-connection attempt");
+                tracing::warn!(%peer_id, "should_accept: rejecting self-connection attempt (address match)");
                 return false;
             }
+        }
+
+        // Secondary check: compare pub_key directly
+        // This catches self-connections even when peer_key is not yet set,
+        // which can happen early in initialization. Same pub_key means same node.
+        if *self.pub_key == peer_id.pub_key {
+            tracing::warn!(
+                %peer_id,
+                "should_accept: rejecting self-connection attempt (pub_key match)"
+            );
+            return false;
         }
 
         tracing::info!("Checking if should accept connection");
@@ -723,6 +735,43 @@ mod tests {
         assert!(
             accepted,
             "should_accept must accept connection from different peer"
+        );
+    }
+
+    #[test]
+    fn rejects_self_connection_by_pubkey_when_peer_key_not_set() {
+        // Create a ConnectionManager WITHOUT setting peer_key (simulating early initialization)
+        let keypair = TransportKeypair::new();
+
+        let cm = ConnectionManager::init(
+            Rate::new_per_second(1_000_000.0),
+            Rate::new_per_second(1_000_000.0),
+            1,
+            10,
+            7,
+            (
+                keypair.public().clone(),
+                None, // peer_key is None - this is the key difference from the other test
+                AtomicU64::new(u64::from_le_bytes(0.5f64.to_le_bytes())),
+            ),
+            false,
+            10,
+            Duration::from_secs(60),
+        );
+
+        // Verify peer_key is indeed None
+        assert_eq!(cm.get_peer_key(), None);
+
+        // Create a PeerId with the SAME pub_key but different address
+        let self_like_addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+        let self_like_peer_id = PeerId::new(self_like_addr, keypair.public().clone());
+
+        // should_accept must reject this because the pub_key matches our own
+        let location = Location::new(0.5);
+        let accepted = cm.should_accept(location, &self_like_peer_id);
+        assert!(
+            !accepted,
+            "should_accept must reject self-connection by pub_key even when peer_key is not set"
         );
     }
 }


### PR DESCRIPTION
## Problem

The `test_three_node_network_connectivity` test started failing after both PR #2140 (self-connection guard) and PR #2142 (ConnectResponse address fix) were merged. Neither PR caused failures individually, but combined they exposed a race condition.

**Root cause**: When a gateway has no other peers during early initialization, connect requests can be forwarded back to itself. The existing `peer_key` check in `should_accept()` fails to catch these self-connections because `get_peer_key()` returns `None` during early initialization—the node doesn't know its own `peer_key` yet.

The `PeerId` equality check is address-based (not pub_key-based), so comparing `peer_key` only works when the address matches exactly. But during early init, the node may not have recorded its own address yet.

## This Solution

Add a **secondary check** that compares `pub_key` directly:

```rust
if *self.pub_key == peer_id.pub_key {
    tracing::warn!(%peer_id, "should_accept: rejecting self-connection attempt (pub_key match)");
    return false;
}
```

This works because:
1. `pub_key` is **always** set in `ConnectionManager` (unlike `peer_key` which is `Option<PeerId>`)
2. Same `pub_key` definitively means same node, regardless of address
3. The check runs even when `peer_key` is `None`

## Testing

- Added `rejects_self_connection_by_pubkey_when_peer_key_not_set` test that:
  - Creates a `ConnectionManager` with `peer_key = None` (simulating early init)
  - Verifies `should_accept()` rejects a `PeerId` with matching `pub_key`
- All 244 lib tests pass locally
- The three-node connectivity test that was failing now passes

## Fixes

Closes #2139

[AI-assisted - Claude]