### PR TITLE
fix(executor): use shared notification storage at pool level

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -691,14 +691,20 @@ pub(crate) trait ContractExecutor: Send + 'static {
 /// - `R`: The runtime type (default: `Runtime` for production, `MockRuntime` for testing)
 /// - `S`: The state storage type (default: `Storage` for disk-based, can use `MockStateStorage` for in-memory)
 // Type alias for shared notification storage (used by RuntimePool)
-// Uses DashMap for concurrent access without blocking - critical because
-// send_update_notification calls WASM (get_state_delta) and we must not hold locks during that
-type SharedNotifications =
-    Arc<dashmap::DashMap<ContractInstanceId, Vec<(ClientId, mpsc::UnboundedSender<HostResult>)>>>;
+// Uses RwLock<HashMap> with snapshot pattern - locks are only held briefly during clone,
+// never during WASM execution (get_state_delta)
+type SharedNotifications = Arc<
+    std::sync::RwLock<
+        HashMap<ContractInstanceId, Vec<(ClientId, mpsc::UnboundedSender<HostResult>)>>,
+    >,
+>;
 
 // Type alias for shared subscriber summaries (used by RuntimePool)
-type SharedSummaries =
-    Arc<dashmap::DashMap<ContractInstanceId, HashMap<ClientId, Option<StateSummary<'static>>>>>;
+type SharedSummaries = Arc<
+    std::sync::RwLock<
+        HashMap<ContractInstanceId, HashMap<ClientId, Option<StateSummary<'static>>>>,
+    >,
+>;
 
 pub struct Executor<R = Runtime, S: StateStorage = Storage> {
     mode: OperationMode,


### PR DESCRIPTION
## Problem

Users in River chat rooms couldn't see each other's messages despite UPDATE operations succeeding at the network level. Investigation revealed that:

1. Lukas's Freenet peer received and applied broadcast updates (telemetry confirmed `update_broadcast_applied: 1`)
2. But his browser never received `UpdateNotification` events
3. The issue was **local notification delivery**, not network propagation

The root cause was a race condition in the executor pool subscription registration.

### Race Condition

```
Time T1: Executor A checked out for some operation
Time T2: Client subscribes → register_contract_notifier runs
         → Only registers with executors B,C,D (A's slot is None)
Time T3: Executor A returns to pool
Time T4: Update arrives → pop_executor returns Executor A
Time T5: Executor A's send_update_notification finds NO subscribers
         → Notification never sent!
```

`RuntimePool::register_contract_notifier` used `iter().flatten()` which only iterated executors currently in the pool. Checked-out executors (slots with `None`) were skipped.

### Why CI Didn't Catch This

1. **Mock runtime does nothing** - `mock_runtime.rs::register_contract_notifier()` returns `Ok(())` without storing subscriptions
2. **Integration tests are timing-dependent** - The race requires an executor to be checked out during registration AND handle the subsequent update
3. **Low parallelism in CI** - CI machines may have fewer cores, reducing pool size (2-16 based on CPU count) and race likelihood

## Approach

Move notification storage from per-executor HashMaps to shared pool-level storage:

1. Add `SharedNotifications` and `SharedSummaries` at `RuntimePool` level using `Arc<std::sync::RwLock<HashMap<...>>>`
2. `register_contract_notifier` now stores in shared storage instead of iterating per-executor storage
3. `send_update_notification` checks for shared storage and uses it when available (pool mode) or falls back to per-executor storage (standalone mode)
4. Each executor is initialized with references to the shared storage

This ensures notifications work regardless of which executor is checked out when subscriptions are registered or when updates arrive.

### Why std::sync::RwLock instead of tokio::sync::RwLock

`register_contract_notifier` is a sync function called from various contexts. Using `tokio::sync::RwLock::blocking_write()` panics when called from within an async runtime context ("Cannot block the current thread from within a runtime"). `std::sync::RwLock` works correctly from both sync and async contexts.

## Testing

- Existing `test_get_with_subscribe_flag` passes (exercises subscription + notification path)
- All 1052 lib tests pass
- **TODO**: Add a targeted test that exercises the race condition by:
  1. Creating a pool
  2. Checking out all executors
  3. Registering a subscription
  4. Returning executors
  5. Triggering an update
  6. Verifying notification is received

## Related

This was discovered while debugging why River chat users couldn't see each other's messages. The network propagation architecture review in `/home/ian/.claude/plans/lazy-napping-lamport.md` proposes additional improvements for subscription-scoped gossip.

[AI-assisted - Claude]