### PR TITLE
feat(server): inject auth token into webapp HTML

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -265,7 +265,9 @@ async fn get_web_body(
         error_cause: format!("{err}"),
     })?;
 
-    // Inject auth token into HTML so web apps can access it without re-fetching
+    // Inject auth token into HTML so web apps can access it without re-fetching.
+    // Safety: AuthToken uses base58 encoding which only produces alphanumeric characters
+    // (0-9, A-Z, a-z excluding 0, O, I, l), so no escaping is needed for the JavaScript string.
     let token_script = format!(
         r#"<script>window.__FREENET_AUTH_TOKEN__ = "{}";</script>"#,
         auth_token.as_str()


### PR DESCRIPTION
## Problem

Web apps served through Freenet's HTTP gateway currently have no direct way to access their auth token. The token is sent in the HTTP `Authorization` header, but browsers don't expose response headers to JavaScript.

As a workaround, River was re-fetching the **entire page URL** just to read the Authorization header from the fetch response. This caused ~40 second delays on initial load because it triggers another full contract lookup through the Freenet network.

## Solution

Inject the auth token directly into the HTML as a global JavaScript variable when serving `index.html`:

```html
<script>window.__FREENET_AUTH_TOKEN__ = "token_value";</script>
```

This is inserted just before `</head>` (with fallbacks for malformed HTML). Web apps can then read `window.__FREENET_AUTH_TOKEN__` synchronously on startup without any network requests.

## Security Note

AuthToken uses base58 encoding which only produces alphanumeric characters (0-9, A-Z, a-z excluding 0, O, I, l). This means no JavaScript escaping is needed when injecting into the script tag - there's no risk of XSS from the token value itself.

## Changes

- Modified `get_web_body()` in `path_handlers.rs` to accept the auth token
- Inject token script into HTML before serving
- Clone the token before passing to `NewConnection` so it remains available for injection
- Added safety comment documenting the base58 encoding guarantee

## Testing

- Local clippy and build pass
- Existing `path_handlers` tests pass
- The change is purely additive to the HTML - it doesn't affect any existing functionality
- End-to-end testing with River will validate the full flow

## Impact

This unblocks River from using the auth token immediately on page load. A corresponding River change will update the client to read from `window.__FREENET_AUTH_TOKEN__` instead of re-fetching.

[AI-assisted - Claude]