### PR TITLE
fix(transport): eliminate race condition in gateway handshake completion

### DIFF
--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -662,10 +662,15 @@ impl<S: Socket> UdpPacketsListener<S> {
                     match res.expect("task shouldn't panic") {
                         Ok((outbound_remote_conn, inbound_remote_connection, outbound_ack_packet)) => {
                             let remote_addr = outbound_remote_conn.remote_addr;
-                            ongoing_gw_connections.remove(&remote_addr);
                             let sent_tracker = outbound_remote_conn.sent_tracker.clone();
 
+                            // Issue #2517: Insert into remote_connections BEFORE removing from
+                            // ongoing_gw_connections to prevent race condition. Without this order,
+                            // there's a gap where incoming packets aren't found in either map and
+                            // fall through to RSA decryption, causing spurious "decryption error"
+                            // failures when symmetric packets are misrouted.
                             self.remote_connections.insert(remote_addr, inbound_remote_connection);
+                            ongoing_gw_connections.remove(&remote_addr);
 
                             if self.new_connection_notifier
                                 .send(PeerConnection::new(outbound_remote_conn))


### PR DESCRIPTION
## Problem

The `test_small_network_get_failure` test fails intermittently with RSA decryption errors during connection establishment:

```
[ERROR freenet::transport::connection_handler] Failed to establish gateway connection 
  error=decryption error peer_addr=127.0.0.1:43396 direction="inbound"
```

The same peer address repeatedly fails with "decryption error", indicating packets are being misrouted to the RSA decryption handler when they shouldn't be.

## Root Cause

**Race condition between `ongoing_gw_connections.remove()` and `remote_connections.insert()`**

When a gateway handshake completes successfully:

1. **Line 665 (before fix):** `ongoing_gw_connections.remove(&remote_addr)`
2. **Line 668 (before fix):** `self.remote_connections.insert(remote_addr, ...)`

Between these two operations, if a packet arrives from the same peer:
- Not found in `remote_connections` (not yet inserted)
- Not found in `ongoing_gw_connections` (already removed)
- Falls through to line 574, creating a NEW gateway connection attempt
- Tries RSA decryption on what's actually a symmetric packet → decryption error

This is timing-dependent, explaining why the test is flaky.

## Solution

Insert into `remote_connections` BEFORE removing from `ongoing_gw_connections`. This ensures there's no gap where incoming packets can fall through to RSA decryption.

The packet routing checks `remote_connections` first (line ~409), so once a connection is inserted there, packets will be correctly routed even while the entry still exists in `ongoing_gw_connections`.

## Why CI Didn't Always Catch This

The race window is small (a few microseconds). It only manifests when:
- A packet arrives during the exact window between remove and insert
- More common under high load, network jitter, or slow CI machines

The test has documented flakiness history (PRs #2213, #2465, Issue #2023).

## Testing

- Ran `test_small_network_get_failure` twice locally - both passed
- `cargo fmt` and `cargo clippy` pass

Fixes #2517

[AI-assisted - Claude]