### PR TITLE
feat: add telemetry for subscription trees and contract seeding

### DIFF
--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -15,7 +15,10 @@ use either::Either;
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use parking_lot::RwLock;
 
-pub use seeding::{PruneSubscriptionsResult, RemoveSubscriberResult, SubscriptionError};
+pub use seeding::{
+    AddClientSubscriptionResult, AddDownstreamResult, PruneSubscriptionsResult,
+    RemoveSubscriberResult, SubscriberType, SubscriptionError,
+};
 
 use crate::message::TransactionType;
 use crate::topology::rate::Rate;
@@ -367,12 +370,14 @@ impl Ring {
     /// The `observed_addr` parameter is the transport-level address from which the subscribe
     /// message was received. This is used instead of the address embedded in `subscriber`
     /// because NAT peers may embed incorrect (e.g., loopback) addresses in their messages.
+    ///
+    /// Returns information about the operation for telemetry.
     pub fn add_downstream(
         &self,
         contract: &ContractKey,
         subscriber: PeerKeyLocation,
         observed_addr: Option<ObservedAddr>,
-    ) -> Result<(), SubscriptionError> {
+    ) -> Result<AddDownstreamResult, SubscriptionError> {
         self.seeding_manager
             .add_downstream(contract, subscriber, observed_addr)
     }
@@ -405,11 +410,13 @@ impl Ring {
     // ==================== Client Subscription Management ====================
 
     /// Register a client subscription for a contract (WebSocket client subscribed).
+    ///
+    /// Returns information about the operation for telemetry.
     pub fn add_client_subscription(
         &self,
         instance_id: &ContractInstanceId,
         client_id: crate::client_events::ClientId,
-    ) {
+    ) -> AddClientSubscriptionResult {
         self.seeding_manager
             .add_client_subscription(instance_id, client_id)
     }

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -403,7 +403,21 @@ fn event_kind_to_string(kind: &EventKind) -> String {
                 GetEvent::GetFailure { .. } => "get_failure".to_string(),
             }
         }
-        EventKind::Subscribe(_) => "subscribe".to_string(),
+        EventKind::Subscribe(subscribe_event) => {
+            use super::SubscribeEvent;
+            match subscribe_event {
+                SubscribeEvent::Request { .. } => "subscribe_request".to_string(),
+                SubscribeEvent::SubscribeSuccess { .. } => "subscribe_success".to_string(),
+                SubscribeEvent::SubscribeNotFound { .. } => "subscribe_not_found".to_string(),
+                SubscribeEvent::SeedingStarted { .. } => "seeding_started".to_string(),
+                SubscribeEvent::SeedingStopped { .. } => "seeding_stopped".to_string(),
+                SubscribeEvent::DownstreamAdded { .. } => "downstream_added".to_string(),
+                SubscribeEvent::DownstreamRemoved { .. } => "downstream_removed".to_string(),
+                SubscribeEvent::UpstreamSet { .. } => "upstream_set".to_string(),
+                SubscribeEvent::Unsubscribed { .. } => "unsubscribed".to_string(),
+                SubscribeEvent::SubscriptionState { .. } => "subscription_state".to_string(),
+            }
+        }
         EventKind::Update(update_event) => {
             use super::UpdateEvent;
             match update_event {
@@ -795,6 +809,102 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         "target": target.to_string(),
                         "hop_count": hop_count,
                         "elapsed_ms": elapsed_ms,
+                        "timestamp": timestamp,
+                    })
+                }
+                SubscribeEvent::SeedingStarted {
+                    instance_id,
+                    timestamp,
+                } => {
+                    serde_json::json!({
+                        "type": "seeding_started",
+                        "instance_id": instance_id.to_string(),
+                        "timestamp": timestamp,
+                    })
+                }
+                SubscribeEvent::SeedingStopped {
+                    instance_id,
+                    reason,
+                    timestamp,
+                } => {
+                    serde_json::json!({
+                        "type": "seeding_stopped",
+                        "instance_id": instance_id.to_string(),
+                        "reason": format!("{:?}", reason),
+                        "timestamp": timestamp,
+                    })
+                }
+                SubscribeEvent::DownstreamAdded {
+                    key,
+                    subscriber,
+                    downstream_count,
+                    timestamp,
+                } => {
+                    serde_json::json!({
+                        "type": "downstream_added",
+                        "key": key.to_string(),
+                        "subscriber": subscriber.to_string(),
+                        "downstream_count": downstream_count,
+                        "timestamp": timestamp,
+                    })
+                }
+                SubscribeEvent::DownstreamRemoved {
+                    key,
+                    subscriber,
+                    reason,
+                    downstream_count,
+                    timestamp,
+                } => {
+                    serde_json::json!({
+                        "type": "downstream_removed",
+                        "key": key.to_string(),
+                        "subscriber": subscriber.as_ref().map(|s| s.to_string()),
+                        "reason": format!("{:?}", reason),
+                        "downstream_count": downstream_count,
+                        "timestamp": timestamp,
+                    })
+                }
+                SubscribeEvent::UpstreamSet {
+                    key,
+                    upstream,
+                    timestamp,
+                } => {
+                    serde_json::json!({
+                        "type": "upstream_set",
+                        "key": key.to_string(),
+                        "upstream": upstream.to_string(),
+                        "timestamp": timestamp,
+                    })
+                }
+                SubscribeEvent::Unsubscribed {
+                    key,
+                    reason,
+                    upstream,
+                    timestamp,
+                } => {
+                    serde_json::json!({
+                        "type": "unsubscribed",
+                        "key": key.to_string(),
+                        "reason": format!("{:?}", reason),
+                        "upstream": upstream.as_ref().map(|u| u.to_string()),
+                        "timestamp": timestamp,
+                    })
+                }
+                SubscribeEvent::SubscriptionState {
+                    key,
+                    is_seeding,
+                    upstream,
+                    downstream_count,
+                    downstream,
+                    timestamp,
+                } => {
+                    serde_json::json!({
+                        "type": "subscription_state",
+                        "key": key.to_string(),
+                        "is_seeding": is_seeding,
+                        "upstream": upstream.as_ref().map(|u| u.to_string()),
+                        "downstream_count": downstream_count,
+                        "downstream": downstream.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
                         "timestamp": timestamp,
                     })
                 }


