### PR TITLE
test: add Variable RTT tests at transport level

### DIFF
--- a/crates/core/src/transport/ledbat.rs
+++ b/crates/core/src/transport/ledbat.rs
@@ -4550,6 +4550,8 @@ mod tests {
     //
     // Implementation notes:
     // - Duration comparisons use tolerance where exact equality is fragile.
+    // - Tests use wall-clock sleep() because LEDBAT internally uses std::time::Instant
+    //   for epoch timing, which is not affected by tokio's mock time.
     // =========================================================================
 
     /// Helper for approximate Duration comparison with tolerance.


### PR DESCRIPTION
Add comprehensive tests for LEDBAT behavior under variable network latency conditions, addressing a gap identified in issue #2559.

Parametrized tests (using rstest):
- test_variable_rtt_at_different_base_latencies: Tests jittery RTT across LAN (10ms±5ms), regional (50ms±20ms), continental (100ms±30ms), and satellite (300ms±50ms) network types
- test_variable_rtt_queue_buildup_parametrized: Tests queue buildup at 20ms, 50ms, and 100ms base latencies with 60ms queue growth
- test_variable_rtt_spike_recovery_parametrized: Tests recovery from 2.7x, 5x, and 10x latency spikes

Additional scenario tests:
- test_variable_rtt_continuous_jitter: Validates cwnd stability under continuous 40ms ± 20ms jitter (CoV < 0.5)
- test_variable_rtt_base_delay_shift: Tests detection of permanent network path changes (20ms → 80ms)
- test_variable_rtt_extreme_variation: Stress test with 10-350ms RTT swings
- test_variable_rtt_timeout_with_degrading_conditions: Tests timeout recovery after degrading network conditions

These tests complement existing fixed-latency tests by exercising the dynamic RTT scenarios that occur in real networks.

Relates to #2559