### PR TITLE
ci: pin Rust to 1.91.0 to avoid rustc 1.92.0 ICE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
       # RUST_LOG controls tracing output level (used by both test-log and production code)
       RUST_LOG: error
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # Increase rustc stack size to prevent SIGSEGV during compilation
+      RUST_MIN_STACK: 16777216
 
     steps:
       - uses: actions/checkout@v6
@@ -158,6 +160,10 @@ jobs:
       # Ensure lzma-sys can find liblzma on Arch Linux (self-hosted runner)
       LIBRARY_PATH: /usr/lib
       PKG_CONFIG_PATH: /usr/lib/pkgconfig
+      # Increase rustc stack size to prevent SIGSEGV during compilation
+      # The river workspace builds many crates fresh (no cache), which can
+      # exhaust default stack space during parallel compilation
+      RUST_MIN_STACK: 16777216
 
     steps:
       - uses: actions/checkout@v6
@@ -223,6 +229,8 @@ jobs:
       RUST_LOG: error
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       UBERTEST_PEER_COUNT: 6  # Fewer peers for faster CI
+      # Increase rustc stack size to prevent SIGSEGV during compilation
+      RUST_MIN_STACK: 16777216
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

CI is failing due to two related rustc issues:

### Issue 1: rustc 1.92.0 ICE (monomorphization)

rustc 1.92.0 (released Dec 2025) has a transient Internal Compiler Error (ICE) in monomorphization/LLVM that causes CI failures:

```
error: rustc interrupted by SIGSEGV, printing backtrace
/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/libLLVM.so.21.1-rust-1.92.0-stable
```

Related issue: https://github.com/rust-lang/rust/issues/147164

### Issue 2: Stack exhaustion on self-hosted runner

Even after pinning to Rust 1.91.0, the six-peer-regression job was failing with SIGSEGV due to stack exhaustion during parallel compilation. The river workspace builds many crates fresh (without cache), which can exceed default stack limits:

```
help: you can increase rustc's stack size by setting RUST_MIN_STACK=16777216
```

## Solution

1. **Pin CI to Rust 1.91.0** - Avoids the 1.92.0 ICE in monomorphization
2. **Set RUST_MIN_STACK=16777216** - Provides 16MB stack for rustc to handle large parallel builds

Both fixes are applied to all self-hosted jobs: `test_all`, `six_peer_regression`, and `ubertest`.

## Future

Once rustc 1.93.0+ is released with fixes for these issues, we can unpin and return to `stable`.

[AI-assisted - Claude]