### PR TITLE
fix: allow upgraded peers to reconnect immediately after version mismatch

### DIFF
--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -417,6 +417,8 @@ impl<S: Socket> UdpPacketsListener<S> {
                                                          Peer likely upgraded. Allowing reconnection."
                                                     );
                                                     outdated_peer.remove(&remote_addr);
+                                                    // Clean up rate-limit tracking now that peer is reconnecting
+                                                    self.last_rsa_attempt.remove(&remote_addr);
                                                     // Don't continue - fall through to process the packet
                                                 } else {
                                                     continue; // Still incompatible version


### PR DESCRIPTION
## Problem

When a peer connects with an incompatible protocol version, they get added to the `outdated_peer` HashMap and ALL subsequent packets from that IP:port are dropped for 10 minutes. This is problematic during rolling upgrades:

1. Gateway upgrades to v0.1.73
2. Peer (still v0.1.72) tries to connect → version mismatch → marked as "outdated"  
3. Peer upgrades to v0.1.73 and retries
4. Gateway still drops all packets from peer for 10 minutes (even though peer now has correct version!)

This was observed during the v0.1.72→v0.1.73 upgrade where technic peer couldn't reconnect until both gateway and peer were restarted.

## Solution

Modify the `outdated_peer` check to examine incoming packets before dropping them:

1. Check if the packet is a 256-byte RSA intro packet (the handshake initiation)
2. Attempt RSA decryption and validate the protocol version
3. If it matches the current `PROTOC_VERSION`, clear the outdated status and process the packet
4. Rate limit RSA decryption attempts to prevent DoS (reuses existing `last_rsa_attempt` tracking)

This allows upgraded peers to reconnect immediately instead of waiting 10 minutes.

## Testing

- Verified code compiles with clippy warnings treated as errors
- The fix uses the same RSA decryption and protocol validation logic that already exists for new identity detection (issue #2277)
- Rate limiting prevents the RSA decryption from being a DoS vector

## Notes

The 10-minute block was originally designed to prevent spamming from truly incompatible peers, and that behavior is preserved for:
- Non-intro packets (wrong size)
- Intro packets that fail RSA decryption
- Intro packets with incorrect protocol version

Only valid intro packets with the current protocol version bypass the block.

[AI-assisted - Claude]