### PR TITLE
fix: ensure key_to_code_part indexed for all contract instances

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -199,6 +199,10 @@ impl ContractExecutor for Executor<Runtime> {
             // that reuse the same WASM code with different parameters (e.g., different
             // River rooms). Without this, lookup_key() fails for the new instance_id.
             // See issue #2380.
+            //
+            // We only index when code was provided in this request (code.is_some()).
+            // When code is None, this is a state-only update to an existing contract
+            // that should already be indexed.
             if code.is_some() {
                 self.runtime
                     .contract_store


### PR DESCRIPTION
## Problem

When creating multiple contracts that share the same WASM code but have different parameters (e.g., multiple River chat rooms), only the first room's contract works correctly. Subsequent rooms fail with Subscribe timeouts.

**User impact:** Creating a second River chat room times out after 60 seconds, even though the PUT operation succeeds. The room creator never gets subscribed.

**Why CI didn't catch this:** CI tests use a 6-peer mesh topology where contracts are stored on multiple nodes with fallback paths. In production with a single peer → gateway setup, if the gateway can't find the contract for Subscribe, there's no fallback.

## Root Cause

`ContractStore` indexes contracts by `ContractInstanceId → CodeHash` in a `key_to_code_part` DashMap. This mapping is essential for `lookup_key()` to reconstruct a `ContractKey` from just an instance ID.

The bug: When `fetch_contract()` finds the `code_hash` in the in-memory cache, it returns `Some(...)` immediately. This causes `upsert_contract_state()` to skip calling `store_contract()`, which means subsequent contract instances with the same code (but different parameters) never get their `instance_id` indexed.

**Bug sequence:**
1. First room: PUT stores WASM code, adds `instance_id_1 → code_hash` to index ✅
2. Second room: PUT calls `fetch_contract(&key)` → cache hit → returns `Some(...)` → `store_contract` skipped
3. Second room's `instance_id_2` is **never indexed**
4. Subscribe calls `lookup_key(instance_id_2)` → returns `None` → `has_contract` fails

## Solution

1. Add `ensure_key_indexed()` method to `ContractStore` that atomically ensures a `ContractInstanceId → CodeHash` mapping exists
2. Call it from `upsert_contract_state()` even when `fetch_contract()` succeeds (the `else` branch)
3. Also add indexing to `store_contract()`'s cache-hit early return path as defense-in-depth

## Testing

Tested on production infrastructure (nova gateway + technic peer):
- Created 5 River rooms in succession - all succeeded
- Verified log messages show "Indexed new contract instance (same code, different params)" for rooms 2-5
- Before fix: room 1 succeeds, rooms 2+ timeout after 60s
- After fix: all rooms succeed within seconds

## Fixes

Closes #2380

[AI-assisted - Claude]