### PR TITLE
fix: return PUT response immediately without waiting for sub-operation completion

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -552,18 +552,6 @@ impl OpManager {
             .expect_and_register_sub_operation(parent, child);
     }
 
-    /// Returns true if all child operations of the parent have completed.
-    pub fn all_sub_operations_completed(&self, parent: Transaction) -> bool {
-        self.sub_op_tracker
-            .all_sub_operations_completed(parent, &self.ops.completed)
-    }
-
-    /// Returns the number of pending child operations for the parent.
-    pub fn count_pending_sub_operations(&self, parent: Transaction) -> usize {
-        self.sub_op_tracker
-            .count_pending_sub_operations(parent, &self.ops.completed)
-    }
-
     /// Handle sub-operation failure - propagate error to parent.
     pub async fn sub_operation_failed(
         &self,
@@ -625,11 +613,6 @@ impl OpManager {
     /// Sub-operations should not send responses directly to clients.
     pub fn is_sub_operation(&self, tx: Transaction) -> bool {
         self.sub_op_tracker.is_sub_operation(tx)
-    }
-
-    /// Exposes root operations awaiting sub-operation completion.
-    pub(crate) fn root_ops_awaiting_sub_ops(&self) -> &Arc<DashMap<Transaction, OpEnum>> {
-        &self.sub_op_tracker.root_ops_awaiting_sub_ops
     }
 
     /// Exposes failed parent operations.


### PR DESCRIPTION
## What This Changes

When a PUT operation completes with `subscribe=true`, a child subscription operation is spawned. The previous implementation waited for this subscription to complete before returning the PUT response to the client. This change returns the finalized state immediately - sub-operations are "fire and forget" from the client's perspective.

## Important Note

**This change does NOT affect River's PUT timeout issue.** River always uses `subscribe: false` for PUT requests and subscribes separately afterward. The timeout issue in Docker NAT testing has a different root cause that still needs to be investigated.

However, this change is still correct behavior: clients that DO use `subscribe=true` shouldn't have to wait for the subscription to complete before getting their PUT response.

## Changes

1. Returns finalized PUT state immediately regardless of pending sub-operations
2. Removes now-unused public methods from `OpManager`:
   - `all_sub_operations_completed()`
   - `count_pending_sub_operations()`
   - `root_ops_awaiting_sub_ops()`

## Testing

- `cargo build` - no warnings
- `cargo test -p freenet` - all tests pass
- Pre-commit hooks pass (fmt, clippy, no TODO-MUST-FIX, no disabled tests)

[AI-assisted - Claude]