### PR TITLE
feat: add cargo-binstall support for freenet and fdev

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -112,14 +112,14 @@ jobs:
 
       - name: Prepare release assets
         run: |
-          # Create zip files for each binary with appropriate naming
-          cd artifacts/x86_64-freenet && zip ../../freenet-x86_64-linux.zip freenet && cd ../..
-          cd artifacts/x86_64-fdev && zip ../../fdev-x86_64-linux.zip fdev && cd ../..
-          cd artifacts/arm64-freenet && zip ../../freenet-aarch64-linux.zip freenet && cd ../..
-          cd artifacts/arm64-fdev && zip ../../fdev-aarch64-linux.zip fdev && cd ../..
+          # Create tar.gz files for each binary with binstall-compatible naming
+          cd artifacts/x86_64-freenet && tar -czvf ../../freenet-x86_64-unknown-linux-gnu.tar.gz freenet && cd ../..
+          cd artifacts/x86_64-fdev && tar -czvf ../../fdev-x86_64-unknown-linux-gnu.tar.gz fdev && cd ../..
+          cd artifacts/arm64-freenet && tar -czvf ../../freenet-aarch64-unknown-linux-gnu.tar.gz freenet && cd ../..
+          cd artifacts/arm64-fdev && tar -czvf ../../fdev-aarch64-unknown-linux-gnu.tar.gz fdev && cd ../..
 
           # Display the created files
-          ls -lh *.zip
+          ls -lh *.tar.gz
 
       - name: Upload binaries to release
         env:
@@ -128,11 +128,11 @@ jobs:
           # Extract the tag name (e.g., v0.1.30)
           TAG_NAME="${GITHUB_REF#refs/tags/}"
 
-          # Upload all zip files to the release
+          # Upload all tar.gz files to the release
           gh release upload "$TAG_NAME" \
-            freenet-x86_64-linux.zip \
-            fdev-x86_64-linux.zip \
-            freenet-aarch64-linux.zip \
-            fdev-aarch64-linux.zip \
+            freenet-x86_64-unknown-linux-gnu.tar.gz \
+            fdev-x86_64-unknown-linux-gnu.tar.gz \
+            freenet-aarch64-unknown-linux-gnu.tar.gz \
+            fdev-aarch64-unknown-linux-gnu.tar.gz \
             --repo ${{ github.repository }} \
             --clobber

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,6 +9,11 @@ license-file = "LICENSE.md"
 repository = "https://github.com/freenet/freenet-core"
 readme = "README.md"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/freenet-{ target }.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "freenet"
+
 [[bin]]
 name = "freenet"
 path = "src/bin/freenet.rs"

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -9,6 +9,11 @@ license-file = "LICENSE.md"
 repository = "https://github.com/freenet/freenet-core"
 readme = "README.md"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/fdev-{ target }.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "fdev"
+
 [dependencies]
 bytesize = "2.3"
 anyhow = "1"


### PR DESCRIPTION
## Summary

- Add `[package.metadata.binstall]` sections to `crates/core/Cargo.toml` and `crates/fdev/Cargo.toml`
- Change release asset names from short form (`freenet-x86_64-linux.zip`) to full target triples (`freenet-x86_64-unknown-linux-gnu.tar.gz`)
- Switch from zip to tar.gz format (more standard for Linux, preferred by binstall)

## Why

Currently installing Freenet requires compiling from source via `cargo install freenet`, which is slow. With binstall metadata, users can run:

```bash
cargo binstall freenet
cargo binstall fdev
```

This downloads pre-built binaries from GitHub releases instead of compiling, making installation much faster.

## Test plan

- [ ] CI passes (no code changes, only Cargo.toml metadata and workflow naming)
- [ ] After next release, verify `cargo binstall freenet` downloads binary correctly

[AI-assisted - Claude]