### PR TITLE
perf(transport): replace RSA-2048 with X25519 for transport key exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,7 +1912,9 @@ dependencies = [
  "futures 0.3.31",
  "gag",
  "headers",
+ "hex",
  "hickory-resolver",
+ "hkdf",
  "hostname",
  "httptest",
  "itertools 0.14.0",
@@ -1894,12 +1928,10 @@ dependencies = [
  "parking_lot",
  "pav_regression",
  "pin-project",
- "pkcs8",
  "rand 0.9.2",
  "redb",
  "regex",
  "reqwest",
- "rsa",
  "rstest",
  "semver",
  "serde",
@@ -1931,6 +1963,7 @@ dependencies = [
  "which",
  "winapi",
  "wmi",
+ "x25519-dalek",
  "xz2",
  "zip",
 ]
@@ -3556,7 +3589,6 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.5",
- "serde",
  "smallvec",
  "zeroize",
 ]
@@ -4752,7 +4784,6 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "serde",
  "signature",
  "spki",
  "subtle",
@@ -7523,6 +7554,18 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "xattr"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -73,9 +73,10 @@ wasmer-middlewares = "6.1.0"
 wasmer-compiler-singlepass = { workspace = true }
 xz2 = { version = "0.1" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
-rsa = { version = "0.9", features = ["serde", "pem"] }
-pkcs8 = { version = "0.10", features = ["std", "pem"] }
 sha2 = "0.10"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+hkdf = "0.12"
+hex = "0.4"
 
 # Tracing deps
 opentelemetry = "0.31"

--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -53,7 +53,6 @@ use crate::{
     message::{MessageStats, NetMessageV1},
 };
 use freenet_stdlib::client_api::DelegateRequest;
-use rsa::pkcs8::DecodePublicKey;
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 
@@ -192,8 +191,18 @@ impl NodeConfig {
             let mut buf = String::new();
             key_file.read_to_string(&mut buf)?;
 
-            let pub_key = rsa::RsaPublicKey::from_public_key_pem(&buf)?;
-            let transport_pub_key = TransportPublicKey::from(pub_key);
+            // X25519 public keys are stored as hex-encoded 32 bytes
+            let key_bytes = hex::decode(buf.trim()).with_context(|| {
+                format!("Invalid hex in gateway public key: {public_key_path:?}")
+            })?;
+            if key_bytes.len() != 32 {
+                anyhow::bail!(
+                    "Invalid gateway public key length (expected 32 bytes): {public_key_path:?}"
+                );
+            }
+            let mut key_array = [0u8; 32];
+            key_array.copy_from_slice(&key_bytes);
+            let transport_pub_key = TransportPublicKey::from_bytes(key_array);
 
             // Skip if this gateway's public key matches our own
             if &transport_pub_key == own_pub_key {

--- a/crates/core/src/transport/mod.rs
+++ b/crates/core/src/transport/mod.rs
@@ -44,7 +44,7 @@ pub fn clear_version_mismatch() {
 }
 
 pub mod connection_handler;
-mod crypto;
+pub(crate) mod crypto;
 
 /// Mock transport infrastructure for testing and benchmarking.
 /// Provides MockSocket and helper functions to create mock peer connections
@@ -169,8 +169,8 @@ pub enum TransportError {
     IO(#[from] std::io::Error),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
-    #[error(transparent)]
-    PubKeyDecryptionError(#[from] rsa::errors::Error),
+    #[error("Key exchange failed: {0}")]
+    KeyExchangeFailed(Cow<'static, str>),
     #[error(transparent)]
     Serialization(#[from] bincode::Error),
 }

--- a/crates/core/src/transport/symmetric_message.rs
+++ b/crates/core/src/transport/symmetric_message.rs
@@ -33,11 +33,13 @@ impl SymmetricMessage {
         bincode::deserialize(bytes)
     }
 
+    #[allow(dead_code)]
     const ACK_ERROR_MSG: &str = concat!(
         "remote is using a different protocol version, expected version ",
         env!("CARGO_PKG_VERSION")
     );
 
+    #[allow(dead_code)]
     const ACK_ERROR: SymmetricMessage = SymmetricMessage {
         packet_id: Self::FIRST_PACKET_ID,
         confirm_receipt: Vec::new(),
@@ -106,6 +108,7 @@ impl SymmetricMessage {
         *MAX_NUM_CONFIRM_RECEIPTS
     }
 
+    #[allow(dead_code)]
     pub fn ack_error(
         outbound_sym_key: &Aes128Gcm,
     ) -> Result<PacketData<SymmetricAES>, bincode::Error> {


### PR DESCRIPTION
## Problem

The transport layer uses RSA-2048 for key exchange, which is slow:
- **Key generation**: 50-100ms per keypair
- **Public key size**: 256 bytes
- **Key exchange**: ~5ms for encryption/decryption

This becomes a bottleneck when:
- Nodes restart and need to regenerate keys
- Many new connections are established quickly
- Mobile/embedded devices with slower CPUs

## Approach

Replace RSA-2048 with X25519 Elliptic Curve Diffie-Hellman (ECDH):
- **Key generation**: ~0.05ms per keypair (~1000-2000x faster)
- **Public key size**: 32 bytes (8x smaller)
- **Same security level**: Both provide ~128-bit security

### Key Design Decisions

1. **Ephemeral ECDH for gateway connections**: Each connection generates a fresh ephemeral keypair, providing forward secrecy. The peer sends its ephemeral public key in the intro packet, and the gateway derives the shared secret using `gateway_static.DH(peer_ephemeral)`.

2. **Static-to-static ECDH for NAT traversal**: In peer-to-peer NAT traversal scenarios, both peers may send intro packets simultaneously and some may be dropped. Using static keys ensures both sides derive the same symmetric keys regardless of packet loss, trading some forward secrecy for reliability.

3. **HKDF-SHA256 for key derivation**: Symmetric AES-128-GCM keys are derived from the DH shared secret using HKDF with canonical ordering of public keys, ensuring both parties derive identical keys.

4. **ACK retransmission for dropped packets**: Added handling for resent intro packets at the gateway - if the gateway's ACK was dropped, it will resend when it receives a duplicate intro.

### Why not other curves?

X25519 was chosen because:
- Used by TLS 1.3, WireGuard, Signal (battle-tested)
- Simple, constant-time implementation (side-channel resistant)
- The `x25519-dalek` crate is well-audited and widely used

## Testing

- All 858 lib tests pass
- Mock transport tests pass (gateway connection, NAT traversal, packet dropping scenarios)
- Key derivation tests verify both parties derive identical symmetric keys
- Added tests for ephemeral/static ECDH scenarios

Note: `sim_network` tests fail due to Docker permission issues unrelated to this change.

## Fixes

Closes #2531

[AI-assisted - Claude]