### PR TITLE
build: release 0.1.56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.55"
+version = "0.1.56"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.55"
+version = "0.1.56"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -44,7 +44,7 @@ reqwest = { version = "0.12", features = ["json"] }
 http = "1.4"
 
 # internal
-freenet = { path = "../core", version = "0.1.55" }
+freenet = { path = "../core", version = "0.1.56" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Problem

CI is broken on main after merging PR #2362 (ContractKey.code non-optional).

The six-peer-regression test fails because:
- River depends on `freenet = "0.1.55"` (old API)
- River uses `freenet-stdlib = "0.1.28"` (new API)
- These are incompatible: freenet 0.1.55 expects `code_hash()` to return `Option<&CodeHash>`, but stdlib 0.1.28 returns `&CodeHash` directly

## Solution

Release freenet 0.1.56 which is compatible with freenet-stdlib 0.1.28.

After this is published to crates.io, update river to use freenet 0.1.56.

## Changes

- Bump version from 0.1.55 to 0.1.56 in:
  - `crates/core/Cargo.toml`
  - `crates/fdev/Cargo.toml`

[AI-assisted - Claude]