### PR TITLE
build: release 0.1.85

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.84"
+version = "0.1.85"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -44,7 +44,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 http = "1.4"
 
 # internal
-freenet = { path = "../core", version = "0.1.84" }
+freenet = { path = "../core", version = "0.1.85" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary
- Bump freenet version to 0.1.85

## Changes included
- fix: await result delivery before marking operation complete (#2621)
- fix(ledbat): allow cwnd to grow up to ssthresh on high-latency paths (#2619)
- feat: auto-subscribe to contracts after GET with LRU+TTL eviction (#2620)
- Dependency updates

[AI-assisted - Claude]