### PR TITLE
ci: skip expensive tests for release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     needs: fmt_check
+    # Skip tests for release PRs - they only change version numbers in Cargo.toml
+    # The actual code has already passed CI when it merged to main
+    if: ${{ !startsWith(github.head_ref || '', 'release/v') }}
 
     env:
       FREENET_LOG: error
@@ -138,6 +141,8 @@ jobs:
     needs: test_all  # Run after Test to avoid resource contention on self-hosted runner
     runs-on: self-hosted
     timeout-minutes: 30
+    # Skip for release PRs - same reason as test_all
+    if: ${{ !startsWith(github.head_ref || '', 'release/v') }}
 
     env:
       FREENET_LOG: error
@@ -230,7 +235,11 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     needs: [test_all, clippy_check, fmt_check]
-    if: failure() && contains(github.event.pull_request.labels.*.name, 'claude-debug')
+    # Run if any job failed (not skipped) and has claude-debug label
+    if: |
+      failure() &&
+      contains(github.event.pull_request.labels.*.name, 'claude-debug') &&
+      !startsWith(github.head_ref || '', 'release/v')
 
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

The release process runs CI 3 times:
1. **PR check** (~20 min) - when version bump PR is created
2. **Merge queue** (~20 min) - when PR enters merge queue
3. **Push to main** (~20 min) - after PR merges

That's ~60 minutes of CI for a version-only change where the actual code has already passed CI when it merged to main.

## Solution

Detect release PRs (branches matching `release/v*`) and skip the expensive tests:
- `test_all` (~20 min)
- `six_peer_regression` (~20 min)

Fast checks (fmt, clippy, conventional commits) still run.

## Impact

Reduces release CI time from ~60 min to ~10 min.

## Risk

Low. Release PRs only change version numbers in `Cargo.toml`. The functional code has already passed full CI when those changes merged to main.

## Note on branch protection

If `test_all` or `six_peer_regression` are required checks in branch protection settings, skipped jobs will show as "skipped" (neutral status). GitHub may need branch protection adjusted to not require these specific jobs for release branches, or to accept skipped status.

[AI-assisted - Claude]