### PR TITLE
fix: reduce LEDBAT retransmission timeout log spam

### DIFF
--- a/crates/core/benches/transport_full.rs
+++ b/crates/core/benches/transport_full.rs
@@ -117,7 +117,6 @@ criterion_group!(
     targets =
         bench_large_transfer_validation,
         bench_1mb_transfer_validation,
-        bench_congestion_256kb,
 );
 
 criterion_group!(

--- a/crates/core/src/transport/ledbat.rs
+++ b/crates/core/src/transport/ledbat.rs
@@ -484,11 +484,14 @@ impl LedbatController {
         let current_cwnd = self.cwnd.load(Ordering::Acquire);
         self.cwnd.store(new_cwnd, Ordering::Release);
 
-        tracing::error!(
-            old_cwnd_kb = current_cwnd / 1024,
-            new_cwnd_kb = new_cwnd / 1024,
-            "LEDBAT retransmission timeout - reset to 1*MSS"
-        );
+        // Only log when cwnd actually changes to avoid spam when already at minimum
+        if current_cwnd != new_cwnd {
+            tracing::warn!(
+                old_cwnd_kb = current_cwnd / 1024,
+                new_cwnd_kb = new_cwnd / 1024,
+                "LEDBAT retransmission timeout - reset to 1*MSS"
+            );
+        }
     }
 
     /// Get current congestion window (bytes).


### PR DESCRIPTION
## Problem

1. **Log spam**: Running Freenet generates massive log spam with ERROR-level messages:
   ```
   ERROR freenet::transport::ledbat: LEDBAT retransmission timeout - reset to 1*MSS, old_cwnd_kb: 2, new_cwnd_kb: 2
   ```
   These flood the logs because they're logged at ERROR level (when this is normal congestion control behavior) and fire repeatedly even when cwnd is already at minimum.

2. **Compilation error**: `cargo clippy --all-targets --all-features` fails because `bench_congestion_256kb` is referenced but doesn't exist.

## This Solution

1. **LEDBAT logging fix**:
   - Change log level from `error!` to `warn!` - retransmission timeouts are expected LEDBAT behavior
   - Only log when cwnd actually changes - no point logging "2 -> 2"

2. **Bench fix**: Remove reference to non-existent `bench_congestion_256kb` from `transport_full.rs`

## Testing

- All 17 LEDBAT unit tests pass
- `cargo clippy --all-targets --all-features` passes

[AI-assisted - Claude]