### PR TITLE
fix: only build freenet and fdev in musl cross-compile workflow

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -28,7 +28,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools musl-dev
 
       - name: Compile for x86_64-unknown-linux-musl
-        run: cargo build --release --target x86_64-unknown-linux-musl
+        # Only build freenet and fdev - cdylib crates (contracts) don't support musl
+        run: cargo build --release --target x86_64-unknown-linux-musl -p freenet -p fdev
 
       - name: Upload freenet binary
         uses: actions/upload-artifact@v6
@@ -64,7 +65,8 @@ jobs:
           sudo apt-get install -y musl-tools musl-dev
 
       - name: Compile for aarch64-unknown-linux-musl
-        run: cargo build --release --target aarch64-unknown-linux-musl
+        # Only build freenet and fdev - cdylib crates (contracts) don't support musl
+        run: cargo build --release --target aarch64-unknown-linux-musl -p freenet -p fdev
 
       - name: Upload freenet binary
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Problem

After PR #2398 merged, the "Build and Cross-Compile" CI workflow started failing on main with:

```
error: cannot produce cdylib for `freenet-ping-contract` as the target `x86_64-unknown-linux-musl` does not support these crate types
```

The musl build runs `cargo build --release --target x86_64-unknown-linux-musl` which attempts to compile the entire workspace. However, the workspace includes `apps/freenet-ping/contracts/ping` which is a WebAssembly contract configured as `crate-type = ["cdylib"]`. Musl targets don't support cdylib.

## This Solution

Explicitly specify `-p freenet -p fdev` to only build the release binaries we actually ship. The ping contract and other apps are not needed for the cross-compile release artifacts.

## Testing

- Verified the workflow syntax is correct
- The workflow only runs on main pushes and tags, so CI on this PR won't test it directly, but the fix is straightforward

[AI-assisted - Claude]