### PR TITLE
build: release 0.1.70

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.46"
+version = "0.3.47"
 dependencies = [
  "anyhow",
  "axum",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.69"
+version = "0.1.70"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.46"
+version = "0.3.47"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -44,7 +44,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 http = "1.4"
 
 # internal
-freenet = { path = "../core", version = "0.1.69" }
+freenet = { path = "../core", version = "0.1.70" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
Release v0.1.70

Includes:
- feat(networking): implement exponential backoff for peer connection attempts (#2485)
- feat: add telemetry for subscription trees and contract seeding (#2487)

[AI-assisted - Claude]