### PR TITLE
fix(cli): handle rotated log files in `freenet service logs`

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -10,6 +10,50 @@ use std::path::Path;
 
 use super::report::ReportCommand;
 
+/// Find the latest log file in the given directory.
+/// Handles both static files (e.g., "freenet.log" from systemd) and
+/// rotated files (e.g., "freenet.2025-12-27.log" from tracing-appender).
+fn find_latest_log_file(log_dir: &Path, base_name: &str) -> Option<std::path::PathBuf> {
+    use std::fs;
+
+    // First, check for the static file (used by systemd StandardOutput)
+    let static_file = log_dir.join(format!("{base_name}.log"));
+    if static_file.exists() {
+        // Check if the file has content or was recently modified
+        if let Ok(metadata) = fs::metadata(&static_file) {
+            if metadata.len() > 0 {
+                return Some(static_file);
+            }
+        }
+    }
+
+    // Look for rotated files (pattern: {base_name}.YYYY-MM-DD.log)
+    let Ok(entries) = fs::read_dir(log_dir) else {
+        return None;
+    };
+
+    let mut log_files: Vec<_> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name();
+            let name_str = name.to_string_lossy();
+            // Match pattern: {base_name}.YYYY-MM-DD.log
+            name_str.starts_with(&format!("{base_name}."))
+                && name_str.ends_with(".log")
+                && name_str.len() > format!("{base_name}..log").len()
+        })
+        .collect();
+
+    // Sort by modification time (most recent first)
+    log_files.sort_by(|a, b| {
+        let time_a = a.metadata().and_then(|m| m.modified()).ok();
+        let time_b = b.metadata().and_then(|m| m.modified()).ok();
+        time_b.cmp(&time_a)
+    });
+
+    log_files.first().map(|e| e.path())
+}
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum ServiceCommand {
     /// Install Freenet as a system service
@@ -240,18 +284,18 @@ fn service_logs(error_only: bool) -> Result<()> {
         .context("Failed to get home directory")?
         .join(".local/state/freenet");
 
-    let log_file = if error_only {
-        log_dir.join("freenet.error.log")
+    let base_name = if error_only {
+        "freenet.error"
     } else {
-        log_dir.join("freenet.log")
+        "freenet"
     };
 
-    if !log_file.exists() {
-        anyhow::bail!(
-            "Log file not found: {}\nMake sure the service has been installed and started.",
-            log_file.display()
-        );
-    }
+    let log_file = find_latest_log_file(&log_dir, base_name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "No log files found in: {}\nMake sure the service has been installed and started.",
+            log_dir.display()
+        )
+    })?;
 
     println!("Following logs from: {}", log_file.display());
     println!("Press Ctrl+C to stop.\n");
@@ -453,18 +497,18 @@ fn service_logs(error_only: bool) -> Result<()> {
         .context("Failed to get home directory")?
         .join("Library/Logs/freenet");
 
-    let log_file = if error_only {
-        log_dir.join("freenet.error.log")
+    let base_name = if error_only {
+        "freenet.error"
     } else {
-        log_dir.join("freenet.log")
+        "freenet"
     };
 
-    if !log_file.exists() {
-        anyhow::bail!(
-            "Log file not found: {}\nMake sure the service has been installed and started.",
-            log_file.display()
-        );
-    }
+    let log_file = find_latest_log_file(&log_dir, base_name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "No log files found in: {}\nMake sure the service has been installed and started.",
+            log_dir.display()
+        )
+    })?;
 
     println!("Following logs from: {}", log_file.display());
     println!("Press Ctrl+C to stop.\n");


### PR DESCRIPTION
## Problem

The `freenet service logs` command fails with "Log file not found" when users try to view logs, even though logs are being written correctly.

**Root cause:** After PR #2435 introduced log rotation via `tracing-appender::RollingFileAppender`, log files are created with date stamps (e.g., `freenet.2025-12-27.log`). However, `freenet service logs` was still looking for a static `freenet.log` file that doesn't exist in this setup.

There are actually two logging paths:
1. **systemd service** - writes to `freenet.log` via `StandardOutput=append:`
2. **Direct execution with file logging** - writes to date-stamped rotated files

The `service logs` command needed to handle both cases.

## Solution

Add a `find_latest_log_file()` helper that checks for:
1. Static file first (`freenet.log`) - non-empty files from systemd
2. Latest rotated file by modification time (`freenet.YYYY-MM-DD.log`)

This ensures the command works whether Freenet is run as a systemd service or directly with `FREENET_LOG_TO_FILE=1`.

## Testing

Verified locally that `freenet service logs` now correctly finds and tails the latest rotated log file:
```
$ freenet service logs
Following logs from: /home/ian/.local/state/freenet/freenet.2025-12-28.log
Press Ctrl+C to stop.
```

[AI-assisted - Claude]