### PR TITLE
ci: use GitHub-hosted runners for fast checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
   # Fast checks first - fail fast on simple issues
   # Order: fastest to slowest for single-runner efficiency
 
+  # Fast checks on GitHub-hosted runners (don't block nova)
   conventional_commits:
     name: Conventional Commits
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
 
     steps:
@@ -51,7 +52,7 @@ jobs:
 
   fmt_check:
     name: Fmt
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: conventional_commits
     if: always() && (needs.conventional_commits.result == 'success' || needs.conventional_commits.result == 'skipped')
 
@@ -66,6 +67,7 @@ jobs:
       - name: Check code formatting
         run: cargo fmt -- --check
 
+  # Clippy needs build artifacts, use self-hosted for speed
   clippy_check:
     name: Clippy
     runs-on: self-hosted


### PR DESCRIPTION
## Summary

- Move conventional commits and fmt checks to `ubuntu-latest` (GitHub-hosted)
- Keep clippy, tests, and six-peer tests on `self-hosted` (nova)

## Rationale

With a single self-hosted runner, all jobs queue sequentially. Fast checks (commit format, rustfmt) were waiting behind expensive tests from other PRs.

This hybrid approach:
- **Fast feedback**: Developers see format/commit issues within seconds
- **No blocking**: Fast checks don't wait for nova to finish expensive tests
- **Nova for builds**: Heavy compilation and tests still use nova's resources

## Cost impact

Minimal - fmt and conventional commit checks use <1 minute of GitHub-hosted runner time (free tier covers this easily).

[AI-assisted - Claude]