### PR TITLE
fix(ledbat): apply min_ssthresh floor in periodic slowdowns

### DIFF
--- a/crates/core/src/transport/ledbat.rs
+++ b/crates/core/src/transport/ledbat.rs
@@ -1378,8 +1378,10 @@ impl<T: TimeSource> LedbatController<T> {
             return false;
         }
 
-        // Save current cwnd as ssthresh and ramp-up target, applying min_ssthresh floor
-        // This mirrors the logic in on_timeout() which also applies the floor
+        // Save current cwnd as ssthresh and ramp-up target, applying min_ssthresh floor.
+        // Note: Unlike on_timeout() which halves cwnd before flooring (aggressive response
+        // to packet loss), periodic slowdown preserves cwnd as ssthresh (proactive probe).
+        // Both apply the floor to prevent ssthresh death spiral on high-BDP paths.
         let floor = self.calculate_adaptive_floor();
         let new_ssthresh = current_cwnd.max(floor);
         self.ssthresh.store(new_ssthresh, Ordering::Release);
@@ -10117,6 +10119,178 @@ mod tests {
             "✓ ssthresh ({:.0}KB) >= min_ssthresh floor ({:.0}KB) - PASSED",
             ssthresh_after as f64 / 1024.0,
             min_ssthresh as f64 / 1024.0
+        );
+    }
+
+    /// Integration test: Large transfer on high-latency path must complete in reasonable time.
+    ///
+    /// This is the "golden test" that catches the entire class of slow-transfer bugs:
+    /// - ssthresh death spiral (repeated reductions below useful levels)
+    /// - cwnd trapped below ssthresh (can't grow to match BDP)
+    /// - Excessive slowdowns preventing sustained throughput
+    /// - min_ssthresh floor not being applied (in timeout OR periodic slowdown)
+    /// - Any other issue that prevents reasonable throughput on high-BDP paths
+    ///
+    /// The test simulates the real-world scenario that kept failing:
+    /// - ~2.5MB transfer (River UI contract)
+    /// - 135ms RTT (Germany to USA)
+    /// - Starting from minimum cwnd (post-timeout recovery)
+    ///
+    /// If this test passes, we have high confidence the transfer will complete
+    /// in a reasonable time in production.
+    #[test]
+    fn test_large_transfer_high_latency_completes_in_reasonable_time() {
+        // Production scenario parameters
+        let transfer_size = 2_500_000; // 2.5MB (River UI contract size)
+        let rtt_ms = 135; // Germany <-> USA
+        let min_ssthresh = 100 * 1024; // 100KB floor (production config)
+
+        // Calculate acceptable bounds
+        // At 100KB/RTT steady state: 2.5MB / 100KB = 25 RTTs (ideal)
+        // With slow start, ramp-ups, and slowdowns: allow 4x overhead
+        // 25 * 4 = 100 RTTs = 13.5 seconds at 135ms RTT
+        // We'll use 150 RTTs (~20 seconds) as the absolute maximum
+        let max_rtts = 150;
+        let min_avg_throughput_per_rtt = transfer_size / max_rtts; // ~16KB/RTT minimum
+
+        let config = LedbatConfig {
+            initial_cwnd: 2_848, // Start at minimum (simulating post-timeout)
+            min_cwnd: 2_848,
+            max_cwnd: 10_000_000,
+            ssthresh: 1_000_000, // Will be set by recovery
+            enable_slow_start: true,
+            enable_periodic_slowdown: true,
+            randomize_ssthresh: false,
+            min_ssthresh: Some(min_ssthresh),
+            ..Default::default()
+        };
+
+        // Use intercontinental conditions but without packet loss for determinism
+        // (packet loss would cause timeouts which reset progress unpredictably)
+        let condition = NetworkCondition::custom(rtt_ms, Some(0.1), 0.0);
+        let mut harness = LedbatTestHarness::new(config, condition, 42);
+
+        println!("\n========== Large Transfer High-Latency Test ==========");
+        println!(
+            "Transfer: {:.1}MB, RTT: {}ms, min_ssthresh: {}KB",
+            transfer_size as f64 / (1024.0 * 1024.0),
+            rtt_ms,
+            min_ssthresh / 1024
+        );
+        println!(
+            "Success criteria: Complete in <{} RTTs (<{:.1}s)",
+            max_rtts,
+            max_rtts as f64 * rtt_ms as f64 / 1000.0
+        );
+
+        // Track cumulative "bytes transferred" (cwnd per RTT approximates throughput)
+        let mut total_bytes_transferred: usize = 0;
+        let mut rtts_elapsed = 0;
+        let mut min_ssthresh_observed = usize::MAX;
+        let mut max_slowdowns_observed = 0;
+        let mut snapshots_below_floor = 0;
+
+        // Run until we've transferred enough bytes or hit the RTT limit
+        while total_bytes_transferred < transfer_size && rtts_elapsed < max_rtts {
+            harness.step(100_000); // Simulate sending up to 100KB per RTT
+            let snap = harness.snapshot();
+
+            // cwnd represents how much we could send this RTT
+            total_bytes_transferred += snap.cwnd;
+            rtts_elapsed += 1;
+
+            // Track pathological states
+            let ssthresh = harness.controller.ssthresh.load(Ordering::Acquire);
+            min_ssthresh_observed = min_ssthresh_observed.min(ssthresh);
+            max_slowdowns_observed = max_slowdowns_observed.max(snap.periodic_slowdowns);
+
+            if ssthresh < min_ssthresh {
+                snapshots_below_floor += 1;
+            }
+
+            // Progress logging every 25 RTTs
+            if rtts_elapsed % 25 == 0 || total_bytes_transferred >= transfer_size {
+                println!(
+                    "  RTT {}: transferred {:.1}MB/{:.1}MB, cwnd={}KB, ssthresh={}KB, slowdowns={}",
+                    rtts_elapsed,
+                    total_bytes_transferred as f64 / (1024.0 * 1024.0),
+                    transfer_size as f64 / (1024.0 * 1024.0),
+                    snap.cwnd / 1024,
+                    ssthresh / 1024,
+                    snap.periodic_slowdowns
+                );
+            }
+        }
+
+        // Calculate results
+        let transfer_complete = total_bytes_transferred >= transfer_size;
+        let transfer_time_s = rtts_elapsed as f64 * rtt_ms as f64 / 1000.0;
+        let avg_throughput_per_rtt = total_bytes_transferred / rtts_elapsed.max(1);
+        let throughput_mbps =
+            (total_bytes_transferred as f64 * 8.0) / (transfer_time_s * 1_000_000.0);
+
+        println!("\n--- Results ---");
+        println!(
+            "Transfer complete: {} ({:.1}MB in {} RTTs = {:.1}s)",
+            if transfer_complete { "YES" } else { "NO" },
+            total_bytes_transferred as f64 / (1024.0 * 1024.0),
+            rtts_elapsed,
+            transfer_time_s
+        );
+        println!("Throughput: {:.1} Mbps", throughput_mbps);
+        println!(
+            "Avg cwnd/RTT: {}KB (min required: {}KB)",
+            avg_throughput_per_rtt / 1024,
+            min_avg_throughput_per_rtt / 1024
+        );
+        println!(
+            "Min ssthresh observed: {}KB (floor: {}KB)",
+            min_ssthresh_observed / 1024,
+            min_ssthresh / 1024
+        );
+        println!("Total slowdowns: {}", max_slowdowns_observed);
+        println!("RTTs with ssthresh below floor: {}", snapshots_below_floor);
+
+        // Assertions
+        assert!(
+            transfer_complete,
+            "Transfer did not complete in {} RTTs ({:.1}s)! \
+             Only transferred {:.1}MB of {:.1}MB. \
+             This indicates a throughput problem on high-latency paths. \
+             Check: ssthresh floor enforcement, cwnd growth, slowdown frequency.",
+            max_rtts,
+            transfer_time_s,
+            total_bytes_transferred as f64 / (1024.0 * 1024.0),
+            transfer_size as f64 / (1024.0 * 1024.0)
+        );
+
+        assert!(
+            avg_throughput_per_rtt >= min_avg_throughput_per_rtt,
+            "Average throughput {}KB/RTT below minimum {}KB/RTT required for acceptable transfer speed",
+            avg_throughput_per_rtt / 1024,
+            min_avg_throughput_per_rtt / 1024
+        );
+
+        assert_eq!(
+            snapshots_below_floor, 0,
+            "ssthresh fell below min_ssthresh floor {} times! \
+             This indicates the floor is not being enforced in all code paths.",
+            snapshots_below_floor
+        );
+
+        // Warn if close to the limit (indicates fragile throughput)
+        if rtts_elapsed > max_rtts * 3 / 4 {
+            println!(
+                "WARNING: Transfer used {}% of RTT budget - throughput is marginal",
+                rtts_elapsed * 100 / max_rtts
+            );
+        }
+
+        println!(
+            "\n✓ Large transfer test PASSED: {:.1}MB in {:.1}s ({:.1} Mbps)",
+            transfer_size as f64 / (1024.0 * 1024.0),
+            transfer_time_s,
+            throughput_mbps
         );
     }
 }


