### PR TITLE
fix(ci): ad-hoc sign macOS binaries and set deployment target

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -96,7 +96,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Compile for aarch64-apple-darwin
+        env:
+          # Support macOS 11 (Big Sur) and later for broader compatibility
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
         run: cargo build --release
+
+      - name: Ad-hoc sign binaries
+        run: |
+          # Ad-hoc sign binaries so they can run without Gatekeeper blocking
+          codesign -s - --force target/release/freenet
+          codesign -s - --force target/release/fdev
+          # Verify signatures
+          codesign -v target/release/freenet
+          codesign -v target/release/fdev
 
       - name: Upload freenet binary
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Problem

macOS binaries were crashing with "Abort trap: 6" immediately on user machines when running `freenet --version` after install via `curl -fsSL https://freenet.org/install.sh | sh`.

User report:
```
sh: line 221:  5484 Abort trap: 6           "$install_dir/freenet" --version > /dev/null 2>&1
error: Installed binary verification failed. The binary may be corrupted or incompatible with your system.
```

## Root Cause

Two issues with macOS binary distribution:

1. **No code signature** - Gatekeeper blocks or kills unsigned binaries downloaded from the internet
2. **No deployment target** - Binary built on macOS 15 (Sequoia) may use APIs unavailable on older macOS versions

## Solution

- Add ad-hoc signing with `codesign -s -` - creates a local signature without needing an Apple Developer certificate ($99/year). This satisfies Gatekeeper's basic requirement.
- Set `MACOSX_DEPLOYMENT_TARGET=11.0` to ensure compatibility with macOS Big Sur and later.

## Testing

The next release after this merges should produce signed binaries that work on macOS 11+.

[AI-assisted - Claude]