### PR TITLE
refactor: use bloom filter for Connect operation visited list

### DIFF
--- a/crates/core/src/operations/visited_peers.rs
+++ b/crates/core/src/operations/visited_peers.rs
@@ -166,6 +166,18 @@ impl VisitedPeers {
     }
 }
 
+/// Default implementation creates an empty bloom filter with zero hash keys.
+/// The bloom filter won't work correctly until hash keys are set via `with_transaction()`.
+/// This is useful for tests or when the bloom filter will be restored after deserialization.
+impl Default for VisitedPeers {
+    fn default() -> Self {
+        Self {
+            bits: [0u8; BLOOM_BYTES],
+            hash_keys: (0, 0),
+        }
+    }
+}
+
 /// Implement Contains trait for use with k_closest_potentially_caching.
 impl crate::util::Contains<SocketAddr> for VisitedPeers {
     fn has_element(&self, target: SocketAddr) -> bool {


### PR DESCRIPTION
## Problem

The Connect operation was using a `Vec<SocketAddr>` to track visited peers, while other routed operations (GET, SUBSCRIBE) use a bloom filter (`VisitedPeers`). This inconsistency causes:

1. **Growing message size**: The visited list grows linearly with hop count, while bloom filter is fixed at 64 bytes
2. **Privacy concerns**: The exact list of visited peers is visible, whereas bloom filter provides privacy through transaction-specific hashing
3. **Inconsistent codebase**: Different tracking mechanisms for similar operations

## Previous Approaches

PR #2422 was merged first, which refactored Connect forwarding into `forward_to_peer()`. This required rebasing and re-applying the bloom filter changes on top of the new code structure.

## This Solution

Replace `Vec<SocketAddr>` with `VisitedPeers` bloom filter in the Connect operation:

- **ConnectRequest.visited**: Changed from `Vec<SocketAddr>` to `VisitedPeers`
- **RelayState.handle_request**: Uses `mark_visited()` instead of `push_unique_addr()`
- **SkipListWithSelf**: Uses `probably_visited()` for candidate filtering
- **Hash key restoration**: Calls `with_transaction()` after deserialization in `new_relay()`
- **NAT reliability**: Marks upstream address first per issue comment about neighbor's observation being more reliable

Key insight: The bloom filter uses transaction-specific hash keys for privacy, so after deserialization the hash keys must be restored via `with_transaction()`. This is already done for GET/SUBSCRIBE operations.

## Testing

- Added 4 regression tests for bloom filter functionality:
  - `test_visited_peers_tracks_addresses` - basic bloom filter operations
  - `test_visited_peers_hash_key_restoration` - serialization/deserialization cycle
  - `test_initiate_join_request_uses_bloom_filter` - initial request setup
  - `test_skip_list_with_bloom_filter` - candidate filtering integration
- All 23 connect module tests pass
- CI six-peer-regression test passes
- Local fmt, clippy, test all pass

## Fixes

Closes #2421

[AI-assisted - Claude]