### PR TITLE
feat(telemetry): add separate peer_id and peer_addr fields for correlation

### DIFF
--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -523,7 +523,11 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     serde_json::json!({
                         "type": "connected",
                         "this_peer": this.to_string(),
+                        "this_peer_id": this.pub_key().to_string(),
+                        "this_peer_addr": this.peer_addr.to_string(),
                         "connected_peer": connected.to_string(),
+                        "connected_peer_id": connected.pub_key().to_string(),
+                        "connected_peer_addr": connected.peer_addr.to_string(),
                         "elapsed_ms": elapsed_ms,
                         "connection_type": connection_type.to_string(),
                         "latency_ms": latency_ms,
@@ -608,6 +612,8 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
             serde_json::json!({
                 "type": "disconnected",
                 "from": from.to_string(),
+                "from_peer_id": from.pub_key.to_string(),
+                "from_peer_addr": from.addr.to_string(),
                 "reason": reason.to_string(),
                 "connection_duration_ms": connection_duration_ms,
                 "bytes_sent": bytes_sent,


### PR DESCRIPTION
## Problem

Telemetry events use inconsistent peer identification that makes correlation difficult:

1. **Topology events** (connected/disconnected): Identify peers using combined `PeerKeyLocation` strings like `{pub_key}@{addr} (@ {loc})`
2. **Contract state events** (put_success, get_success, etc.): Include `peer_id` in attributes using cryptographic PeerId format

This makes it difficult to correlate contract state events with network topology - you can't easily see which peers in the ring have which state for a contract without parsing and mapping between different ID formats.

The telemetry dashboard currently has a workaround that:
- Parses `this_peer` strings to extract PeerId
- Maps IP → PeerId for correlation
- Filters contract_states against active peers using PeerId

## Approach

Add explicit, separate fields for peer identity and address to connection events, making correlation trivial:

**Connected events** now include:
- `this_peer_id` / `connected_peer_id`: The cryptographic identity (bs58-encoded public key)
- `this_peer_addr` / `connected_peer_addr`: The socket address

**Disconnected events** now include:
- `from_peer_id`: The cryptographic identity
- `from_peer_addr`: The socket address

The original combined `this_peer`, `connected_peer`, and `from` fields are preserved for backwards compatibility.

With these fields, the dashboard can trivially build a `PeerId ↔ SocketAddr` mapping when peers connect, without any string parsing.

## Testing

- All telemetry unit tests pass
- Clippy passes with no warnings

## Fixes

Closes #2508

[AI-assisted - Claude]