### PR DESCRIPTION
## Problem

On high-latency paths (e.g., 135ms RTT between Germany and USA), River UI retrieval was taking 20+ seconds for a ~2.5MB contract. Telemetry showed `slowdowns_triggered: 1, total_timeouts: 0` - indicating the issue was with periodic slowdowns, not packet loss/timeouts.

Investigation revealed that `ssthresh` was being reduced to ~37KB by periodic slowdowns, preventing `cwnd` from growing past that point. This happened despite `min_ssthresh` being configured to 100KB as a floor.

### Root Cause

The periodic slowdown handler sets `ssthresh = current_cwnd` without applying the `min_ssthresh` floor:

```rust
// Line ~1382 - BUG: no floor applied
self.ssthresh.store(current_cwnd, Ordering::Release);
```

But the timeout handler correctly applies the floor:

```rust
// Line ~1718-1720 - CORRECT
let floor = self.calculate_adaptive_floor();
let new_ssthresh = (old_cwnd / 2).max(floor);
```

This asymmetry defeated PR #2619's fix ("allow cwnd to grow up to ssthresh on high-latency paths") because if `ssthresh` itself gets reduced below `min_ssthresh` by periodic slowdowns, cwnd is capped at that low value.

### Why CI Didn't Catch This

All existing `min_ssthresh` floor tests use `inject_timeout()` to trigger the floor check. No test triggered a natural periodic slowdown and verified the floor was applied. The test coverage gap was:
- Tests with `enable_periodic_slowdown: true` either immediately called `inject_timeout()` or didn't verify ssthresh stayed above the floor after slowdown.

## Solution

Apply the same floor calculation in the periodic slowdown handler as in the timeout handler:

```rust
let floor = self.calculate_adaptive_floor();
let new_ssthresh = current_cwnd.max(floor);
self.ssthresh.store(new_ssthresh, Ordering::Release);
```

## Testing

Added regression test `test_periodic_slowdown_applies_min_ssthresh_floor` which:
1. Configures LEDBAT with `min_ssthresh: 200KB` floor
2. Sets initial `ssthresh: 50KB` to force slow start exit at ~50KB (below floor)
3. Runs until natural periodic slowdown triggers via `run_until_slowdown()`
4. Asserts `ssthresh >= min_ssthresh` after the slowdown

**Before fix:** Test fails with `ssthresh=100KB < floor=200KB`
**After fix:** Test passes with `ssthresh=200KB >= floor=200KB`

All 148 LEDBAT tests pass.

## Impact

This fix ensures that on high-BDP paths:
- Periodic slowdowns respect the `min_ssthresh` floor (same as timeouts)
- `cwnd` can grow up to the configured floor even after slowdowns
- Combined with PR #2619, transfers on high-latency paths should achieve reasonable throughput

[AI-assisted - Claude]