### PR TITLE
ci: add sensible timeouts to all workflow jobs

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   auto-label:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Rate limit: only 1 run at a time, cancel if new issue comes in
     concurrency:
       group: auto-label

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,6 +24,7 @@ jobs:
   benchmark:
     name: Performance Benchmarks
     runs-on: self-hosted
+    timeout-minutes: 20
     # Don't fail the whole workflow if benchmarks detect regressions
     continue-on-error: true
 
@@ -193,6 +194,7 @@ jobs:
   benchmark-summary:
     name: Benchmark Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: benchmark
     # Always run, even if benchmark job "fails" (detected regression)
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   conventional_commits:
     name: Conventional Commits
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name == 'pull_request'
 
     steps:
@@ -53,6 +54,7 @@ jobs:
   fmt_check:
     name: Fmt
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Run in parallel with conventional_commits (both are fast GitHub-hosted checks)
 
     steps:
@@ -70,6 +72,7 @@ jobs:
   clippy_check:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: fmt_check
 
     env:
@@ -92,6 +95,7 @@ jobs:
   test_all:
     name: Test
     runs-on: self-hosted
+    timeout-minutes: 30
     needs: fmt_check
 
     env:
@@ -191,6 +195,7 @@ jobs:
     # TODO: Re-enable when ubertest is stable - currently failing
     if: false
     runs-on: self-hosted
+    timeout-minutes: 30
 
     env:
       FREENET_LOG: error
@@ -223,6 +228,7 @@ jobs:
   claude-ci-analysis:
     name: Claude CI Analysis
     runs-on: self-hosted
+    timeout-minutes: 30
     needs: [test_all, clippy_check, fmt_check]
     if: failure() && contains(github.event.pull_request.labels.*.name, 'claude-debug')
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write       # Allows pushing commits, rebasing, creating branches
       pull-requests: write  # Allows updating PRs, requesting reviews, merging

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -10,8 +10,8 @@ on:
 jobs:
   build-x86_64:
     name: Build for x86_64-unknown-linux-gnu
-
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6
@@ -45,8 +45,8 @@ jobs:
 
   build-arm64:
     name: Build for aarch64-unknown-linux-gnu
-
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6
@@ -78,6 +78,7 @@ jobs:
   attach-to-release:
     name: Attach binaries to GitHub release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [build-x86_64, build-arm64]
     if: startsWith(github.ref, 'refs/tags/v')
 

--- a/.github/workflows/matrix_pr_merge_notify.yml
+++ b/.github/workflows/matrix_pr_merge_notify.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   notify_matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.pull_request.merged == true
     steps:
       - name: Send message to Matrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
   validate:
     name: Validate release inputs
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.validate.outputs.version }}
       fdev_version: ${{ steps.validate.outputs.fdev_version }}
@@ -67,6 +68,7 @@ jobs:
   update_versions:
     name: Update versions and create PR
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: validate
     outputs:
       pr_number: ${{ steps.create_pr.outputs.pr_number }}
@@ -150,6 +152,7 @@ jobs:
   wait_for_pr:
     name: Wait for PR to merge
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [validate, update_versions]
 
     steps:
@@ -189,6 +192,7 @@ jobs:
   publish_crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [validate, wait_for_pr]
     if: always() && (needs.wait_for_pr.result == 'success' || inputs.dry_run)
 
@@ -241,6 +245,7 @@ jobs:
   create_release:
     name: Create GitHub release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [validate, publish_crates]
     if: always() && (needs.publish_crates.result == 'success' || inputs.dry_run)
 
@@ -311,6 +316,7 @@ jobs:
   summary:
     name: Release summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [validate, create_release]
     if: always()
 


### PR DESCRIPTION
## Problem

CI jobs can hang indefinitely, wasting runner resources and blocking other work. GitHub Actions default timeout is 6 hours (360 minutes) - far too permissive.

**Example:** Job [57897547066](https://github.com/freenet/freenet-core/actions/runs/20168430198/job/57897547066) ran for **2h 30m** before manual cancellation.

## Solution

Add `timeout-minutes` to all workflow jobs with values based on expected runtime:

### Timeout Matrix

| Timeout | Job Types | Rationale |
|---------|-----------|-----------|
| **5 min** | `fmt_check`, `conventional_commits`, summary jobs, notifications | Fast checks with minimal compute |
| **10 min** | `auto-label`, release tasks, artifact uploads | GitHub API calls and file operations |
| **20 min** | `clippy_check`, benchmarks, crate publishing | Compilation with caching |
| **30 min** | `test_all`, `six-peer-regression`, `ubertest`, Claude CI | Test suites with network I/O |
| **60 min** | Release builds (`build-x86_64`, `build-arm64`), `wait_for_pr` | Full release compilation, CI wait loops |

All values are **2-3x typical runtime** to avoid false positives while providing safety net.

## Changes

```diff
+ ci.yml: 6 jobs now have timeouts (conventional_commits, fmt, clippy, test, ubertest, claude-ci-analysis)
+ benchmarks.yml: 2 jobs (benchmark, benchmark-summary)
+ claude.yml: 1 job (claude)
+ cross-compile.yml: 3 jobs (build-x86_64, build-arm64, attach-to-release)
+ release.yml: 6 jobs (validate, update_versions, wait_for_pr, publish_crates, create_release, summary)
+ auto-label-issues.yml: 1 job (auto-label)
+ matrix_pr_merge_notify.yml: 1 job (notify_matrix)
```

## Test Plan

- [x] Local validation: All workflow YAML syntax valid
- [ ] Verify jobs complete normally within timeout limits
- [ ] Monitor for timeout failures indicating values need adjustment

## Impact

- **Prevents**: Runaway jobs consuming CI resources indefinitely
- **Safety net**: Catches stuck jobs after 2-3x normal runtime
- **Resource efficiency**: Frees runners faster when jobs fail
- **No breaking changes**: All timeouts exceed normal job duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)