### PR TITLE
test: improve transport module unit test coverage

### DIFF
--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -71,6 +71,13 @@ impl std::fmt::Display for StreamId {
     }
 }
 
+#[cfg(test)]
+impl<'a> arbitrary::Arbitrary<'a> for StreamId {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self(u.arbitrary()?))
+    }
+}
+
 type InboundStreamResult = Result<(StreamId, SerializedMessage), StreamId>;
 
 /// The `PeerConnection` struct is responsible for managing the connection with a remote peer.

--- a/crates/core/src/transport/rate_limiter.rs
+++ b/crates/core/src/transport/rate_limiter.rs
@@ -284,4 +284,249 @@ mod tests {
         tracker.add_packet(3000);
         assert_eq!(tracker.can_send_packet(10000, 2000), None);
     }
+
+    // Property-based tests using arbitrary for edge case coverage
+    mod property_tests {
+        use super::*;
+        use arbitrary::Unstructured;
+
+        /// Helper to run a property test with random data
+        fn run_property_test<F>(iterations: usize, mut property: F)
+        where
+            F: FnMut(&mut Unstructured) -> arbitrary::Result<()>,
+        {
+            let mut rng = rand::rng();
+            for _ in 0..iterations {
+                let data: Vec<u8> = (0..1024).map(|_| rand::Rng::random(&mut rng)).collect();
+                let mut u = Unstructured::new(&data);
+                // Ignore errors from insufficient data
+                let _ = property(&mut u);
+            }
+        }
+
+        #[test]
+        fn property_bandwidth_invariant_maintained() {
+            // Invariant: current_bandwidth always equals sum of packet sizes
+            run_property_test(100, |u| {
+                let window_ms: u64 = u.int_in_range(1..=10000)?;
+                let mut tracker = mock_tracker(Duration::from_millis(window_ms));
+
+                // Add a random number of packets
+                let num_packets: usize = u.int_in_range(0..=20)?;
+                for _ in 0..num_packets {
+                    let size: usize = u.int_in_range(0..=10000)?;
+                    tracker.add_packet(size);
+                    verify_bandwidth_match(&tracker);
+                }
+
+                // Advance time randomly and cleanup
+                let advance_ms: u64 = u.int_in_range(0..=20000)?;
+                tracker
+                    .time_source
+                    .advance_time(Duration::from_millis(advance_ms));
+                tracker.cleanup();
+                verify_bandwidth_match(&tracker);
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        fn property_can_send_when_under_limit() {
+            // If current_bandwidth + packet_size <= limit, should return None (immediate send)
+            run_property_test(100, |u| {
+                let window_ms: u64 = u.int_in_range(1..=10000)?;
+                let mut tracker = mock_tracker(Duration::from_millis(window_ms));
+
+                let bandwidth_limit: usize = u.int_in_range(1000..=1_000_000)?;
+                let packet_size: usize = u.int_in_range(0..=bandwidth_limit)?;
+
+                // Add packets that stay under the limit
+                let num_packets: usize = u.int_in_range(0..=5)?;
+                let max_per_packet = (bandwidth_limit - packet_size) / (num_packets + 1);
+                for _ in 0..num_packets {
+                    if max_per_packet > 0 {
+                        let size: usize = u.int_in_range(0..=max_per_packet)?;
+                        tracker.add_packet(size);
+                    }
+                }
+
+                // If we're under the limit, should be able to send immediately
+                if tracker.current_bandwidth + packet_size <= bandwidth_limit {
+                    assert!(
+                        tracker
+                            .can_send_packet(bandwidth_limit, packet_size)
+                            .is_none(),
+                        "Should allow immediate send when under bandwidth limit"
+                    );
+                }
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        fn property_wait_time_never_exceeds_window() {
+            // The wait time should never exceed the window size
+            run_property_test(100, |u| {
+                let window_ms: u64 = u.int_in_range(1..=10000)?;
+                let window = Duration::from_millis(window_ms);
+                let mut tracker = mock_tracker(window);
+
+                // Add enough packets to exceed any reasonable limit
+                let num_packets: usize = u.int_in_range(1..=10)?;
+                for _ in 0..num_packets {
+                    let size: usize = u.int_in_range(1000..=50000)?;
+                    tracker.add_packet(size);
+                }
+
+                let bandwidth_limit: usize = u.int_in_range(1000..=100000)?;
+                let packet_size: usize = u.int_in_range(1..=10000)?;
+
+                if let Some(wait_time) = tracker.can_send_packet(bandwidth_limit, packet_size) {
+                    assert!(
+                        wait_time <= window,
+                        "Wait time {:?} exceeds window {:?}",
+                        wait_time,
+                        window
+                    );
+                }
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        fn property_cleanup_removes_old_packets() {
+            // After advancing time past window, all packets should be cleaned up
+            run_property_test(100, |u| {
+                let window_ms: u64 = u.int_in_range(1..=1000)?;
+                let mut tracker = mock_tracker(Duration::from_millis(window_ms));
+
+                // Add some packets
+                let num_packets: usize = u.int_in_range(1..=20)?;
+                for _ in 0..num_packets {
+                    let size: usize = u.int_in_range(1..=10000)?;
+                    tracker.add_packet(size);
+                }
+
+                // Advance time past the window
+                tracker
+                    .time_source
+                    .advance_time(Duration::from_millis(window_ms + 1));
+                tracker.cleanup();
+
+                assert!(
+                    tracker.packets.is_empty(),
+                    "All packets should be cleaned up after window expires"
+                );
+                assert_eq!(
+                    tracker.current_bandwidth, 0,
+                    "Bandwidth should be zero after cleanup"
+                );
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        fn property_partial_cleanup_preserves_recent() {
+            // Packets added after time advance should be preserved
+            run_property_test(100, |u| {
+                let window_ms: u64 = u.int_in_range(100..=1000)?;
+                let mut tracker = mock_tracker(Duration::from_millis(window_ms));
+
+                // Add initial packets
+                let initial_size: usize = u.int_in_range(1..=5000)?;
+                tracker.add_packet(initial_size);
+
+                // Advance time - must be > 0 to separate the packets in time
+                // and < window_ms to keep within window for the recent packet
+                let advance_ms: u64 = u.int_in_range(1..=(window_ms / 2).max(1))?;
+                tracker
+                    .time_source
+                    .advance_time(Duration::from_millis(advance_ms));
+
+                // Add more packets (these are now timestamped later)
+                let recent_size: usize = u.int_in_range(1..=5000)?;
+                tracker.add_packet(recent_size);
+
+                // Advance past initial packet's window but not recent
+                // The initial packet will expire after window_ms from when it was added
+                // The recent packet will expire after window_ms from when *it* was added
+                // So we need to advance exactly enough to expire initial but not recent
+                tracker
+                    .time_source
+                    .advance_time(Duration::from_millis(window_ms - advance_ms + 1));
+                tracker.cleanup();
+
+                // Recent packet should still be there (it was added advance_ms after initial,
+                // so it has advance_ms - 1 left before expiring)
+                assert!(
+                    !tracker.packets.is_empty(),
+                    "Recent packets should be preserved (window_ms={}, advance_ms={})",
+                    window_ms,
+                    advance_ms
+                );
+                verify_bandwidth_match(&tracker);
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        fn edge_case_zero_packet_size() {
+            let mut tracker = mock_tracker(Duration::from_secs(1));
+            tracker.add_packet(0);
+            verify_bandwidth_match(&tracker);
+            assert_eq!(tracker.current_bandwidth, 0);
+
+            // Zero-size packet should always be allowed
+            assert!(tracker.can_send_packet(100, 0).is_none());
+        }
+
+        #[test]
+        fn edge_case_zero_bandwidth_limit() {
+            let mut tracker = mock_tracker(Duration::from_secs(1));
+
+            // With zero limit and zero packet, should still work
+            assert!(tracker.can_send_packet(0, 0).is_none());
+
+            // Any non-zero packet should require waiting (or be blocked)
+            tracker.add_packet(100);
+            // With 0 limit but existing bandwidth, the math gets interesting
+            // The function should handle this gracefully
+            let _ = tracker.can_send_packet(0, 1);
+        }
+
+        #[test]
+        fn edge_case_exact_bandwidth_limit() {
+            let mut tracker = mock_tracker(Duration::from_secs(1));
+            tracker.add_packet(5000);
+
+            // Exactly at limit - should still allow
+            assert!(
+                tracker.can_send_packet(10000, 5000).is_none(),
+                "Should allow send when exactly at limit"
+            );
+
+            // One byte over - should require waiting
+            assert!(
+                tracker.can_send_packet(10000, 5001).is_some(),
+                "Should require wait when over limit"
+            );
+        }
+
+        #[test]
+        fn edge_case_very_small_window() {
+            let mut tracker = mock_tracker(Duration::from_nanos(1));
+            tracker.add_packet(1000);
+
+            // With tiny window, packets expire almost immediately
+            tracker.time_source.advance_time(Duration::from_micros(1));
+            tracker.cleanup();
+
+            assert!(tracker.packets.is_empty());
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The transport module had significant gaps in unit test coverage:
- `crypto.rs`: ~50% line coverage - many core functions untested
- `rate_limiter.rs`: ~69% line coverage - no edge case or property-based tests
- No `Arbitrary` implementations for transport types, limiting fuzz testing potential

This was identified using `cargo llvm-cov` to analyze line-by-line coverage.

## This Solution

Add comprehensive unit tests and property-based testing infrastructure:

### crypto.rs (8 new tests)
- `Arbitrary` impls for `TransportKeypair` and `TransportPublicKey` with caching to avoid expensive RSA generation
- Tests for previously uncovered functions: `save()`, `Default`, `new_with_rng()`, `from_private_key()`, `Debug` impl, `From<RsaPublicKey>`
- Keypair save/load round-trip test via PKCS8 PEM encoding

### peer_connection.rs
- `Arbitrary` impl for `StreamId` to enable property-based testing

### rate_limiter.rs (9 new tests)
Property-based tests using the `arbitrary` crate:
- `property_bandwidth_invariant_maintained`: verifies `current_bandwidth` always matches packet sum
- `property_can_send_when_under_limit`: verifies immediate send when under bandwidth limit  
- `property_wait_time_never_exceeds_window`: verifies wait times are bounded by window
- `property_cleanup_removes_old_packets`: verifies expired packets are cleaned up
- `property_partial_cleanup_preserves_recent`: verifies recent packets survive cleanup

Edge case tests:
- Zero packet size, zero bandwidth limit, exact bandwidth limit, very small window

## Testing

All 63 transport tests pass:
```
cargo test --package freenet --lib -- transport::
test result: ok. 63 passed; 0 failed; 5 ignored
```

## Changes

- 439 new lines of test code
- No changes to production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)