### PR TITLE
fix: write systemd service logs to files for headless systems

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -246,7 +246,8 @@ fn service_logs(error_only: bool) -> Result<()> {
     println!("Press Ctrl+C to stop.\n");
 
     let status = std::process::Command::new("tail")
-        .args(["-f", log_file.to_str().unwrap()])
+        .arg("-f")
+        .arg(&log_file)
         .status()
         .context("Failed to tail log file")?;
 
@@ -458,7 +459,8 @@ fn service_logs(error_only: bool) -> Result<()> {
     println!("Press Ctrl+C to stop.\n");
 
     let status = std::process::Command::new("tail")
-        .args(["-f", log_file.to_str().unwrap()])
+        .arg("-f")
+        .arg(&log_file)
         .status()
         .context("Failed to tail log file")?;
 


### PR DESCRIPTION
## Problem

On Linux systems running Freenet as a systemd user service (`freenet service install`), logs are not persisted on headless servers or systems without an active user journald session. This is because the current configuration uses `StandardOutput=journal` which relies on user journald, which doesn't persist logs when:
- The system is headless (no graphical session)
- `loginctl enable-linger` hasn't been run
- The user doesn't have an active session bus

This was reported by a user on Debian who couldn't find any logs after installing the service.

## Approach

The macOS implementation already writes logs to files (`~/Library/Logs/freenet/`). This PR applies the same approach to Linux:

1. **Create log directory**: `~/.local/state/freenet/` (XDG-compliant location for state/logs)
2. **Configure systemd service**: Use `StandardOutput=append:<path>` and `StandardError=append:<path>` instead of `journal`
3. **Add `freenet service logs` command**: Allows users to easily tail the logs with `freenet service logs` (or `freenet service logs --err` for error logs only)

## Changes

- `install_service()`: Creates log directory and passes it to service file generator
- `generate_service_file()`: Now accepts log_dir parameter and writes to log files
- New `service_logs()` function for all platforms (Linux/macOS use `tail -f`, Windows shows helpful message)
- Test updated to verify log paths in generated service file

## Testing

- All local checks pass (fmt, clippy, test)
- Unit test verifies correct log paths in generated systemd service file

[AI-assisted - Claude]