### PR DESCRIPTION
## Problem

When debugging subscription tree issues (like the branch pruning problem in #2464), we lack visibility into:
- When peers start/stop seeding contracts locally
- When downstream subscribers are added/removed
- When upstream relationships are established
- The overall structure of the subscription tree

This makes it difficult to debug update propagation and subscription tree pruning issues.

## This Solution

Add new telemetry events to the `SubscribeEvent` enum that track subscription tree structure changes:

### New Events
- **`seeding_started`** - When the first local client subscribes to a contract
- **`seeding_stopped`** - When the last local client unsubscribes (helper available)
- **`downstream_added`** - When a peer subscribes through us
- **`downstream_removed`** - When a downstream subscriber is removed
- **`upstream_set`** - When we subscribe through another peer
- **`unsubscribed`** - When we unsubscribe from upstream (helper available)
- **`subscription_state`** - Snapshot of subscription state (helper available)

### Implementation Approach
1. Added new event variants to `SubscribeEvent` enum in `tracing/mod.rs`
2. Added JSON serialization for events in `telemetry.rs`
3. Modified `SeedingManager` methods to return enriched results with telemetry-relevant data:
   - `add_downstream` now returns `AddDownstreamResult` with `is_new`, `downstream_count`, and `subscriber`
   - `add_client_subscription` now returns `AddClientSubscriptionResult` with `is_first_client`
   - `remove_subscriber` now returns enriched `RemoveSubscriberResult` with `removed`, `removed_role`, and `downstream_count`
4. Added telemetry emission at call sites in `operations/subscribe.rs`, `client_events/mod.rs`, and `node/mod.rs`

### Currently Wired Up
- `seeding_started` - emitted when first client subscribes to a contract
- `downstream_added` - emitted when registering a new downstream subscriber
- `upstream_set` - emitted when setting upstream source for a contract
- `downstream_removed` - emitted when a downstream subscriber unsubscribes

### Remaining Work
Helper methods for `seeding_stopped`, `unsubscribed`, and `subscription_state` are available but not yet wired to call sites. These require additional changes to the seeding manager to track which contracts had their last client unsubscribe, and can be added in a follow-up PR.

## Testing
- All 838 unit tests pass
- Clippy passes with no warnings

Closes #2486

[AI-assisted - Claude]