### PR TITLE
ci: skip expensive tests in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,10 +138,10 @@ jobs:
 
   six_peer_regression:
     name: six-peer-regression
-    needs: test_all  # Run after Test to avoid resource contention on self-hosted runner
+    needs: fmt_check  # Changed from test_all to avoid dependency skip cascade
     runs-on: self-hosted
     timeout-minutes: 30
-    # Skip on merge_group - same rationale as test_all
+    # Skip on merge_group - PR already passed full tests
     if: github.event_name != 'merge_group'
 
     env:
@@ -196,10 +196,10 @@ jobs:
 
   ubertest:
     name: Ubertest
-    needs: test_all
+    needs: fmt_check  # Changed from test_all to avoid dependency skip cascade
     # TODO: Re-enable when ubertest is stable - currently failing
-    # Also skip on merge_group
-    if: false && github.event_name != 'merge_group'
+    # When re-enabling, add: && github.event_name != 'merge_group'
+    if: false
     runs-on: self-hosted
     timeout-minutes: 30
 
@@ -235,7 +235,7 @@ jobs:
     name: Claude CI Analysis
     runs-on: self-hosted
     timeout-minutes: 30
-    needs: [test_all, clippy_check, fmt_check]
+    needs: [clippy_check, fmt_check]  # Removed test_all to avoid dependency skip cascade
     # Only run on PRs with claude-debug label when there's a failure
     if: |
       github.event_name == 'pull_request' &&


### PR DESCRIPTION
## Problem

The merge queue runs the full CI suite again after PR checks pass. This adds ~20 minutes per PR but provides no additional value - the code already passed all tests.

## Solution

Skip expensive tests (`test_all`, `six_peer_regression`) on `merge_group` events. The merge queue only needs to verify compilation succeeds with any concurrent changes, which `fmt` and `clippy` already handle.

### What runs in merge queue now
- ✅ `fmt` (~15s) - catches formatting conflicts
- ✅ `clippy` (~1min) - catches compilation issues, lint conflicts

### What's skipped in merge queue
- ⏭️ `test_all` (~10min) - already passed on PR
- ⏭️ `six_peer_regression` (~10min) - already passed on PR

## Impact

- **Time saved per PR**: ~20 minutes
- **Risk**: Low - if concurrent PRs cause test failures (rare), we can revert after merge
- **Rollback**: Easy - just revert the commit on main

## Context

From Matrix discussion with Nacho:
> "On CI changes, there is any real value added over running CI again on merge queue? At least the full one? ... I think it should check at most that things compile in case of concurrent dependency changes which are conflictive (a simple cargo check would do that)."

[AI-assisted - Claude]