### PR TITLE
feat(cli): add `freenet service report` command for diagnostic uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1628,7 +1628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1868,6 +1868,7 @@ dependencies = [
  "futures 0.3.31",
  "headers",
  "hickory-resolver",
+ "hostname",
  "httptest",
  "itertools 0.14.0",
  "libc",
@@ -2468,6 +2469,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,7 +2667,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2929,7 +2941,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3488,7 +3500,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4295,7 +4307,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4332,9 +4344,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4738,7 +4750,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5642,7 +5654,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6921,7 +6933,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -45,6 +45,7 @@ futures = "0.3"
 semver = { version = "1",  features = ["serde"] }
 headers = "0.4"
 hickory-resolver = { version = "0.24", features = ["dns-over-rustls"] }
+hostname = "0.4"
 itertools = "0.14"
 notify = "8"
 pav_regression = "0.6.1"

--- a/crates/core/src/bin/commands/mod.rs
+++ b/crates/core/src/bin/commands/mod.rs
@@ -1,2 +1,3 @@
+pub mod report;
 pub mod service;
 pub mod update;

--- a/crates/core/src/bin/commands/report.rs
+++ b/crates/core/src/bin/commands/report.rs
@@ -1,0 +1,449 @@
+//! Diagnostic report generation and upload for debugging.
+//!
+//! Collects system info, logs, config, and optional problem description,
+//! then uploads to the Freenet report server for debugging.
+
+use anyhow::{Context, Result};
+use clap::Args;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+
+const DEFAULT_REPORT_SERVER: &str = "https://nova.locut.us/api/reports";
+
+#[derive(Args, Debug, Clone)]
+pub struct ReportCommand {
+    /// Save report locally instead of uploading
+    #[arg(long, value_name = "PATH")]
+    pub local: Option<PathBuf>,
+
+    /// Problem description (skips interactive prompt)
+    #[arg(long, short = 'm')]
+    pub message: Option<String>,
+
+    /// Skip problem description prompt
+    #[arg(long)]
+    pub no_message: bool,
+
+    /// Override upload server URL
+    #[arg(long, default_value = DEFAULT_REPORT_SERVER)]
+    pub server: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DiagnosticReport {
+    /// Client timestamp for clock skew detection
+    pub client_timestamp: String,
+    /// System information
+    pub system_info: SystemInfo,
+    /// Version and build info
+    pub version_info: VersionInfo,
+    /// Log file contents
+    pub logs: LogContents,
+    /// Config file contents (if available)
+    pub config: Option<String>,
+    /// Network status (if node is running)
+    pub network_status: Option<String>,
+    /// User's problem description
+    pub user_message: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SystemInfo {
+    pub os: String,
+    pub arch: String,
+    pub hostname: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct VersionInfo {
+    pub version: String,
+    pub git_commit: String,
+    pub git_dirty: bool,
+    pub build_timestamp: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LogContents {
+    pub main_log: Option<String>,
+    pub error_log: Option<String>,
+    pub main_log_size_bytes: u64,
+    pub error_log_size_bytes: u64,
+}
+
+#[derive(Deserialize, Debug)]
+struct UploadResponse {
+    code: String,
+}
+
+impl ReportCommand {
+    pub fn run(
+        &self,
+        version: &str,
+        git_commit: &str,
+        git_dirty: &str,
+        build_timestamp: &str,
+    ) -> Result<()> {
+        println!("Collecting diagnostic info...");
+
+        // Collect all diagnostic data
+        let report = self.collect_report(version, git_commit, git_dirty, build_timestamp)?;
+
+        // Print summary
+        self.print_summary(&report);
+
+        // Handle local save or upload
+        if let Some(ref path) = self.local {
+            self.save_local(&report, path)?;
+        } else {
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(self.upload_report(&report))?;
+        }
+
+        Ok(())
+    }
+
+    fn collect_report(
+        &self,
+        version: &str,
+        git_commit: &str,
+        git_dirty: &str,
+        build_timestamp: &str,
+    ) -> Result<DiagnosticReport> {
+        let system_info = SystemInfo {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            hostname: hostname::get()
+                .map(|h| h.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "unknown".to_string()),
+        };
+
+        let version_info = VersionInfo {
+            version: version.to_string(),
+            git_commit: git_commit.to_string(),
+            git_dirty: git_dirty == " (dirty)",
+            build_timestamp: build_timestamp.to_string(),
+        };
+
+        let logs = self.collect_logs()?;
+        let config = self.collect_config();
+        let network_status = self.collect_network_status();
+        let user_message = self.get_user_message()?;
+
+        let client_timestamp = chrono::Utc::now().to_rfc3339();
+
+        Ok(DiagnosticReport {
+            client_timestamp,
+            system_info,
+            version_info,
+            logs,
+            config,
+            network_status,
+            user_message,
+        })
+    }
+
+    fn collect_logs(&self) -> Result<LogContents> {
+        let log_dir = get_log_dir()?;
+
+        let main_log_path = log_dir.join("freenet.log");
+        let error_log_path = log_dir.join("freenet.error.log");
+
+        let (main_log, main_log_size) = read_log_file(&main_log_path);
+        let (error_log, error_log_size) = read_log_file(&error_log_path);
+
+        Ok(LogContents {
+            main_log,
+            error_log,
+            main_log_size_bytes: main_log_size,
+            error_log_size_bytes: error_log_size,
+        })
+    }
+
+    fn collect_config(&self) -> Option<String> {
+        // Try standard config locations
+        let config_paths = [
+            dirs::config_dir().map(|p| p.join("freenet").join("config.toml")),
+            dirs::home_dir().map(|p| p.join(".config").join("freenet").join("config.toml")),
+        ];
+
+        for path in config_paths.into_iter().flatten() {
+            if path.exists() {
+                if let Ok(content) = fs::read_to_string(&path) {
+                    return Some(content);
+                }
+            }
+        }
+
+        None
+    }
+
+    fn collect_network_status(&self) -> Option<String> {
+        // Try to query the local node's WebSocket API
+        // This is optional - if the node isn't running, we just skip this
+        // For now, we'll leave this as None and implement it when we have
+        // the WebSocket client available
+        // TODO: Query ws://127.0.0.1:50509 for node diagnostics
+        None
+    }
+
+    fn get_user_message(&self) -> Result<Option<String>> {
+        // Check for --message flag
+        if let Some(ref msg) = self.message {
+            return Ok(Some(msg.clone()));
+        }
+
+        // Check for --no-message flag
+        if self.no_message {
+            return Ok(None);
+        }
+
+        // Interactive prompt
+        println!();
+        println!("What issue are you experiencing? (blank line to finish, Enter twice to skip)");
+        print!("> ");
+        io::stdout().flush()?;
+
+        let stdin = io::stdin();
+        let mut lines = Vec::new();
+        let mut last_was_empty = false;
+
+        for line in stdin.lock().lines() {
+            let line = line.context("Failed to read input")?;
+
+            if line.is_empty() {
+                if last_was_empty || lines.is_empty() {
+                    // Two consecutive empty lines or empty first line = skip
+                    break;
+                }
+                last_was_empty = true;
+                lines.push(line);
+            } else {
+                last_was_empty = false;
+                lines.push(line);
+                print!("> ");
+                io::stdout().flush()?;
+            }
+        }
+
+        // Remove trailing empty lines
+        while lines.last().map(|s| s.is_empty()).unwrap_or(false) {
+            lines.pop();
+        }
+
+        if lines.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(lines.join("\n")))
+        }
+    }
+
+    fn print_summary(&self, report: &DiagnosticReport) {
+        println!(
+            "  - Version: {} ({}{})",
+            report.version_info.version,
+            report.version_info.git_commit,
+            if report.version_info.git_dirty {
+                " dirty"
+            } else {
+                ""
+            }
+        );
+        println!(
+            "  - OS: {} {}",
+            report.system_info.os, report.system_info.arch
+        );
+
+        let total_log_size = report.logs.main_log_size_bytes + report.logs.error_log_size_bytes;
+        println!("  - Logs: {}", format_bytes(total_log_size));
+
+        println!(
+            "  - Config: {}",
+            if report.config.is_some() {
+                "found"
+            } else {
+                "not found"
+            }
+        );
+        println!(
+            "  - Node status: {}",
+            if report.network_status.is_some() {
+                "running"
+            } else {
+                "not running or unreachable"
+            }
+        );
+    }
+
+    fn save_local(&self, report: &DiagnosticReport, path: &PathBuf) -> Result<()> {
+        let json = serde_json::to_string_pretty(report)?;
+        fs::write(path, &json).context("Failed to write report to file")?;
+        println!();
+        println!("Report saved to: {}", path.display());
+        Ok(())
+    }
+
+    async fn upload_report(&self, report: &DiagnosticReport) -> Result<()> {
+        println!();
+        print!("Uploading report...");
+        io::stdout().flush()?;
+
+        // Serialize to JSON
+        let json = serde_json::to_vec(report)?;
+
+        // Gzip compress
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&json)?;
+        let compressed = encoder.finish()?;
+
+        // Upload
+        let client = reqwest::Client::builder()
+            .user_agent("freenet-report")
+            .build()?;
+
+        let response = client
+            .post(&self.server)
+            .header("Content-Type", "application/json")
+            .header("Content-Encoding", "gzip")
+            .body(compressed)
+            .send()
+            .await
+            .context("Failed to upload report")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Upload failed: {} - {}", status, body);
+        }
+
+        let upload_response: UploadResponse = response
+            .json()
+            .await
+            .context("Failed to parse upload response")?;
+
+        println!(" done");
+        println!();
+        println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        println!("  Report code: {}", upload_response.code);
+        println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        println!();
+        println!("Share this code with the Freenet team on Matrix.");
+
+        Ok(())
+    }
+}
+
+fn get_log_dir() -> Result<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        Ok(dirs::home_dir()
+            .context("Failed to get home directory")?
+            .join(".local/state/freenet"))
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Ok(dirs::home_dir()
+            .context("Failed to get home directory")?
+            .join("Library/Logs/freenet"))
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        Ok(dirs::data_local_dir()
+            .context("Failed to get local app data directory")?
+            .join("freenet")
+            .join("logs"))
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        anyhow::bail!("Unsupported platform for log collection")
+    }
+}
+
+fn read_log_file(path: &PathBuf) -> (Option<String>, u64) {
+    match fs::metadata(path) {
+        Ok(metadata) => {
+            let size = metadata.len();
+            match fs::read_to_string(path) {
+                Ok(content) => (Some(content), size),
+                Err(_) => (None, size),
+            }
+        }
+        Err(_) => (None, 0),
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+
+    if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} bytes", bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(0), "0 bytes");
+        assert_eq!(format_bytes(500), "500 bytes");
+        assert_eq!(format_bytes(1024), "1.0 KB");
+        assert_eq!(format_bytes(1536), "1.5 KB");
+        assert_eq!(format_bytes(1048576), "1.0 MB");
+        assert_eq!(format_bytes(1572864), "1.5 MB");
+    }
+
+    #[test]
+    fn test_system_info() {
+        let info = SystemInfo {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            hostname: "test".to_string(),
+        };
+        assert!(!info.os.is_empty());
+        assert!(!info.arch.is_empty());
+    }
+
+    #[test]
+    fn test_report_serialization() {
+        let report = DiagnosticReport {
+            client_timestamp: "2025-01-01T00:00:00Z".to_string(),
+            system_info: SystemInfo {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                hostname: "test".to_string(),
+            },
+            version_info: VersionInfo {
+                version: "0.1.0".to_string(),
+                git_commit: "abc123".to_string(),
+                git_dirty: false,
+                build_timestamp: "2025-01-01".to_string(),
+            },
+            logs: LogContents {
+                main_log: Some("test log".to_string()),
+                error_log: None,
+                main_log_size_bytes: 8,
+                error_log_size_bytes: 0,
+            },
+            config: None,
+            network_status: None,
+            user_message: Some("Test message".to_string()),
+        };
+
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("linux"));
+        assert!(json.contains("test log"));
+    }
+}

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -8,6 +8,8 @@ use anyhow::{Context, Result};
 use clap::Subcommand;
 use std::path::Path;
 
