### PR TITLE
fix: increase WebSocket client message size limit to 100MB

### DIFF
--- a/apps/freenet-ping/app/tests/run_app.rs
+++ b/apps/freenet-ping/app/tests/run_app.rs
@@ -16,12 +16,12 @@ use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use rand::SeedableRng;
 use testresult::TestResult;
 use tokio::{select, time::sleep, time::timeout};
-use tokio_tungstenite::connect_async;
 use tracing::{span, Instrument, Level};
 
 use common::{
-    base_node_test_config, base_node_test_config_with_rng, gw_config_from_path,
-    gw_config_from_path_with_rng, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
+    base_node_test_config, base_node_test_config_with_rng, connect_async_with_config,
+    gw_config_from_path, gw_config_from_path_with_rng, ws_config, APP_TAG, PACKAGE_DIR,
+    PATH_TO_CONTRACT,
 };
 use freenet_ping_app::ping_client::{
     run_ping_client, wait_for_get_response, wait_for_put_response, wait_for_subscribe_response,
@@ -267,8 +267,9 @@ async fn test_node_diagnostics_query() -> TestResult {
             "ws://127.0.0.1:{ws_api_port_node}/v1/contract/command?encodingProtocol=native"
         );
 
-        let (stream_gw, _) = connect_async(&uri_gw).await?;
-        let (stream_node, _) = connect_async(&uri_node).await?;
+        let (stream_gw, _) = connect_async_with_config(&uri_gw, Some(ws_config()), false).await?;
+        let (stream_node, _) =
+            connect_async_with_config(&uri_node, Some(ws_config()), false).await?;
 
         let mut client_gw = WebApi::start(stream_gw);
         let mut client_node = WebApi::start(stream_node);
@@ -636,9 +637,11 @@ async fn test_ping_multi_node() -> TestResult {
             "ws://127.0.0.1:{ws_api_port_node2}/v1/contract/command?encodingProtocol=native"
         );
 
-        let (stream_gw, _) = connect_async(&uri_gw).await?;
-        let (stream_node1, _) = connect_async(&uri_node1).await?;
-        let (stream_node2, _) = connect_async(&uri_node2).await?;
+        let (stream_gw, _) = connect_async_with_config(&uri_gw, Some(ws_config()), false).await?;
+        let (stream_node1, _) =
+            connect_async_with_config(&uri_node1, Some(ws_config()), false).await?;
+        let (stream_node2, _) =
+            connect_async_with_config(&uri_node2, Some(ws_config()), false).await?;
 
         let mut client_gw = WebApi::start(stream_gw);
         let mut client_node1 = WebApi::start(stream_node1);
@@ -1230,9 +1233,11 @@ async fn test_ping_application_loop() -> TestResult {
             "ws://127.0.0.1:{ws_api_port_node2}/v1/contract/command?encodingProtocol=native"
         );
 
-        let (stream_gw, _) = connect_async(&uri_gw).await?;
-        let (stream_node1, _) = connect_async(&uri_node1).await?;
-        let (stream_node2, _) = connect_async(&uri_node2).await?;
+        let (stream_gw, _) = connect_async_with_config(&uri_gw, Some(ws_config()), false).await?;
+        let (stream_node1, _) =
+            connect_async_with_config(&uri_node1, Some(ws_config()), false).await?;
+        let (stream_node2, _) =
+            connect_async_with_config(&uri_node2, Some(ws_config()), false).await?;
 
         let mut client_gw = WebApi::start(stream_gw);
         let mut client_node1 = WebApi::start(stream_node1);
@@ -1718,7 +1723,8 @@ async fn test_ping_partially_connected_network() -> TestResult {
             let uri = format!(
                 "ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native"
             );
-            let (stream, _) = connect_async(&uri).await?;
+            let (stream, _) =
+                connect_async_with_config(&uri, Some(ws_config()), false).await?;
             let client = WebApi::start(stream);
             gateway_clients.push(client);
             tracing::info!("Connected to gateway {}", i);
@@ -1729,7 +1735,8 @@ async fn test_ping_partially_connected_network() -> TestResult {
             let uri = format!(
                 "ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native"
             );
-            let (stream, _) = connect_async(&uri).await?;
+            let (stream, _) =
+                connect_async_with_config(&uri, Some(ws_config()), false).await?;
             let client = WebApi::start(stream);
             node_clients.push(client);
             tracing::info!("Connected to regular node {}", i);

--- a/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
+++ b/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
@@ -60,8 +60,9 @@ use freenet_stdlib::{
 use futures::FutureExt;
 use testresult::TestResult;
 use tokio::{select, time::sleep};
-use tokio_tungstenite::connect_async;
 use tracing::{span, Instrument, Level};
+
+use common::{connect_async_with_config, ws_config};
 
 /// Configuration for blocked peers test variants
 #[derive(Debug, Clone)]
@@ -233,15 +234,17 @@ async fn run_blocked_peers_test(config: BlockedPeersConfig) -> TestResult {
         );
 
         tracing::info!("Connecting to Gateway at {}", uri_gw);
-        let (stream_gw, _) = connect_async(&uri_gw).await?;
+        let (stream_gw, _) = connect_async_with_config(&uri_gw, Some(ws_config()), false).await?;
         let mut client_gw = WebApi::start(stream_gw);
 
         tracing::info!("Connecting to Node1 at {}", uri_node1);
-        let (stream_node1, _) = connect_async(&uri_node1).await?;
+        let (stream_node1, _) =
+            connect_async_with_config(&uri_node1, Some(ws_config()), false).await?;
         let mut client_node1 = WebApi::start(stream_node1);
 
         tracing::info!("Connecting to Node2 at {}", uri_node2);
-        let (stream_node2, _) = connect_async(&uri_node2).await?;
+        let (stream_node2, _) =
+            connect_async_with_config(&uri_node2, Some(ws_config()), false).await?;
         let mut client_node2 = WebApi::start(stream_node2);
 
         // Compile/load contract code (same helper used by other app tests)

--- a/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
+++ b/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
@@ -27,10 +27,12 @@ use freenet_stdlib::{
 use futures::FutureExt;
 use testresult::TestResult;
 use tokio::{select, time::timeout};
-use tokio_tungstenite::connect_async;
 use tracing::{span, Instrument, Level};
 
-use common::{base_node_test_config, gw_config_from_path, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT};
+use common::{
+    base_node_test_config, connect_async_with_config, gw_config_from_path, ws_config, APP_TAG,
+    PACKAGE_DIR, PATH_TO_CONTRACT,
+};
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[ignore = "Test has never worked - nodes fail on startup with channel closed errors"]
@@ -236,9 +238,11 @@ async fn test_ping_partially_connected_network() -> TestResult {
             let uri = format!(
                 "ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native"
             );
-            let (stream, _) = connect_async(&uri).await.inspect_err(|err| {
-                println!("Failed to connect to gateway ws {i}: {err}");
-            })?;
+            let (stream, _) = connect_async_with_config(&uri, Some(ws_config()), false)
+                .await
+                .inspect_err(|err| {
+                    println!("Failed to connect to gateway ws {i}: {err}");
+                })?;
             let client = WebApi::start(stream);
             gateway_clients.push(client);
             println!("Connected to gateway {i}");
@@ -249,9 +253,11 @@ async fn test_ping_partially_connected_network() -> TestResult {
             let uri = format!(
                 "ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native"
             );
-            let (stream, _) = connect_async(&uri).await.inspect_err(|err| {
-                println!("Failed to connect to regular node ws {i}: {err}");
-            })?;
+            let (stream, _) = connect_async_with_config(&uri, Some(ws_config()), false)
+                .await
+                .inspect_err(|err| {
+                    println!("Failed to connect to regular node ws {i}: {err}");
+                })?;
             let client = WebApi::start(stream);
             node_clients.push(client);
             println!("Connected to regular node {i}");

--- a/apps/freenet-ping/app/tests/test_50_node_operations.rs
+++ b/apps/freenet-ping/app/tests/test_50_node_operations.rs
@@ -19,9 +19,11 @@ use futures::FutureExt;
 use std::{net::TcpListener, path::PathBuf, time::Duration};
 use testresult::TestResult;
 use tokio::{select, time::timeout};
-use tokio_tungstenite::connect_async;
 
-use common::{base_node_test_config, gw_config_from_path, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT};
+use common::{
+    base_node_test_config, connect_async_with_config, gw_config_from_path, ws_config, APP_TAG,
+    PACKAGE_DIR, PATH_TO_CONTRACT,
+};
 
 const NUM_GATEWAYS: usize = 3; // Multiple gateways to distribute load
 const NUM_REGULAR_NODES: usize = 47; // 3 + 47 = 50 total
@@ -216,7 +218,7 @@ async fn setup_50_node_network() -> TestResult<(Vec<WebApi>, Vec<WebApi>, Contra
         let mut gateway_clients = Vec::with_capacity(NUM_GATEWAYS);
         for (i, port) in ws_api_ports_gw.iter().enumerate() {
             let uri = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
-            let (stream, _) = connect_async(&uri).await?;
+            let (stream, _) = connect_async_with_config(&uri, Some(ws_config()), false).await?;
             let client = WebApi::start(stream);
             gateway_clients.push(client);
             println!("📡 Connected to gateway {i}");
@@ -231,7 +233,7 @@ async fn setup_50_node_network() -> TestResult<(Vec<WebApi>, Vec<WebApi>, Contra
         let mut node_clients = Vec::with_capacity(NUM_REGULAR_NODES);
         for (i, port) in ws_api_ports_nodes.iter().enumerate() {
             let uri = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
-            let (stream, _) = connect_async(&uri).await?;
+            let (stream, _) = connect_async_with_config(&uri, Some(ws_config()), false).await?;
             let client = WebApi::start(stream);
             node_clients.push(client);
 

--- a/apps/freenet-ping/app/tests/test_connection_timing.rs
+++ b/apps/freenet-ping/app/tests/test_connection_timing.rs
@@ -11,10 +11,9 @@ use freenet_stdlib::client_api::WebApi;
 use futures::FutureExt;
 use testresult::TestResult;
 use tokio::{select, time::timeout};
-use tokio_tungstenite::connect_async;
 use tracing::{span, Instrument, Level};
 
-use common::{base_node_test_config, gw_config_from_path};
+use common::{base_node_test_config, connect_async_with_config, gw_config_from_path, ws_config};
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_connection_timing() -> TestResult {
@@ -93,7 +92,7 @@ async fn test_connection_timing() -> TestResult {
         let ws_start = Instant::now();
         let uri_gw =
             format!("ws://127.0.0.1:{ws_api_port_gw}/v1/contract/command?encodingProtocol=native");
-        let (stream_gw, _) = connect_async(&uri_gw).await?;
+        let (stream_gw, _) = connect_async_with_config(&uri_gw, Some(ws_config()), false).await?;
         let _client_gw = WebApi::start(stream_gw);
         println!(
             "   ✓ Gateway WebSocket connected in {}ms",
@@ -104,7 +103,8 @@ async fn test_connection_timing() -> TestResult {
         let uri_node1 = format!(
             "ws://127.0.0.1:{ws_api_port_node1}/v1/contract/command?encodingProtocol=native"
         );
-        let (stream_node1, _) = connect_async(&uri_node1).await?;
+        let (stream_node1, _) =
+            connect_async_with_config(&uri_node1, Some(ws_config()), false).await?;
         let _client_node1 = WebApi::start(stream_node1);
         println!(
             "   ✓ Node1 WebSocket connected in {}ms",

--- a/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
+++ b/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
@@ -12,10 +12,12 @@ use freenet_stdlib::{
 use futures::FutureExt;
 use testresult::TestResult;
 use tokio::{select, time::timeout};
-use tokio_tungstenite::connect_async;
 use tracing::{span, Instrument, Level};
 
-use common::{base_node_test_config, gw_config_from_path, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT};
+use common::{
+    base_node_test_config, connect_async_with_config, gw_config_from_path, ws_config, APP_TAG,
+    PACKAGE_DIR, PATH_TO_CONTRACT,
+};
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_small_network_get_failure() -> TestResult {
@@ -137,19 +139,21 @@ async fn test_small_network_get_failure() -> TestResult {
 
         let uri_gw =
             format!("ws://127.0.0.1:{_ws_api_port_gw}/v1/contract/command?encodingProtocol=native");
-        let (stream_gw, _) = connect_async(&uri_gw).await?;
+        let (stream_gw, _) = connect_async_with_config(&uri_gw, Some(ws_config()), false).await?;
         let mut client_gw = WebApi::start(stream_gw);
 
         let uri_node1 = format!(
             "ws://127.0.0.1:{ws_api_port_node1}/v1/contract/command?encodingProtocol=native"
         );
-        let (stream_node1, _) = connect_async(&uri_node1).await?;
+        let (stream_node1, _) =
+            connect_async_with_config(&uri_node1, Some(ws_config()), false).await?;
         let mut client_node1 = WebApi::start(stream_node1);
 
         let uri_node2 = format!(
             "ws://127.0.0.1:{ws_api_port_node2}/v1/contract/command?encodingProtocol=native"
         );
-        let (stream_node2, _) = connect_async(&uri_node2).await?;
+        let (stream_node2, _) =
+            connect_async_with_config(&uri_node2, Some(ws_config()), false).await?;
         let mut client_node2 = WebApi::start(stream_node2);
 
         let path_to_code = PathBuf::from(PACKAGE_DIR).join(PATH_TO_CONTRACT);


### PR DESCRIPTION
## Problem

Test `test_ping_blocked_peers` was failing with:
```
Space limit exceeded: Message too long: 21697171 > 16777216
```

The server-side WebSocket (in `crates/core/src/client_events/websocket.rs`) is configured for 100MB messages, but all WebSocket clients were using `tokio_tungstenite::connect_async()` which defaults to tungstenite's 16MB limit.

When contract state grew beyond 16MB, clients couldn't receive the response.

## Solution

- Add `ws_config()` helper that configures 100MB message limit and 16MB frame limit
- Update all WebSocket connections to use `connect_async_with_config()` with this config
- Apply to both the ping client library and all test files

## Changes

- `apps/freenet-ping/app/src/ping_client.rs` - Updated `connect_to_host()`
- `apps/freenet-ping/app/tests/common/mod.rs` - Added shared `ws_config()` helper
- Updated all test files that create WebSocket connections

## Test Plan

- [x] `cargo check -p freenet-ping-app --tests` passes
- [ ] CI should now pass for `test_ping_blocked_peers*` tests
- [ ] Dependabot PRs should pass after rebasing

[AI-assisted - Claude]