### PR TITLE
revert: undo Joiner enum (#2158) to unblock PR stack #2167-#2175

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -5,7 +5,7 @@ use futures::FutureExt;
 use futures::StreamExt;
 use std::convert::Infallible;
 use std::future::Future;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::pin::Pin;
 use std::time::Duration;
 use std::{
@@ -148,19 +148,21 @@ impl P2pConnManager {
         let gateways = config.get_gateways()?;
         let key_pair = config.key_pair.clone();
 
-        // Initialize our peer identity.
-        // - Gateways must know their public address upfront (required)
-        // - Peers with configured public_address use that
-        // - Peers behind NAT start with a placeholder (127.0.0.1) which will be updated
-        //   when they receive ObservedAddress from a gateway
-        let advertised_addr = if config.is_gateway {
-            // Gateways must have a public address configured
+        // Initialize our peer identity before any connection attempts so join requests can
+        // reference the correct address.
+        let advertised_addr = {
             let advertised_ip = config
                 .peer_id
                 .as_ref()
                 .map(|peer| peer.addr.ip())
                 .or(config.config.network_api.public_address)
-                .expect("Gateway must have public_address configured");
+                .unwrap_or_else(|| {
+                    if listener_ip.is_unspecified() {
+                        IpAddr::V4(Ipv4Addr::LOCALHOST)
+                    } else {
+                        listener_ip
+                    }
+                });
             let advertised_port = config
                 .peer_id
                 .as_ref()
@@ -168,14 +170,6 @@ impl P2pConnManager {
                 .or(config.config.network_api.public_port)
                 .unwrap_or(listen_port);
             SocketAddr::new(advertised_ip, advertised_port)
-        } else if let Some(public_addr) = config.config.network_api.public_address {
-            // Non-gateway peer with explicitly configured public address
-            let port = config.config.network_api.public_port.unwrap_or(listen_port);
-            SocketAddr::new(public_addr, port)
-        } else {
-            // Non-gateway peer behind NAT: use placeholder address.
-            // This will be updated when we receive ObservedAddress from gateway.
-            SocketAddr::new(std::net::Ipv4Addr::new(127, 0, 0, 1).into(), listen_port)
         };
         bridge
             .op_manager

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -159,7 +159,6 @@ impl NodeP2P {
                 .min(u8::MAX as usize) as u8;
             let target_connections = self.op_manager.ring.connection_manager.min_connections;
 
-            let is_gateway = self.op_manager.ring.connection_manager.is_gateway();
             let (tx, op, msg) = ConnectOp::initiate_join_request(
                 joiner,
                 query_target.clone(),
@@ -167,7 +166,6 @@ impl NodeP2P {
                 ttl,
                 target_connections,
                 self.op_manager.connect_forward_estimator.clone(),
-                is_gateway,
             );
 
             tracing::debug!(

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -333,43 +333,6 @@ impl ConnectionManager {
         }
     }
 
-    /// Updates the address of the peer key.
-    ///
-    /// This is used when a peer behind NAT learns its actual public address from a gateway
-    /// via the ObservedAddress message. The peer initially starts with a placeholder address
-    /// (127.0.0.1) and updates it here when the real address is discovered.
-    ///
-    /// Returns true if the address was updated, false if the address was already set to a
-    /// non-placeholder value.
-    pub fn update_peer_address(&self, new_addr: SocketAddr) -> bool {
-        let mut this_peer = self.peer_key.lock();
-        if let Some(ref mut peer) = *this_peer {
-            // Only update if current address is a placeholder (localhost)
-            if peer.addr.ip().is_loopback() {
-                tracing::info!(
-                    old_addr = %peer.addr,
-                    %new_addr,
-                    "Updating peer address from placeholder to observed address"
-                );
-                peer.addr = new_addr;
-                true
-            } else {
-                tracing::debug!(
-                    current_addr = %peer.addr,
-                    %new_addr,
-                    "Peer address already set to non-placeholder, not updating"
-                );
-                false
-            }
-        } else {
-            tracing::warn!(
-                %new_addr,
-                "Attempted to update peer address but peer key not set"
-            );
-            false
-        }
-    }
-
     pub fn prune_alive_connection(&self, peer: &PeerId) -> Option<Location> {
         self.prune_connection(peer, true)
     }

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -655,7 +655,6 @@ impl Ring {
         let ttl = self.max_hops_to_live.max(1).min(u8::MAX as usize) as u8;
         let target_connections = self.connection_manager.min_connections;
 
-        let is_gateway = self.connection_manager.is_gateway();
         let (tx, op, msg) = ConnectOp::initiate_join_request(
             joiner,
             query_target.clone(),
@@ -663,7 +662,6 @@ impl Ring {
             ttl,
             target_connections,
             op_manager.connect_forward_estimator.clone(),
-            is_gateway,
         );
 
         live_tx_tracker.add_transaction(query_target.peer.clone(), tx);


### PR DESCRIPTION
## Summary

Reverts #2158 ("fix: use Joiner enum to properly handle NAT peer address discovery")

## Why

PR #2158 was merged to fix NAT peer address discovery, but it conflicts with the pending PR stack (#2167 → #2169 → #2171 → #2172 → #2174 → #2175) which takes a more comprehensive approach to the same problem.

The PR stack:
- Implements `PeerAddr` enum (`Unknown`/`Known`) - similar concept but integrated with broader refactoring
- Changes routing to use `SocketAddr` directly instead of relying on embedded addresses
- Removes `from`/`sender` fields from wire protocol messages
- Is awaiting human review

By reverting #2158, the PR stack will merge cleanly and CI can run on those PRs. The PR stack's approach supersedes and improves upon #2158's `Joiner` enum.

## Impact

- Removes `Joiner` enum from `connect.rs`
- NAT peer discovery will temporarily regress until the PR stack is merged
- The PR stack (#2167-#2175) should be merged promptly after this

[AI-assisted - Claude]