### PR TITLE
perf: transport layer optimizations for throughput

### DIFF
--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -589,7 +589,7 @@ impl PeerConnection {
                         .map_err(|_| TransportError::ConnectionClosed(self.remote_addr()))?;
                     tracing::trace!(%stream_id, %fragment_number, "fragment pushed to existing stream");
                 } else {
-                    let (sender, receiver) = mpsc::channel(1);
+                    let (sender, receiver) = mpsc::channel(64);
                     tracing::trace!(%stream_id, %fragment_number, "new stream");
                     self.inbound_streams.insert(stream_id, sender);
                     let mut stream = inbound_stream::InboundStream::new(total_length_bytes);


### PR DESCRIPTION
Implement high-priority performance improvements from issue https://github.com/freenet/freenet-core/issues/2226:

1. Increase inbound stream channel buffer from 1 to 64
   - Addresses 27x throughput difference identified in benchmarks
   - Reduces channel contention for incoming packet fragments

2. Replace random nonce generation with counter-based approach
   - Uses atomic counter + random prefix for AES-GCM nonces
   - ~5.5x faster than random generation while maintaining uniqueness
   - Random prefix ensures uniqueness across process restarts
   - Counter ensures uniqueness within process lifetime

These changes target the low-effort, high-impact optimizations from
the transport layer performance analysis (PR https://github.com/freenet/freenet-core/pull/2224).