### PR TITLE
build: release 0.1.72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.48"
+version = "0.3.49"
 dependencies = [
  "anyhow",
  "axum",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.71"
+version = "0.1.72"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.71"
+version = "0.1.72"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.48"
+version = "0.3.49"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -44,7 +44,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 http = "1.4"
 
 # internal
-freenet = { path = "../core", version = "0.1.71" }
+freenet = { path = "../core", version = "0.1.72" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary

- Bump freenet version to 0.1.72
- Bump fdev version to 0.3.49

This release fixes a critical bug where peers would panic on startup when reading AOF event logs containing newer event types (Transfer, Lifecycle, TransportSnapshot).

**Fix:** 86ba7f6f - accept unknown event kinds in AOF for version compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)