### PR TITLE
perf: enhanced thread explosion diagnostics

### DIFF
--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -6,21 +6,36 @@ use freenet::{
     run_local_node, run_network_node,
     server::serve_gateway,
 };
+use std::collections::HashSet;
 use std::sync::Arc;
 
-/// Count threads with "tokio-runtime" in their name by reading /proc/self/task
-fn count_tokio_threads() -> usize {
+/// Thread info for diagnostics
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ThreadInfo {
+    tid: u64,
+    name: String,
+}
+
+/// Get all tokio runtime threads with their TIDs and names
+/// Looks for both "freenet-main" (our main runtime) and "tokio-runtime" (rogue runtimes)
+fn get_tokio_threads() -> Vec<ThreadInfo> {
     let Ok(entries) = std::fs::read_dir("/proc/self/task") else {
-        return 0;
+        return Vec::new();
     };
     entries
         .filter_map(|e| e.ok())
         .filter_map(|entry| {
+            let tid: u64 = entry.file_name().to_str()?.parse().ok()?;
             let comm_path = entry.path().join("comm");
-            std::fs::read_to_string(comm_path).ok()
+            let name = std::fs::read_to_string(comm_path).ok()?.trim().to_string();
+            // Match our main runtime threads OR any rogue tokio runtime threads
+            if name.contains("freenet-main") || name.contains("tokio-runtime") {
+                Some(ThreadInfo { tid, name })
+            } else {
+                None
+            }
         })
-        .filter(|name| name.contains("tokio-runtime"))
-        .count()
+        .collect()
 }
 
 /// Build metadata embedded at compile time
@@ -63,24 +78,104 @@ async fn run_network(config: Config) -> anyhow::Result<()> {
     tracing::info!("Starting freenet node in network mode");
 
     // Thread monitor for diagnosing thread explosion issue
+    // Enhanced to track individual thread TIDs and detect exactly when new threads appear
     tokio::spawn(async {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        static BASELINE: AtomicUsize = AtomicUsize::new(0);
         let expected = std::thread::available_parallelism()
             .map(|p| p.get())
             .unwrap_or(1);
-        let initial = count_tokio_threads();
-        BASELINE.store(initial, Ordering::SeqCst);
-        tracing::info!(target: "freenet::diagnostics::thread_explosion", initial, expected, "Thread monitor started");
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+
+        // Track known thread TIDs
+        let initial_threads = get_tokio_threads();
+        let mut known_tids: HashSet<u64> = initial_threads.iter().map(|t| t.tid).collect();
+        let baseline = initial_threads.len();
+
+        // Log initial thread TIDs for reference
+        let initial_tid_range = if !initial_threads.is_empty() {
+            let min_tid = initial_threads.iter().map(|t| t.tid).min().unwrap();
+            let max_tid = initial_threads.iter().map(|t| t.tid).max().unwrap();
+            format!("{}-{}", min_tid, max_tid)
+        } else {
+            "none".to_string()
+        };
+
+        tracing::info!(
+            target: "freenet::diagnostics::thread_explosion",
+            initial = baseline,
+            expected,
+            tid_range = %initial_tid_range,
+            "Thread monitor started (checking every 10s)"
+        );
+
+        // Check every 10 seconds for faster detection
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(10));
+
         loop {
             interval.tick().await;
-            let current = count_tokio_threads();
-            let baseline = BASELINE.load(Ordering::SeqCst);
-            if current > baseline + 10 {
-                tracing::error!(target: "freenet::diagnostics::thread_explosion", current, baseline, "THREAD EXPLOSION");
-            } else if current > baseline {
-                tracing::warn!(target: "freenet::diagnostics::thread_explosion", current, baseline, "Thread count increased");
+
+            let current_threads = get_tokio_threads();
+            let current_count = current_threads.len();
+            let current_tids: HashSet<u64> = current_threads.iter().map(|t| t.tid).collect();
+
+            // Find newly created threads
+            let new_tids: Vec<u64> = current_tids.difference(&known_tids).copied().collect();
+
+            if !new_tids.is_empty() {
+                // New threads detected! Log detailed info
+                let new_threads: Vec<_> = current_threads
+                    .iter()
+                    .filter(|t| new_tids.contains(&t.tid))
+                    .collect();
+
+                // Check if this looks like a new runtime (batch of consecutive TIDs)
+                let mut sorted_new_tids = new_tids.clone();
+                sorted_new_tids.sort();
+                let is_batch = sorted_new_tids.len() > 1 && {
+                    let first = sorted_new_tids[0];
+                    let last = sorted_new_tids[sorted_new_tids.len() - 1];
+                    // Consecutive or near-consecutive TIDs suggest batch creation
+                    (last - first) < (sorted_new_tids.len() as u64 * 2)
+                };
+
+                let new_tid_range = if !sorted_new_tids.is_empty() {
+                    format!(
+                        "{}-{}",
+                        sorted_new_tids[0],
+                        sorted_new_tids[sorted_new_tids.len() - 1]
+                    )
+                } else {
+                    "none".to_string()
+                };
+
+                // Get thread names (should all be tokio-runtime-w or similar)
+                let thread_names: Vec<_> = new_threads.iter().map(|t| t.name.as_str()).collect();
+                let unique_names: HashSet<_> = thread_names.iter().copied().collect();
+
+                if current_count > baseline + 10 {
+                    tracing::error!(
+                        target: "freenet::diagnostics::thread_explosion",
+                        current = current_count,
+                        baseline,
+                        new_thread_count = new_tids.len(),
+                        new_tid_range = %new_tid_range,
+                        is_batch_creation = is_batch,
+                        thread_names = ?unique_names,
+                        "THREAD EXPLOSION - new runtime likely created"
+                    );
+                } else {
+                    tracing::warn!(
+                        target: "freenet::diagnostics::thread_explosion",
+                        current = current_count,
+                        baseline,
+                        new_thread_count = new_tids.len(),
+                        new_tid_range = %new_tid_range,
+                        is_batch_creation = is_batch,
+                        thread_names = ?unique_names,
+                        "New tokio threads detected"
+                    );
+                }
+
+                // Update known TIDs
+                known_tids.extend(new_tids);
             }
         }
     });
@@ -110,6 +205,9 @@ fn main() -> anyhow::Result<()> {
                 .map(usize::from)
                 .unwrap_or(1),
         )
+        // Name threads to distinguish main runtime from any rogue runtimes
+        // Rogue runtimes would use default "tokio-runtime-w" name
+        .thread_name("freenet-main")
         .enable_all()
         .build()
         .unwrap();


### PR DESCRIPTION
## Problem

The gateway experiences thread explosion (~100% CPU) when a rogue tokio runtime is created, doubling the worker thread count from 16 to 33. Current diagnostics (from #2309) detect the explosion but don't capture enough detail to identify the source.

Investigation in #2310 ruled out several suspects but the root cause remains unknown. We know:
- 16 extra `tokio-runtime-w` threads appear at once with consecutive TIDs
- This indicates a new runtime being created (not just task spawning)
- GlobalExecutor fallback is NOT the cause (would log warnings, would name threads "freenet-node")

## This Solution

Enhanced diagnostics to capture more detail when explosion occurs:

1. **Named main runtime threads** - Main runtime threads are now named `freenet-main` instead of default `tokio-runtime-w`. When a rogue runtime is created, its threads will still have the default name, making it easy to identify which threads belong to which runtime.

2. **Track individual thread TIDs** - Instead of just counting threads, we now track the specific TIDs. When new threads appear, we log exactly which TIDs were created.

3. **Increased monitoring frequency** - Reduced interval from 60s to 10s to catch the explosion closer to when it occurs.

4. **Batch detection** - Log whether new threads have consecutive TIDs (indicates batch creation from new runtime) vs scattered TIDs (indicates gradual spawning).

5. **Thread name logging** - Log the names of new threads to confirm if they're from a rogue runtime.

## Expected Output

When thread explosion occurs, logs will now show:
```
THREAD EXPLOSION - new runtime likely created
  current=33, baseline=16, new_thread_count=17
  new_tid_range="1952954-1952971"
  is_batch_creation=true
  thread_names={"tokio-runtime-w"}  // rogue runtime uses default name
```

This will help confirm if threads are from a rogue runtime (default name) vs our main runtime (freenet-main).

## Related

- Closes #2310 (tracking issue)
- Follow-up to #2309 (initial diagnostics)
- Related to #2315 (tracing overhead) and #2316 (futex contention) which may be symptoms

[AI-assisted - Claude]