### PR TITLE
fix: use tempfile in test_serde_config_args for CI reliability

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -1257,11 +1257,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_serde_config_args() {
-        // Use a unique ID to avoid conflicts with other tests or stale /tmp/freenet directories
-        let unique_id = format!("test-serde-{}", std::process::id());
+        // Use tempfile for a guaranteed-writable directory (avoids CI permission issues on /tmp)
+        let temp_dir = tempfile::tempdir().unwrap();
         let args = ConfigArgs {
             mode: Some(OperationMode::Local),
-            id: Some(unique_id),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(temp_dir.path().to_path_buf()),
+                data_dir: Some(temp_dir.path().to_path_buf()),
+            },
             ..Default::default()
         };
         let cfg = args.build().await.unwrap();


### PR DESCRIPTION
## Problem

The `config::tests::test_serde_config_args` test was failing intermittently on our self-hosted CI runners with:

```
thread 'config::tests::test_serde_config_args' panicked at crates/core/src/config/mod.rs:1264:38:
called `Result::unwrap()` on an `Err` value: Permission denied (os error 13)
```

This blocked 5 of 7 Dependabot PRs from passing CI, even though the test failure was unrelated to the dependency updates.

## Root Cause

The test used `id: Some(unique_id)` which triggers `ConfigPathsArgs::default_dirs()` to create directories under `/tmp/freenet-{id}`. Self-hosted runners can have restrictive permissions on `/tmp` directories that prevent this.

## Solution

Use `tempfile::tempdir()` to create a guaranteed-writable temporary directory, then explicitly set `config_paths.config_dir` and `config_paths.data_dir` to that path. This bypasses the `/tmp` code path entirely.

## Testing

- Verified locally that the test passes
- The fix is minimal and low-risk since it only affects test code

## Impact

Once merged, the 5 blocked Dependabot PRs should pass CI:
- #2189 (freenet-test-network)
- #2188 (test-log)
- #2186 (tracing)
- #2185 (bytesize)
- #2179 (tracing-subscriber in test-contract-1)

[AI-assisted - Claude]