### PR TITLE
fix(fdev): ensure graceful WebSocket close before process exit

### DIFF
--- a/crates/fdev/src/diagnostics.rs
+++ b/crates/fdev/src/diagnostics.rs
@@ -2,7 +2,7 @@ use freenet_stdlib::client_api::{HostResponse, NodeDiagnosticsConfig, NodeQuery,
 use prettytable::{Cell, Row, Table};
 
 use crate::{
-    commands::{execute_command, start_api_client},
+    commands::{close_api_client, execute_command, start_api_client},
     config::BaseConfig,
 };
 
@@ -150,6 +150,9 @@ pub async fn diagnostics(base_cfg: BaseConfig, contract_keys: Vec<String>) -> an
         println!("  Seeding contracts: {}", metrics.seeding_contracts);
         println!();
     }
+
+    // Gracefully close the WebSocket connection
+    close_api_client(&mut client).await;
 
     Ok(())
 }

--- a/crates/fdev/src/query.rs
+++ b/crates/fdev/src/query.rs
@@ -2,7 +2,7 @@ use freenet_stdlib::client_api::{HostResponse, NodeQuery, QueryResponse};
 use prettytable::{Cell, Row, Table};
 
 use crate::{
-    commands::{execute_command, start_api_client},
+    commands::{close_api_client, execute_command, start_api_client},
     config::BaseConfig,
 };
 
@@ -71,6 +71,9 @@ pub async fn query(base_cfg: BaseConfig) -> anyhow::Result<()> {
     } else {
         println!("No application subscriptions");
     }
+
+    // Gracefully close the WebSocket connection
+    close_api_client(&mut client).await;
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

When using `fdev query` (and other commands like `put`, `update`, `diagnostics`), the server logs show:

```
ERROR freenet::client_events::websocket: WebSocket protocol error: Connection reset without closing handshake
```

This error occurs because the `WebApi::Drop` implementation spawns a background task to send a `Close` message:

```rust
impl Drop for WebApi {
    fn drop(&mut self) {
        let req = self.request_tx.clone();
        tokio::spawn(async move {
            let _ = req.send(ClientRequest::Close).await;
        });
    }
}
```

When fdev commands complete and the function returns, the tokio runtime shuts down (after `block_on()` returns) before this spawned task can execute. The TCP connection closes abruptly without a proper WebSocket close handshake.

## Why PR #2280 didn't fully fix this

PR #2280 fixed the issue of fdev not waiting for server responses (ensuring operations complete before reporting success). However, it didn't address the cleanup issue where the process exits before the WebSocket close handshake completes.

## This Solution

Add explicit WebSocket disconnection before each command returns:

1. Added `close_api_client()` helper function that:
   - Sends a `ClientRequest::Disconnect` message
   - Waits 50ms for the close handshake to complete

2. Call `close_api_client()` at the end of:
   - `put_contract()`
   - `put_delegate()`
   - `update()`
   - `query()`
   - `diagnostics()`

This ensures the WebSocket close frame is sent and acknowledged before the process exits.

## Testing

- Built and ran `cargo clippy -p fdev` - no warnings
- The failing test (`testing::tests::test_config`) is unrelated - it's a permission error in the test infrastructure

[AI-assisted - Claude]