### PR TITLE
feat: add LEDBAT diagnostic telemetry for slow transfer debugging

### DIFF
--- a/crates/core/src/tracing/mod.rs
+++ b/crates/core/src/tracing/mod.rs
@@ -3145,6 +3145,16 @@ pub enum TransferEvent {
         slowdowns_triggered: Option<u32>,
         /// Final smoothed RTT at completion (milliseconds).
         final_srtt_ms: Option<u32>,
+        /// Final slow start threshold at completion (bytes).
+        /// Key diagnostic for death spiral: if ssthresh collapses to min_cwnd,
+        /// slow start can't recover useful throughput.
+        final_ssthresh_bytes: Option<u32>,
+        /// Effective minimum ssthresh floor (bytes).
+        /// This floor prevents ssthresh from collapsing too low during timeouts.
+        min_ssthresh_floor_bytes: Option<u32>,
+        /// Total retransmission timeouts (RTO events) during transfer.
+        /// High values indicate severe congestion or path issues.
+        total_timeouts: Option<u32>,
         /// Whether we were sending or receiving.
         direction: TransferDirection,
         timestamp: u64,

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -1149,6 +1149,9 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     final_cwnd_bytes,
                     slowdowns_triggered,
                     final_srtt_ms,
+                    final_ssthresh_bytes,
+                    min_ssthresh_floor_bytes,
+                    total_timeouts,
                     direction,
                     timestamp,
                 } => {
@@ -1163,6 +1166,9 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         "final_cwnd_bytes": final_cwnd_bytes,
                         "slowdowns_triggered": slowdowns_triggered,
                         "final_srtt_ms": final_srtt_ms,
+                        "final_ssthresh_bytes": final_ssthresh_bytes,
+                        "min_ssthresh_floor_bytes": min_ssthresh_floor_bytes,
+                        "total_timeouts": total_timeouts,
                         "direction": format!("{:?}", direction),
                         "timestamp": timestamp,
                     })

--- a/crates/core/src/transport/metrics.rs
+++ b/crates/core/src/transport/metrics.rs
@@ -406,6 +406,9 @@ pub fn emit_transfer_completed(
     final_cwnd_bytes: Option<u32>,
     slowdowns_triggered: Option<u32>,
     final_srtt_ms: Option<u32>,
+    final_ssthresh_bytes: Option<u32>,
+    min_ssthresh_floor_bytes: Option<u32>,
+    total_timeouts: Option<u32>,
     direction: TransferDirection,
 ) {
     let sender_guard = TRANSFER_EVENT_SENDER.read();
@@ -420,6 +423,9 @@ pub fn emit_transfer_completed(
             final_cwnd_bytes,
             slowdowns_triggered,
             final_srtt_ms,
+            final_ssthresh_bytes,
+            min_ssthresh_floor_bytes,
+            total_timeouts,
             direction,
             timestamp: crate::tracing::telemetry::current_timestamp_ms(),
         };
@@ -478,6 +484,9 @@ mod tests {
             final_cwnd_bytes: 40000,
             slowdowns_triggered: 1,
             base_delay: Duration::from_millis(10),
+            final_ssthresh_bytes: 100000,
+            min_ssthresh_floor_bytes: 5696,
+            total_timeouts: 0,
         };
 
         metrics.record_transfer_completed(&stats);
@@ -502,6 +511,9 @@ mod tests {
             final_cwnd_bytes: 40000,
             slowdowns_triggered: 1,
             base_delay: Duration::from_millis(10),
+            final_ssthresh_bytes: 100000,
+            min_ssthresh_floor_bytes: 5696,
+            total_timeouts: 0,
         };
 
         metrics.record_transfer_completed(&stats);
@@ -525,6 +537,9 @@ mod tests {
                 final_cwnd_bytes: 35000,
                 slowdowns_triggered: 1,
                 base_delay: Duration::from_millis(10),
+                final_ssthresh_bytes: 100000,
+                min_ssthresh_floor_bytes: 5696,
+                total_timeouts: 0,
             };
             metrics.record_transfer_completed(&stats);
         }

