### PR TITLE
fix(simulation): improve framework robustness and documentation

### DIFF
--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -92,6 +92,7 @@ impl<ER> Builder<ER> {
             op_manager.clone(),
             self.add_noise,
             self.rng_seed,
+            &self.network_name,
         );
 
         GlobalExecutor::spawn(
@@ -199,6 +200,7 @@ impl<ER> Builder<ER> {
             op_manager.clone(),
             self.add_noise,
             self.rng_seed,
+            &self.network_name,
         );
 
         GlobalExecutor::spawn(


### PR DESCRIPTION
## Problem

After merging PR #2553 (simulation testing framework), a code review identified several issues that affect code quality, robustness, and test isolation:

1. **Global mutable state**: Fault injection used a global `static` which caused tests to interfere with each other when run in parallel
2. **Missing error handling**: Deserialization errors caused panics instead of graceful failures
3. **API inconsistencies**: Method naming didn't follow Rust conventions (`connected()` vs `is_connected()`)
4. **Missing documentation**: No module-level docs, unclear ownership semantics for EventChain
5. **Weak test coverage**: Edge cases like 0 nodes, minimal networks were untested
6. **Potential division by zero**: In `network_connectivity_quality()` with empty node lists

## Solution

### Critical Fixes

**Network-scoped fault injection** (fixes test isolation):
- Changed `FAULT_INJECTOR` from a single `Option` to a `HashMap<String, ...>` keyed by network name
- Each `SimNetwork` now has its own isolated fault injector state
- Cleanup happens automatically in `SimNetwork::drop()`

### Bug Fixes

- **Deserialization errors**: Now logged and skipped instead of panicking
- **Division by zero guards**: Added checks in `network_connectivity_quality()` for empty node lists and zero node counts
- **Partition test**: Fixed to use real node addresses from `all_node_addresses()` instead of hardcoded fake addresses

### API Improvements

- Renamed `connected()` → `is_connected()` for Rust naming convention

### Documentation

- Added module-level documentation to `testing_impl.rs` explaining the simulation framework
- Documented `EventChain` ownership semantics (borrow vs consume patterns)
- Added warning about `with_noise()` enabling non-deterministic mode

### Test Coverage

New tests added:
- `test_crash_restart_edge_cases`: Tests error handling for unknown nodes
- `test_zero_nodes_panics`: Verifies 0 nodes panics
- `test_zero_gateways_panics`: Verifies 0 gateways panics
- `test_minimal_network`: Tests 1 gateway + 1 node configuration

## Testing

All 22 simulation integration tests pass:
```
test result: ok. 22 passed; 0 failed; 0 ignored
```

## Files Changed

- `crates/core/src/node/network_bridge/in_memory.rs` - Network-scoped fault injection
- `crates/core/src/node/testing_impl.rs` - Module docs, API fixes, documentation
- `crates/core/src/node/testing_impl/in_memory.rs` - Pass network name to transports
- `crates/core/tests/simulation_integration.rs` - New edge case tests, fixed partition test

🤖 Generated with [Claude Code](https://claude.com/claude-code)