### PR TITLE
fix: use user-specific cache directory for webapp cache

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -264,11 +264,18 @@ async fn get_web_body(path: &Path) -> Result<impl IntoResponse, WebSocketApiErro
     Ok(Html(body))
 }
 
-fn contract_web_path(instance_id: &ContractInstanceId) -> PathBuf {
-    std::env::temp_dir()
-        .join("freenet")
+/// Returns the base directory for webapp cache.
+/// Uses XDG cache directory (~/.cache/freenet on Linux) to avoid permission
+/// conflicts when multiple users run freenet on the same machine.
+fn webapp_cache_dir() -> PathBuf {
+    directories::ProjectDirs::from("", "The Freenet Project Inc", "freenet")
+        .map(|dirs| dirs.cache_dir().to_path_buf())
+        .unwrap_or_else(|| std::env::temp_dir().join("freenet"))
         .join("webapp_cache")
-        .join(instance_id.encode())
+}
+
+fn contract_web_path(instance_id: &ContractInstanceId) -> PathBuf {
+    webapp_cache_dir().join(instance_id.encode())
 }
 
 fn hash_state(state: &[u8]) -> u64 {
@@ -279,8 +286,5 @@ fn hash_state(state: &[u8]) -> u64 {
 }
 
 fn state_hash_path(instance_id: &ContractInstanceId) -> PathBuf {
-    std::env::temp_dir()
-        .join("freenet")
-        .join("webapp_cache")
-        .join(format!("{}.hash", instance_id.encode()))
+    webapp_cache_dir().join(format!("{}.hash", instance_id.encode()))
 }


### PR DESCRIPTION
## Problem

When multiple users run freenet on the same machine (e.g., a CI runner user and a regular user), the webapp cache directory at `/tmp/freenet/webapp_cache/` can be created by one user with permissions that prevent other users from writing to it.

**User-visible impact:** Users see "Failed to create cache dir: Permission denied (os error 13)" when trying to access the River UI or other web apps.

**Root cause:** The CI runner on technic created `/tmp/freenet/` owned by `runner:runner` with 755 permissions. When the regular user runs freenet, they cannot write to this directory.

## This Solution

Use the XDG cache directory (`~/.cache/freenet/webapp_cache` on Linux) instead of `/tmp/freenet/webapp_cache`. This provides per-user isolation and follows standard conventions for cache data.

The `directories` crate is already a dependency and used elsewhere in the codebase for similar purposes (in `config/mod.rs`). Falls back to temp_dir if ProjectDirs is unavailable.

## Testing

- Verified code compiles and passes clippy
- This is a straightforward path change with no behavior change beyond the directory location

[AI-assisted - Claude]