### PR TITLE
chore: remove stale TODO comment from update.rs

### DIFF
--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1,4 +1,3 @@
-// TODO: complete update logic in the network
 use either::Either;
 use freenet_stdlib::client_api::{ErrorKind, HostResponse};
 use freenet_stdlib::prelude::*;


### PR DESCRIPTION
## Summary

Removes the stale TODO comment from `update.rs` line 1.

## Context

The TODO comment `// TODO: complete update logic in the network` was added when the update operation was initially implemented. The update logic has since been completed as part of the Update Propagation Architecture work tracked in #1848.

As noted in [this comment](https://github.com/freenet/freenet-core/issues/1848#issuecomment-3678757442), the update logic appears to be complete and this TODO should be removed.

## Changes

- Removed stale TODO comment from `crates/core/src/operations/update.rs`

## Test plan

- No functional changes, only comment removal
- Pre-commit hooks (fmt, clippy) pass

Closes #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)