### PR TITLE
fix: use UpsertResult to determine PUT-to-UPDATE propagation

### DIFF
--- a/crates/core/src/contract/mod.rs
+++ b/crates/core/src/contract/mod.rs
@@ -189,9 +189,11 @@ where
                 let event_result = match put_result {
                     Ok(UpsertResult::NoChange) => ContractHandlerEvent::PutResponse {
                         new_value: Ok(state),
+                        state_changed: false,
                     },
                     Ok(UpsertResult::Updated(state)) => ContractHandlerEvent::PutResponse {
                         new_value: Ok(state),
+                        state_changed: true,
                     },
                     Err(err) => {
                         if err.is_fatal() {
@@ -205,6 +207,7 @@ where
                         }
                         ContractHandlerEvent::PutResponse {
                             new_value: Err(err),
+                            state_changed: false,
                         }
                     }
                 };

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -1226,6 +1226,7 @@ impl Operation for GetOp {
                                                 match put_result {
                                                     Ok(ContractHandlerEvent::PutResponse {
                                                         new_value: Ok(_),
+                                                        ..
                                                     }) => {
                                                         tracing::debug!(tx = %id, %key, "Re-seeded contract to network");
                                                         super::announce_contract_cached(
@@ -1334,6 +1335,7 @@ impl Operation for GetOp {
                                                 match put_result {
                                                     Ok(ContractHandlerEvent::PutResponse {
                                                         new_value: Ok(_),
+                                                        ..
                                                     }) => {
                                                         tracing::debug!(tx = %id, %key, "Re-seeded contract to network");
                                                         super::announce_contract_cached(
@@ -1538,7 +1540,7 @@ impl Operation for GetOp {
                                     .await?;
 
                                 match res {
-                                    ContractHandlerEvent::PutResponse { new_value: Ok(_) } => {
+                                    ContractHandlerEvent::PutResponse { new_value: Ok(_), .. } => {
                                         tracing::debug!(tx = %id, %key, "Contract put at executor");
                                         let is_subscribed_contract =
                                             op_manager.ring.is_seeding_contract(&key);
@@ -1556,6 +1558,7 @@ impl Operation for GetOp {
                                     }
                                     ContractHandlerEvent::PutResponse {
                                         new_value: Err(err),
+                                        ..
                                     } => {
                                         // Local caching failed, but GET operation succeeded
                                         // Log warning and continue - caching is an optimization, not required


### PR DESCRIPTION
## Problem

When Samuel's peer subscribed to River UI and a newer version was PUT on the network, his peer never received the updated state. Investigation revealed that **PUT operations were not triggering UPDATE propagation to subscribers** even when the stored state changed.

The root cause was in `crates/core/src/operations/put.rs:269-270`:

```rust
let state_changed = merged_value.as_ref() != value.as_ref();
if was_seeding && state_changed {
    start_update_after_put(op_manager, id, key, merged_value.clone()).await;
}
```

This comparison fails when the contract's `summarize` function accepts the incoming state as-is (e.g., River UI's "newer version wins" logic). In this case, `merged_value == input_value` even though **the actual stored state changed** from old to new.

### Why CI didn't catch this

The existing tests used contracts that merge states rather than replace them, so the comparison logic happened to work. This bug only manifests with contracts that have "latest wins" semantics.

## Approach

Instead of comparing input vs output values, we use the `UpsertResult` from the contract executor:
- `UpsertResult::Updated(state)` → state changed, trigger UPDATE
- `UpsertResult::NoChange` → state unchanged, no UPDATE needed

This is semantically correct because the executor already knows whether the stored state changed.

### Changes

1. **`handler.rs`**: Add `state_changed: bool` field to `PutResponse`
2. **`mod.rs`**: Set `state_changed` based on `UpsertResult` variant
3. **`put.rs`**: Use `state_changed` from response instead of value comparison
4. **`get.rs`**: Update `PutResponse` patterns to ignore new field (GET doesn't need it)

## Testing

- Added regression test `test_put_triggers_update_for_subscribers` that:
  1. Peer-A PUTs contract with version 1
  2. Gateway subscribes to the contract
  3. Peer-A PUTs updated version 2
  4. Verifies Gateway receives the update via subscription

- All existing tests pass
- Ran `cargo fmt`, `cargo clippy`, `cargo test`

[AI-assisted - Claude]