### PR TITLE
build: release v0.1.73

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.49"
+version = "0.3.50"
 dependencies = [
  "anyhow",
  "axum",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.72"
+version = "0.1.73"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.72"
+version = "0.1.73"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.49"
+version = "0.3.50"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -44,7 +44,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 http = "1.4"
 
 # internal
-freenet = { path = "../core", version = "0.1.72" }
+freenet = { path = "../core", version = "0.1.73" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary
Release v0.1.73 with the following changes since v0.1.72:

- fix: downgrade neighbor filter warning to debug level (#2512)
- fix: prevent premature LEDBAT++ ramp-up exit on high-latency paths (#2510)
- feat(telemetry): add separate peer_id and peer_addr fields for correlation (#2509)
- fix(deploy): auto-restart service on binary mismatch detection

## Version Changes
- freenet: 0.1.72 → 0.1.73
- fdev: 0.3.49 → 0.3.50

🤖 Generated with [Claude Code](https://claude.com/claude-code)