### PR TITLE
fix: address issues with in-memory simulation infrastructure

### DIFF
--- a/crates/core/src/node/network_bridge/in_memory.rs
+++ b/crates/core/src/node/network_bridge/in_memory.rs
@@ -68,7 +68,8 @@ pub(in crate::node) struct MemoryConnManager {
     transport: InMemoryTransport,
     log_register: Arc<dyn NetEventRegister>,
     op_manager: Arc<OpManager>,
-    msg_queue: Arc<Mutex<Vec<NetMessage>>>,
+    /// Queue of received messages with their source addresses
+    msg_queue: Arc<Mutex<Vec<(NetMessage, SocketAddr)>>>,
 }
 
 impl MemoryConnManager {
@@ -90,9 +91,10 @@ impl MemoryConnManager {
                     tokio::time::sleep(Duration::from_millis(1)).await;
                     continue;
                 };
+                let source_addr = msg.origin.addr;
                 let msg_data: NetMessage =
                     bincode::deserialize_from(Cursor::new(msg.data)).unwrap();
-                msg_queue_cp.lock().await.push(msg_data);
+                msg_queue_cp.lock().await.push((msg_data, source_addr));
             }
         });
 
@@ -144,15 +146,15 @@ impl NetworkBridge for MemoryConnManager {
 }
 
 impl NetworkBridgeExt for MemoryConnManager {
-    async fn recv(&mut self) -> Result<NetMessage, ConnectionError> {
+    async fn recv(&mut self) -> Result<(NetMessage, Option<SocketAddr>), ConnectionError> {
         loop {
             let mut queue = self.msg_queue.lock().await;
-            let Some(msg) = queue.pop() else {
+            let Some((msg, source_addr)) = queue.pop() else {
                 std::mem::drop(queue);
                 tokio::time::sleep(Duration::from_millis(10)).await;
                 continue;
             };
-            return Ok(msg);
+            return Ok((msg, Some(source_addr)));
         }
     }
 }
@@ -182,11 +184,7 @@ impl InMemoryTransport {
         // Register this peer in the global registry
         {
             let mut registry = PEER_REGISTRY.write().unwrap();
-            registry.register(
-                interface_peer.addr,
-                interface_peer.pub_key.clone(),
-                tx,
-            );
+            registry.register(interface_peer.addr, interface_peer.pub_key.clone(), tx);
         }
 
         // Spawn a task to receive messages from our dedicated channel

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -76,10 +76,13 @@ impl<ER> Builder<ER> {
         .map_err(|e| anyhow::anyhow!(e))?;
 
         // Use the actual configured address for this peer
-        let own_addr = self
-            .config
-            .own_addr
-            .unwrap_or_else(|| (self.config.network_listener_ip, self.config.network_listener_port).into());
+        let own_addr = self.config.own_addr.unwrap_or_else(|| {
+            (
+                self.config.network_listener_ip,
+                self.config.network_listener_port,
+            )
+                .into()
+        });
 
         let conn_manager = MemoryConnManager::new(
             PeerId::new(own_addr, self.config.key_pair.public().clone()),

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -144,6 +144,15 @@ pub(crate) enum ConnectMsg {
     },
 }
 
+/// Extracts the transaction ID from a ConnectMsg if it's a Request variant.
+/// Used by the event loop to identify locally-initiated connect requests.
+pub(crate) fn extract_connect_request_tx(msg: &ConnectMsg) -> Option<Transaction> {
+    match msg {
+        ConnectMsg::Request { id, .. } => Some(*id),
+        _ => None,
+    }
+}
+
 impl InnerMessage for ConnectMsg {
     fn id(&self) -> &Transaction {
         match self {

--- a/crates/core/tests/sim_network.rs
+++ b/crates/core/tests/sim_network.rs
@@ -18,12 +18,12 @@ async fn test_sim_network_basic_connectivity() {
     // Create a network with 1 gateway and 5 peers
     let mut sim = SimNetwork::new(
         "basic-connectivity",
-        1,     // gateways
-        5,     // nodes
-        7,     // ring_max_htl
-        3,     // rnd_if_htl_above
-        10,    // max_connections
-        2,     // min_connections
+        1,  // gateways
+        5,  // nodes
+        7,  // ring_max_htl
+        3,  // rnd_if_htl_above
+        10, // max_connections
+        2,  // min_connections
     )
     .await;
 
@@ -54,12 +54,12 @@ async fn test_sim_network_peer_registration() {
     // Create a minimal network for quick testing
     let mut sim = SimNetwork::new(
         "peer-registration",
-        1,     // gateways
-        2,     // nodes (small for quick test)
-        7,     // ring_max_htl
-        3,     // rnd_if_htl_above
-        10,    // max_connections
-        1,     // min_connections
+        1,  // gateways
+        2,  // nodes (small for quick test)
+        7,  // ring_max_htl
+        3,  // rnd_if_htl_above
+        10, // max_connections
+        1,  // min_connections
     )
     .await;
 
@@ -74,7 +74,11 @@ async fn test_sim_network_peer_registration() {
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Check that peers are starting (handles should be running)
-    assert_eq!(handles.len(), 3, "Expected 3 peer handles (1 gateway + 2 nodes)");
+    assert_eq!(
+        handles.len(),
+        3,
+        "Expected 3 peer handles (1 gateway + 2 nodes)"
+    );
 
     // Allow some time for connection attempts
     tokio::time::sleep(Duration::from_secs(3)).await;
@@ -90,12 +94,12 @@ async fn test_sim_network_connection_check() {
     // Create a network with 1 gateway and 3 peers
     let mut sim = SimNetwork::new(
         "connection-check",
-        1,     // gateways
-        3,     // nodes
-        7,     // ring_max_htl
-        3,     // rnd_if_htl_above
-        10,    // max_connections
-        1,     // min_connections
+        1,  // gateways
+        3,  // nodes
+        7,  // ring_max_htl
+        3,  // rnd_if_htl_above
+        10, // max_connections
+        1,  // min_connections
     )
     .await;
 


### PR DESCRIPTION
This commit fixes the in-memory simulation testing infrastructure (issue #2496).

Key changes:
- Replace global NETWORK_WIRES channel with PeerRegistry for direct peer-to-peer message routing, eliminating busy-polling race conditions
- Fix PeerId construction in MemoryConnManager to use target's public key from registry instead of sender's key (was causing 100% message misrouting)
- Set proper own_addr for regular nodes (not just gateways) to ensure peers register with correct socket addresses
- Add basic SimNetwork integration tests to verify the fixes work

The previous implementation used a single global channel where each peer would:
1. Receive a message from the channel
2. Check if it's for them (target == self)
3. Re-send to channel if not for them

This caused race conditions and message loss. The new PeerRegistry approach routes messages directly to the target peer's dedicated channel.

Closes #2496