+use super::report::ReportCommand;
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum ServiceCommand {
     /// Install Freenet as a system service
@@ -28,10 +30,18 @@ pub enum ServiceCommand {
         #[arg(long)]
         err: bool,
     },
+    /// Generate and upload a diagnostic report for debugging
+    Report(ReportCommand),
 }
 
 impl ServiceCommand {
-    pub fn run(&self) -> Result<()> {
+    pub fn run(
+        &self,
+        version: &str,
+        git_commit: &str,
+        git_dirty: &str,
+        build_timestamp: &str,
+    ) -> Result<()> {
         match self {
             ServiceCommand::Install => install_service(),
             ServiceCommand::Uninstall => uninstall_service(),
@@ -40,6 +50,7 @@ impl ServiceCommand {
             ServiceCommand::Stop => stop_service(),
             ServiceCommand::Restart => restart_service(),
             ServiceCommand::Logs { err } => service_logs(*err),
+            ServiceCommand::Report(cmd) => cmd.run(version, git_commit, git_dirty, build_timestamp),
         }
     }
 }

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -149,7 +149,12 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Command::Service(cmd)) => cmd.run(),
+        Some(Command::Service(cmd)) => cmd.run(
+            build_info::VERSION,
+            build_info::GIT_COMMIT,
+            build_info::GIT_DIRTY,
+            build_info::BUILD_TIMESTAMP,
+        ),
         Some(Command::Update(cmd)) => cmd.run(build_info::VERSION),
         Some(Command::Network { mut config }) => {
             config.mode = Some(OperationMode::Network);


### PR DESCRIPTION
## Problem

During alpha testing, debugging user issues is cumbersome. Users need to manually locate log files, copy/paste config files, and describe their system setup. This creates friction and often results in incomplete diagnostic information being shared on Matrix.

## Solution

Add a new `freenet service report` subcommand that:

1. **Collects diagnostic information automatically:**
   - System info (OS, architecture, hostname)
   - Version info (version, git commit, build timestamp)
   - Log files (freenet.log, freenet.error.log)
   - Config file contents
   - Client timestamp (for clock skew detection)

2. **Allows users to describe their issue:**
   - Multi-line interactive prompt by default
   - Skip with `--no-message` or provide inline with `--message`

3. **Uploads to Freenet report server** (or save locally with `--local`)
   - Gzip-compressed for efficiency
   - Returns a short code (e.g., `X7K2M9`) for easy Matrix sharing

### User Experience

```
$ freenet service report
Collecting diagnostic info...
  - Version: 0.1.62 (9b119011)
  - OS: linux x86_64
  - Logs: 1.2 MB
  - Config: found
  - Node status: not running or unreachable

What issue are you experiencing? (blank line to finish, Enter twice to skip)
> My node keeps disconnecting
>

Uploading report... done

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Report code: X7K2M9
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Share this code with the Freenet team on Matrix.
```

## Testing

- Added unit tests for formatting, serialization, and system info collection
- Manual testing with `--local` flag to verify report generation
- All existing tests pass

## Note

This PR adds the CLI command only. The server-side API (freenet-report-server) will be deployed separately to nova.locut.us. Until then, users can use `--local` to save reports locally.

[AI-assisted - Claude]