### PR TITLE
refactor: simplify tracing filter setup

### DIFF
--- a/crates/core/src/tracing/mod.rs
+++ b/crates/core/src/tracing/mod.rs
@@ -1372,11 +1372,6 @@ pub(crate) mod tracer {
         };
         let default_filter = level.unwrap_or(default_filter);
 
-        // Check if RUST_LOG is explicitly set - if so, use EnvFilter for dynamic filtering.
-        // Otherwise use the much faster LevelFilter to avoid ~7% CPU overhead from
-        // EnvFilter::on_enter and EnvFilter::cares_about_span (see issue #2315).
-        let use_env_filter = std::env::var("RUST_LOG").is_ok();
-
         // use opentelemetry_sdk::propagation::TraceContextPropagator;
         use tracing_subscriber::layer::SubscriberExt;
 
@@ -1482,25 +1477,14 @@ pub(crate) mod tracer {
             }
         };
         // Build filter and set subscriber.
-        // When RUST_LOG is set, parse it for dynamic per-target filtering.
-        // When not set, skip env parsing but still apply stretto/sqlx directives.
         // The main optimization is compile-time filtering (release_max_level_info)
         // which eliminates TRACE/DEBUG spans entirely in release builds.
-        let filter_layer = if use_env_filter {
-            tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(default_filter.into())
-                .from_env_lossy()
-                .add_directive("stretto=off".parse().expect("infallible"))
-                .add_directive("sqlx=error".parse().expect("infallible"))
-        } else {
-            // No RUST_LOG set - use static directives only (avoids env parsing)
-            tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(default_filter.into())
-                .parse("")
-                .expect("empty filter is valid")
-                .add_directive("stretto=off".parse().expect("infallible"))
-                .add_directive("sqlx=error".parse().expect("infallible"))
-        };
+        // from_env_lossy() handles both cases: parses RUST_LOG if set, empty filter if not.
+        let filter_layer = tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(default_filter.into())
+            .from_env_lossy()
+            .add_directive("stretto=off".parse().expect("infallible"))
+            .add_directive("sqlx=error".parse().expect("infallible"));
         let subscriber = Registry::default().with(layers.with_filter(filter_layer));
         tracing::subscriber::set_global_default(subscriber).expect("Error setting subscriber");
         Ok(())


### PR DESCRIPTION
## Problem

PR #2317 added branching between `.from_env_lossy()` and `.parse("")` in the tracing setup, claiming this was a performance optimization. However, as @iduartgomez correctly pointed out, these two paths produce nearly identical filters - `from_env_lossy()` already handles the case when RUST_LOG is not set by returning an empty filter.

## This Solution

Remove the unnecessary branching. The real optimization in #2317 is the compile-time filtering via `release_max_level_info`, which eliminates TRACE/DEBUG spans entirely in release builds. The runtime filter selection was always marginal at best.

## Changes

- Remove `use_env_filter` variable and conditional
- Simplify to single `from_env_lossy()` call which handles both cases
- Update comments to reflect the actual optimization

[AI-assisted - Claude]