### PR TITLE
fix(ci): improve test stability on high-core-count runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,9 @@ jobs:
           rm -rf /tmp/freenet /tmp/freenet-* 2>/dev/null || true
 
       - name: Test
-        run: cargo test --workspace --no-default-features --features trace,websocket,redb
+        # Limit test threads to reduce resource contention on high-core-count runners
+        # Without this, 64+ parallel tests cause timing-sensitive network tests to fail
+        run: cargo test --workspace --no-default-features --features trace,websocket,redb -- --test-threads=8
 
   six_peer_regression:
     name: six-peer-regression
@@ -134,6 +136,9 @@ jobs:
 
     env:
       FREENET_LOG: error
+      # Ensure lzma-sys can find liblzma on Arch Linux (self-hosted runner)
+      LIBRARY_PATH: /usr/lib
+      PKG_CONFIG_PATH: /usr/lib/pkgconfig
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

CI tests have been flaky on self-hosted runners with high core counts (64 CPUs on technic). Multiple different tests fail intermittently with timeouts:

- `test_put_contract`
- `test_put_contract_three_hop_returns_response`  
- `test_put_merge_persists_state`
- `test_update_contract`
- `test_three_node_network_connectivity`
- `test_logger_capture*`

Additionally, the `six-peer-regression` job fails with a linker error when building freenet fresh:
```
rust-lld: error: unable to find library -llzma
```

## Root Cause

1. **Test thread contention**: Cargo defaults to one test thread per CPU. With 64 CPUs, 64+ network tests run simultaneously, causing:
   - UDP port exhaustion/collisions
   - Async runtime starvation
   - Timing-sensitive operations failing their timeouts

2. **Library path not set**: When `six-peer-regression` builds freenet from river's workspace (fresh build, no cache), the linker can't find liblzma because rust-lld doesn't search `/usr/lib` by default on Arch Linux.

## Solution

1. **Limit test threads to 8** (`--test-threads=8`) - reduces parallel test execution to a manageable level
2. **Set `LIBRARY_PATH` and `PKG_CONFIG_PATH`** for the six-peer-regression job

## Testing

- All tests pass consistently with thread limiting (verified on both nova and technic)
- Currently running CI on the hop-by-hop-routing PR with these same fixes

[AI-assisted - Claude]