### PR TITLE
ci: enable Docker NAT for six-peer regression test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,18 @@ jobs:
         env:
           FREENET_CORE_PATH: ${{ github.workspace }}
           RUST_LOG: info
-        run: >
-          cargo test --test message_flow
-          river_message_flow_over_freenet_six_peers_five_rounds
-          -- --ignored --exact
+        # Use Docker NAT to simulate realistic network topology where peers
+        # are behind NAT and gateways are on the public network. This provides
+        # better test coverage for NAT traversal and gateway connection code paths.
+        # See issue #2204 for context. Only enable if Docker is accessible.
+        run: |
+          if docker info >/dev/null 2>&1; then
+            echo "Docker available - using Docker NAT backend"
+            export FREENET_TEST_DOCKER_NAT=1
+          else
+            echo "Docker not available - using local backend"
+          fi
+          cargo test --test message_flow river_message_flow_over_freenet_six_peers_five_rounds -- --ignored --exact
 
   ubertest:
     name: Ubertest


### PR DESCRIPTION
## Problem

The six-peer regression test was running without Docker NAT simulation, meaning all peers ran as local processes on localhost. This doesn't match production deployment topology where:
- Gateways are on the public internet (no NAT)
- Peers are behind residential NAT routers

This limited test coverage missed bugs like #2202 where NAT peers failed to connect to gateways.

## Investigation

I verified empirically that the Docker NAT simulation correctly preserves source IPs:
- Set up Docker networks with a gateway, NAT router, and peer
- Confirmed that when the gateway sends responses, the peer sees the gateway's actual IP as the source
- Standard NAT behavior (MASQUERADE) only rewrites source IP on outbound packets, not on return traffic

This means Docker NAT tests DO exercise the code path where `is_known_gateway` would be true for gateway responses.

## Solution

Enable `FREENET_TEST_DOCKER_NAT=1` for the six-peer regression test in CI. This:
- Runs each peer behind a simulated NAT router in Docker
- Runs gateways on the "public" network (no NAT)
- Provides more realistic test coverage for NAT traversal and gateway connection code paths

## Notes

The original bug (#2202) had a timing component where responses arrived before `ongoing_connections.insert()` completed. While Docker NAT doesn't guarantee timing-based bugs will be caught, it does ensure the correct code path is exercised, improving overall test fidelity.

Fixes #2204

[AI-assisted - Claude]