--- a/crates/core/src/transport/mod.rs
+++ b/crates/core/src/transport/mod.rs
@@ -95,6 +95,16 @@ pub struct TransferStats {
     pub slowdowns_triggered: u32,
     /// Minimum observed RTT (base delay) at completion.
     pub base_delay: Duration,
+    /// Final slow start threshold at completion (bytes).
+    /// Key diagnostic for death spiral: if ssthresh collapses to min_cwnd,
+    /// slow start can't recover useful throughput.
+    pub final_ssthresh_bytes: u32,
+    /// Effective minimum ssthresh floor (bytes).
+    /// This floor prevents ssthresh from collapsing too low during timeouts.
+    pub min_ssthresh_floor_bytes: u32,
+    /// Total retransmission timeouts (RTO events) during transfer.
+    /// High values indicate severe congestion or path issues.
+    pub total_timeouts: u32,
 }
 
 impl TransferStats {

--- a/crates/core/src/transport/peer_connection/outbound_stream.rs
+++ b/crates/core/src/transport/peer_connection/outbound_stream.rs
@@ -223,6 +223,9 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
         Some(ledbat_stats.cwnd as u32),
         Some(ledbat_stats.periodic_slowdowns as u32),
         Some(ledbat_stats.base_delay.as_millis() as u32),
+        Some(ledbat_stats.ssthresh as u32),
+        Some(ledbat_stats.min_ssthresh_floor as u32),
+        Some(ledbat_stats.total_timeouts as u32),
         TransferDirection::Send,
     );
 
@@ -235,6 +238,9 @@ pub(super) async fn send_stream<S: super::super::Socket, T: TimeSource>(
         final_cwnd_bytes: ledbat_stats.cwnd as u32,
         slowdowns_triggered: ledbat_stats.periodic_slowdowns as u32,
         base_delay: ledbat_stats.base_delay,
+        final_ssthresh_bytes: ledbat_stats.ssthresh as u32,
+        min_ssthresh_floor_bytes: ledbat_stats.min_ssthresh_floor as u32,
+        total_timeouts: ledbat_stats.total_timeouts as u32,
     })
 }
 


### PR DESCRIPTION
## Problem

GET operations for the River UI contract take ~19 seconds to transfer 2.3MB on the nova→technic path (135ms RTT), despite LEDBAT min_ssthresh fixes being deployed in v0.1.82. The existing telemetry shows final cwnd values (often collapsed to 3-8KB) but doesn't capture the diagnostic data needed to understand **why** cwnd collapses.

Current telemetry gap:
- We see `final_cwnd_bytes` but not `ssthresh` - can't tell if death spiral occurred
- We see `slowdowns_triggered` but not `total_timeouts` - can't correlate with RTO events
- We don't see the effective `min_ssthresh_floor` - can't verify the floor is being applied

Without this data, debugging slow transfers requires enabling DEBUG/TRACE logging, which floods logs and requires restarting peers.

## Approach

Enrich the existing `TransferEvent::Completed` telemetry event with LEDBAT diagnostic fields. This approach:

1. **Doesn't spam** - uses existing per-transfer events, not per-packet
2. **Captures key diagnostics**:
   - `final_ssthresh_bytes` - detects death spiral (if this equals min_cwnd, slow start can't recover)
   - `min_ssthresh_floor_bytes` - verifies the adaptive floor is being applied
   - `total_timeouts` - correlates slow transfers with RTO events

The fields are already computed by `LedbatController::stats()`, just not exposed to telemetry until now.

## Changes

- Add `total_timeouts` counter to `LedbatController`
- Add `ssthresh`, `min_ssthresh_floor`, `total_timeouts` to `LedbatStats`
- Add corresponding fields to `TransferStats` and `TransferEvent::Completed`
- Update `emit_transfer_completed()` and telemetry JSON serialization

## Regression Test Added

Added `test_large_transfer_throughput_regression` that simulates the production scenario and would have caught the death spiral issue:

```
Scenario: 2.3MB transfer on 135ms RTT after 3 timeouts
- Without min_ssthresh fix: ~140 RTTs (19s), avg cwnd ~16KB
- With min_ssthresh fix: 27 RTTs (3.6s), avg cwnd 84KB
- Test thresholds: max 80 RTTs, min 30KB avg cwnd
```

This test verifies:
1. ssthresh stays at 100KB floor after timeouts (not collapsing to 5KB)
2. Transfer completes in reasonable time via slow start recovery
3. New telemetry fields correctly capture timeout count

## Testing

- All 1066 unit tests pass (including new regression test)
- Clippy passes (with `--all-targets --all-features`)
- Format check passes

## What This Enables

After deployment, slow transfer diagnosis becomes:
```bash
# Find transfers with death spiral (ssthresh collapsed to floor)
ssh nova "sudo cat /var/log/freenet-telemetry/logs.jsonl | jq -c '... | select(.final_ssthresh_bytes < 10000)'"

# Find transfers with high timeout count
ssh nova "sudo cat /var/log/freenet-telemetry/logs.jsonl | jq -c '... | select(.total_timeouts > 5)'"
```

[AI-assisted - Claude]