### PR TITLE
fix: improve release script resumption with auto-detection

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,21 +18,20 @@ DRY_RUN=false
 SKIP_TESTS=false
 DEPLOY_LOCAL=false
 DEPLOY_REMOTE=false
-RESUME=false
-STATE_FILE=""
 
-# Release steps for state tracking
-declare -A RELEASE_STEPS=(
-    [1]="PR_CREATED"
-    [2]="PR_MERGED"
-    [3]="TAG_CREATED"
-    [4]="RELEASE_CREATED"
-    [5]="CRATES_PUBLISHED"
-    [6]="LOCAL_DEPLOYED"
-    [7]="MATRIX_ANNOUNCED"
+# Release steps for state tracking (in execution order)
+RELEASE_STEPS=(
+    "PR_CREATED"
+    "PR_MERGED"
+    "TAG_CREATED"
+    "CRATES_PUBLISHED"
+    "RELEASE_CREATED"
+    "LOCAL_DEPLOYED"
+    "MATRIX_ANNOUNCED"
 )
 
-CURRENT_STEP=0
+# Completed steps (populated by auto-detection)
+declare -A COMPLETED_STEPS
 
 show_help() {
     echo "Freenet Release Script"
@@ -48,9 +47,13 @@ show_help() {
     echo "  --deploy-local      Deploy to local gateway after release (optional)"
     echo "  --deploy-remote     Deploy to remote gateways after release (optional)"
     echo "  --skip-tests        Skip pre-release tests"
-    echo "  --resume STATE_FILE Resume failed release from state file"
     echo "  --dry-run           Show what would be done without executing"
     echo "  --help              Show this help"
+    echo
+    echo "Resumption:"
+    echo "  The script automatically detects completed steps and skips them."
+    echo "  If a release fails mid-way, simply re-run with the same --version."
+    echo "  State is also saved to /tmp/release-X.Y.Z.state for inspection."
     echo
     echo "Notes:"
     echo "  • Relies on GitHub CI for testing (more reliable than local tests)"
@@ -79,11 +82,6 @@ while [[ $# -gt 0 ]]; do
         --skip-tests)
             SKIP_TESTS=true
             shift
-            ;;
-        --resume)
-            RESUME=true
-            STATE_FILE="$2"
-            shift 2
             ;;
         --dry-run)
             DRY_RUN=true
@@ -162,6 +160,9 @@ elif [[ "$VERSION_CMP" == "1" ]]; then
     echo "Releasing new version: v$PUBLISHED_VERSION → v$VERSION"
 fi
 
+# State file for tracking progress (backup for manual inspection)
+STATE_FILE="/tmp/release-${VERSION}.state"
+
 # Get current fdev version and increment patch version
 CURRENT_FDEV_VERSION=$(grep "^version" "$PROJECT_ROOT/crates/fdev/Cargo.toml" 2>/dev/null | cut -d'"' -f2)
 if [[ -n "$CURRENT_FDEV_VERSION" ]]; then
@@ -176,7 +177,176 @@ else
     FDEV_VERSION="0.3.1"
 fi
 
-# Helper functions
+# ============================================================================
+# State Management Functions
+# ============================================================================
+
+# Save current state to file
+save_state() {
+    local step="$1"
+    COMPLETED_STEPS["$step"]=1
+
+    # Write all completed steps to state file
+    {
+        echo "# Release state for v$VERSION"
+        echo "# Generated: $(date -Iseconds)"
+        echo "VERSION=$VERSION"
+        echo "FDEV_VERSION=$FDEV_VERSION"
+        for s in "${!COMPLETED_STEPS[@]}"; do
+            echo "COMPLETED_$s=1"
+        done
+    } > "$STATE_FILE"
+}
+
+# Load state from file (for inspection, auto-detect is primary)
+load_state_file() {
+    if [[ -f "$STATE_FILE" ]]; then
+        echo "  Found existing state file: $STATE_FILE"
+        while IFS='=' read -r key value; do
+            if [[ "$key" =~ ^COMPLETED_ ]]; then
+                local step="${key#COMPLETED_}"
+                COMPLETED_STEPS["$step"]=1
+            fi
+        done < "$STATE_FILE"
+    fi
+}
+
+# Check if a step is completed
+is_step_completed() {
+    local step="$1"
+    [[ "${COMPLETED_STEPS[$step]:-}" == "1" ]]
+}
+
+# Mark step completed and save state
+mark_completed() {
+    local step="$1"
+    save_state "$step"
+    echo "  ✓ [$step] completed"
+}
+
+# ============================================================================
+# Auto-Detection Functions
+# ============================================================================
+
+# Detect release PR state
+detect_pr_state() {
+    local branch_name="release/v$VERSION"
+
+    # Check for existing PR
+    local pr_info=$(gh pr list --head "$branch_name" --state all --limit 1 \
+        --json number,state 2>/dev/null | jq -r '.[0] | "\(.number)|\(.state)"' 2>/dev/null || echo "")
+
+    if [[ -z "$pr_info" || "$pr_info" == "null|null" ]]; then
+        return  # No PR exists
+    fi
+
+    local pr_number=$(echo "$pr_info" | cut -d'|' -f1)
+    local pr_state=$(echo "$pr_info" | cut -d'|' -f2)
+
+    if [[ -n "$pr_number" && "$pr_number" != "null" ]]; then
+        COMPLETED_STEPS["PR_CREATED"]=1
+
+        if [[ "$pr_state" == "MERGED" ]]; then
+            COMPLETED_STEPS["PR_MERGED"]=1
+        fi
+    fi
+}
+
+# Detect if tag exists
+detect_tag_state() {
+    # Check local tags
+    if git tag -l | grep -q "^v$VERSION$"; then
+        COMPLETED_STEPS["TAG_CREATED"]=1
+        return
+    fi
+
+    # Check remote tags
+    if git ls-remote --tags origin 2>/dev/null | grep -q "refs/tags/v$VERSION$"; then
+        COMPLETED_STEPS["TAG_CREATED"]=1
+    fi
+}
+
+# Detect if crates are published
+detect_crates_state() {
+    # Check if freenet is published at this version
+    if cargo search freenet --limit 1 2>/dev/null | grep -q "freenet = \"$VERSION\""; then
+        COMPLETED_STEPS["CRATES_PUBLISHED"]=1
+    fi
+}
+
+# Detect if GitHub release exists
+detect_release_state() {
+    if gh release view "v$VERSION" &>/dev/null; then
+        COMPLETED_STEPS["RELEASE_CREATED"]=1
+    fi
+}
+
+# Run all auto-detection
+auto_detect_state() {
+    echo "Detecting release state for v$VERSION:"
+
+    # First load any saved state file
+    load_state_file
+
+    # Then run auto-detection (may update/override)
+    echo -n "  Checking PR status... "
+    detect_pr_state
+    if is_step_completed "PR_MERGED"; then
+        echo "merged ✓"
+    elif is_step_completed "PR_CREATED"; then
+        echo "exists (not merged)"
+    else
+        echo "not found"
+    fi
+
+    echo -n "  Checking tag v$VERSION... "
+    detect_tag_state
+    if is_step_completed "TAG_CREATED"; then
+        echo "exists ✓"
+    else
+        echo "not found"
+    fi
+
+    echo -n "  Checking crates.io... "
+    detect_crates_state
+    if is_step_completed "CRATES_PUBLISHED"; then
+        echo "published ✓"
+    else
+        echo "not published"
+    fi
+
+    echo -n "  Checking GitHub release... "
+    detect_release_state
+    if is_step_completed "RELEASE_CREATED"; then
+        echo "exists ✓"
+    else
+        echo "not found"
+    fi
+
+    # Print summary of what will be skipped
+    local skipped=()
+    local pending=()
+    for step in "${RELEASE_STEPS[@]}"; do
+        if is_step_completed "$step"; then
+            skipped+=("$step")
+        else
+            pending+=("$step")
+        fi
+    done
+
+    echo
+    if [[ ${#skipped[@]} -gt 0 ]]; then
+        echo "Steps to skip: ${skipped[*]}"
+    fi
+    if [[ ${#pending[@]} -gt 0 ]]; then
+        echo "Steps to execute: ${pending[*]}"
+    fi
+}
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
 run_cmd() {
     local desc="$1"
     shift
@@ -199,28 +369,6 @@ run_cmd() {
         echo "💡 Tip: You can fix the issue and re-run the script - it will skip completed steps"
         exit 1
     fi
-}
-
-# Check if a step was already completed
-step_completed() {
-    local step="$1"
-    case "$step" in
-        "version_update")
-            # Check if version is already updated in Cargo.toml
-            grep -q "version = \"$VERSION\"" "$PROJECT_ROOT/crates/core/Cargo.toml" 2>/dev/null
-            ;;
-        "github_release")
-            # Check if tag already exists
-            git tag | grep -q "^v$VERSION$" 2>/dev/null
-            ;;
-        "crates_published")
-            # Check if version exists on crates.io (simple check)
-            cargo search freenet --limit 1 | grep -q "freenet = \"$VERSION\"" 2>/dev/null
-            ;;
-        *)
-            return 1
-            ;;
-    esac
 }
 
 check_prerequisites() {
@@ -277,7 +425,14 @@ check_prerequisites() {
 update_versions() {
     echo "Updating versions:"
 
-    if step_completed "version_update"; then
+    # If PR is merged, versions are already in main
+    if is_step_completed "PR_MERGED"; then
+        echo "  ✓ Versions already in main (PR merged)"
+        return 0
+    fi
+
+    # Check if version is already updated in Cargo.toml
+    if grep -q "^version = \"$VERSION\"" "$PROJECT_ROOT/crates/core/Cargo.toml" 2>/dev/null; then
         echo "  ✓ Versions already updated (skipping)"
         return 0
     fi
@@ -358,6 +513,17 @@ create_release_pr() {
 
     local branch_name="release/v$VERSION"
 
+    # Skip if PR is already merged
+    if is_step_completed "PR_MERGED"; then
+        echo "  ✓ [PR_MERGED] Release PR already merged (skipping)"
+        # Ensure we're on main with latest
+        if [[ $(git branch --show-current) != "main" ]]; then
+            run_cmd "Switching to main branch" git checkout main
+        fi
+        run_cmd "Pulling latest changes" git pull origin main
+        return 0
+    fi
+
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "  [DRY RUN] Would create branch $branch_name"
         echo "  [DRY RUN] Would create auto-merge PR"
@@ -376,6 +542,8 @@ create_release_pr() {
         echo "found #$pr_number ($pr_state)"
 
         if [[ "$pr_state" == "MERGED" ]]; then
+            mark_completed "PR_CREATED"
+            mark_completed "PR_MERGED"
             echo "  ✓ Release PR #$pr_number already merged, skipping PR creation"
 
             # Make sure we're on main with the merged changes
@@ -391,6 +559,7 @@ create_release_pr() {
 
             return 0
         elif [[ "$pr_state" == "OPEN" ]]; then
+            mark_completed "PR_CREATED"
             echo "  ℹ️  Release PR #$pr_number already exists and is open"
             echo "     Monitoring existing PR instead of creating a new one..."
             # Continue with the existing PR monitoring logic below
@@ -436,7 +605,7 @@ create_release_pr() {
         --title "build: release $VERSION" \
         --body "**Automated release PR**
 
-- freenet: → **$VERSION**  
+- freenet: → **$VERSION**
 - fdev: → **$FDEV_VERSION**
 
 This PR will auto-merge once GitHub CI passes.
@@ -445,7 +614,8 @@ Generated by: \`scripts/release.sh\`" \
         --head "$branch_name" \
         --assignee @me 2>/dev/null | grep -o '[0-9]\+$')
     echo "✓ (#$pr_number)"
-    
+    mark_completed "PR_CREATED"
+
     echo -n "  Enabling auto-merge... "
     gh pr merge "$pr_number" --squash --auto >/dev/null 2>&1
     echo "✓"
@@ -478,6 +648,7 @@ Generated by: \`scripts/release.sh\`" \
         
         case "$pr_state" in
             "MERGED")
+                mark_completed "PR_MERGED"
                 echo "  ✓ PR merged successfully!"
                 break
                 ;;
@@ -626,20 +797,31 @@ See commit history for detailed changes.
 publish_crates() {
     echo "Publishing to crates.io:"
 
+    # Skip if already completed
+    if is_step_completed "CRATES_PUBLISHED"; then
+        echo "  ✓ [CRATES_PUBLISHED] Crates already published (skipping)"
+        return 0
+    fi
+
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "  [DRY RUN] Would publish freenet $VERSION"
         echo "  [DRY RUN] Would publish fdev $FDEV_VERSION"
         return 0
     fi
 
+    local freenet_published=false
+    local fdev_published=false
+
     # Check if freenet is already published
     echo -n "  Checking if freenet $VERSION is already published... "
     if cargo search freenet --limit 1 2>/dev/null | grep -q "freenet = \"$VERSION\""; then
         echo "yes"
         echo "  ✓ freenet $VERSION already published to crates.io"
+        freenet_published=true
     else
         echo "no"
         run_cmd "Publishing freenet $VERSION" cargo publish -p freenet
+        freenet_published=true
 
         # Wait a bit for crates.io to propagate
         echo -n "  Waiting for crates.io propagation... "
@@ -652,14 +834,31 @@ publish_crates() {
     if cargo search fdev --limit 1 2>/dev/null | grep -q "fdev = \"$FDEV_VERSION\""; then
         echo "yes"
         echo "  ✓ fdev $FDEV_VERSION already published to crates.io"
+        fdev_published=true
     else
         echo "no"
         run_cmd "Publishing fdev $FDEV_VERSION" cargo publish -p fdev
+        fdev_published=true
+    fi
+
+    # Mark complete if both are published
+    if [[ "$freenet_published" == "true" && "$fdev_published" == "true" ]]; then
+        mark_completed "CRATES_PUBLISHED"
     fi
 }
 
 create_github_release() {
     echo "Creating GitHub release:"
+
+    # Skip if already completed
+    if is_step_completed "RELEASE_CREATED"; then
+        echo "  ✓ [RELEASE_CREATED] GitHub release already exists (skipping)"
+        release_url=$(gh release view "v$VERSION" --json url --jq '.url' 2>/dev/null || echo "")
+        if [[ -n "$release_url" ]]; then
+            echo "  Release URL: $release_url"
+        fi
+        return 0
+    fi
 
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "  [DRY RUN] Would create tag v$VERSION"
@@ -671,6 +870,8 @@ create_github_release() {
     echo -n "  Checking if release v$VERSION already exists... "
     if gh release view "v$VERSION" &>/dev/null; then
         echo "yes"
+        mark_completed "TAG_CREATED"
+        mark_completed "RELEASE_CREATED"
         echo "  ✓ GitHub release v$VERSION already exists"
         release_url=$(gh release view "v$VERSION" --json url --jq '.url')
         echo "  Release URL: $release_url"
@@ -682,6 +883,7 @@ create_github_release() {
     # Check if tag already exists
     if git tag | grep -q "^v$VERSION$"; then
         echo "  ℹ️  Tag v$VERSION already exists locally"
+        mark_completed "TAG_CREATED"
     else
         run_cmd "Creating tag v$VERSION" git tag -a "v$VERSION" -m "Release v$VERSION"
     fi
@@ -689,8 +891,10 @@ create_github_release() {
     # Check if tag exists on remote
     if git ls-remote --tags origin | grep -q "refs/tags/v$VERSION$"; then
         echo "  ℹ️  Tag v$VERSION already exists on remote"
+        mark_completed "TAG_CREATED"
     else
         run_cmd "Pushing tag" git push origin "v$VERSION"
+        mark_completed "TAG_CREATED"
     fi
 
     echo -n "  Generating release notes... "
@@ -700,6 +904,7 @@ create_github_release() {
     echo -n "  Creating GitHub release... "
     release_url=$(gh release create "v$VERSION" --title "v$VERSION" --notes "$release_notes")
     echo "✓"
+    mark_completed "RELEASE_CREATED"
 
     echo "  Release created: $release_url"
 }
@@ -712,6 +917,12 @@ deploy_gateways() {
     # Skip if no deployment requested
     if [[ "$DEPLOY_LOCAL" == "false" ]] && [[ "$DEPLOY_REMOTE" == "false" ]]; then
         echo "Skipping gateway deployment (use --deploy-local or --deploy-remote to enable)"
+        return 0
+    fi
+
+    # Skip if already deployed (only check if local deployment was requested)
+    if [[ "$DEPLOY_LOCAL" == "true" ]] && is_step_completed "LOCAL_DEPLOYED"; then
+        echo "  ✓ [LOCAL_DEPLOYED] Local gateway already deployed (skipping)"
         return 0
     fi
 
@@ -732,6 +943,7 @@ deploy_gateways() {
             else
                 if "$deploy_script" --binary "$PROJECT_ROOT/target/release/freenet"; then
                     echo "  ✓ Local gateway deployed successfully"
+                    mark_completed "LOCAL_DEPLOYED"
                 else
                     echo "  ⚠️  Local gateway deployment failed (non-fatal)"
                     echo "     You can deploy manually with: $deploy_script"
@@ -767,6 +979,12 @@ deploy_gateways() {
 
 announce_to_matrix() {
     echo "Announcing release to Matrix:"
+
+    # Skip if already announced
+    if is_step_completed "MATRIX_ANNOUNCED"; then
+        echo "  ✓ [MATRIX_ANNOUNCED] Matrix announcement already sent (skipping)"
+        return 0
+    fi
 
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "  [DRY RUN] Would announce to #freenet-locutus:matrix.org"
@@ -806,6 +1024,7 @@ Full changelog available at the release link above.
     # Use room ID instead of alias for reliability, add timeout
     if timeout 30 matrix-commander -r '!ygHfYcXtXmivTbOwjX:matrix.org' -m "$announcement" &>/dev/null; then
         echo "✓"
+        mark_completed "MATRIX_ANNOUNCED"
     else
         echo "✗"
         echo "  ⚠️  Failed to send Matrix announcement (non-critical)"
@@ -817,6 +1036,11 @@ echo "Freenet Release Script"
 echo "======================"
 echo "Target version: freenet $VERSION, fdev $FDEV_VERSION"
 echo "Project root: $PROJECT_ROOT"
+echo "State file: $STATE_FILE"
+echo
+
+# Auto-detect what's already completed
+auto_detect_state
 echo
 
 check_prerequisites
@@ -861,3 +1085,6 @@ elif [[ "$DEPLOY_REMOTE" == "false" ]]; then
 fi
 
 echo "- Update any dependent projects to use the new version"
+echo
+echo "State file: $STATE_FILE"
+echo "  (Can be deleted now that release is complete)"


### PR DESCRIPTION
## Problem

The release script often fails mid-way (e.g., timeout waiting for PR merge) and requires manual intervention to complete the remaining steps. Important steps like Matrix announcements get missed when this happens.

The script had a `--resume` flag and `RELEASE_STEPS` array defined but **no actual state management logic was implemented**.

## Solution

Implemented proper auto-detection and state tracking that allows the script to resume from any point of failure:

### Auto-Detection Functions

When run with a version, the script now checks what's already completed:
- **PR state**: Uses `gh pr list` to check if release PR exists and whether it's merged
- **Tag state**: Uses `git tag -l` and `git ls-remote` to check if tag exists locally/remotely  
- **Crates state**: Uses `cargo search freenet` to check if version is published
- **Release state**: Uses `gh release view` to check if GitHub release exists

### Clear Progress Output

The script now shows detected state before executing:

```
Detecting release state for v0.1.39:
  Checking PR status... merged ✓
  Checking tag v0.1.39... exists ✓
  Checking crates.io... published ✓
  Checking GitHub release... exists ✓

Steps to skip: PR_CREATED PR_MERGED TAG_CREATED CRATES_PUBLISHED RELEASE_CREATED
Steps to execute: LOCAL_DEPLOYED MATRIX_ANNOUNCED
```

### State File Backup

State is saved to `/tmp/release-X.Y.Z.state` for manual inspection, but auto-detection is the primary mechanism.

## Key Changes

1. Removed unused `--resume` argument (auto-detection is primary)
2. Added state management functions: `save_state`, `load_state_file`, `is_step_completed`, `mark_completed`
3. Added auto-detection functions: `detect_pr_state`, `detect_tag_state`, `detect_crates_state`, `detect_release_state`
4. Updated all step functions to check state and skip if already completed
5. Main execution now shows detected state summary before running

## Usage

Simply re-run the script with the same `--version` after a failure:

```bash
scripts/release.sh --version 0.1.40
```

The script will automatically detect and skip completed steps, continuing from where it left off.

## Testing

Tested with dry-run on existing release (v0.1.39) to verify auto-detection:
- Correctly detected merged PR
- Correctly detected existing tag
- Correctly detected published crate
- Correctly detected GitHub release
- Correctly identified remaining steps to execute

[AI-assisted - Claude]