### PR TITLE
fix: use musl target triple for Linux in update command

### DIFF
--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -257,13 +257,16 @@ fn verify_checksum(file_path: &Path, expected_hash: &str) -> Result<()> {
 }
 
 fn get_target_triple() -> &'static str {
+    // Note: We always request musl binaries for Linux because that's what
+    // the release workflow builds. musl binaries work on both musl (Alpine)
+    // and glibc systems, so this is the simplest approach.
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     {
-        "x86_64-unknown-linux-gnu"
+        "x86_64-unknown-linux-musl"
     }
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        "aarch64-unknown-linux-gnu"
+        "aarch64-unknown-linux-musl"
     }
     #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
     {


### PR DESCRIPTION
## Problem

Running `freenet update` on Linux fails with:
```
Error: No binary available for your platform (x86_64-unknown-linux-gnu). 
Available assets: fdev-aarch64-apple-darwin.tar.gz, fdev-aarch64-unknown-linux-musl.tar.gz, 
fdev-x86_64-pc-windows-msvc.zip, fdev-x86_64-unknown-linux-musl.tar.gz, ...
```

The update command requests `x86_64-unknown-linux-gnu` binaries, but releases only provide `musl` binaries.

## Root Cause

Mismatch between:
- `install.sh` correctly requests musl: `${arch}-unknown-linux-musl`
- `update.rs` hardcodes gnu: `"x86_64-unknown-linux-gnu"`

## This Solution

Change `get_target_triple()` in `update.rs` to request musl binaries for Linux, matching `install.sh` behavior. musl binaries work on both musl (Alpine) and glibc systems.

## Testing

- Verified code compiles with `cargo check`
- Verified the asset names match release assets

[AI-assisted - Claude]