### PR TITLE
fix: make delegate request error handling resilient

### DIFF
--- a/crates/core/benches/transport/slow_start.rs
+++ b/crates/core/benches/transport/slow_start.rs
@@ -42,6 +42,7 @@ pub fn bench_cold_start_throughput(c: &mut Criterion) {
 
     // Use 16KB only - larger sizes timeout with mock transport
     // (The mock transport is reliable only for smaller messages in benchmark context)
+    #[allow(clippy::single_element_loop)]
     for &transfer_size_kb in &[16] {
         let transfer_size = transfer_size_kb * 1024;
         group.throughput(Throughput::Bytes(transfer_size as u64));

--- a/crates/core/src/contract/mod.rs
+++ b/crates/core/src/contract/mod.rs
@@ -347,7 +347,8 @@ where
                             phase = "unexpected_response",
                             "Unexpected response type from delegate request"
                         );
-                        return Err(ContractError::NoEvHandlerResponse);
+                        // Don't crash the node - log and continue with empty response
+                        Vec::new()
                     }
                     Err(err) => {
                         tracing::error!(
@@ -356,7 +357,10 @@ where
                             phase = "execution_failed",
                             "Failed executing delegate request"
                         );
-                        return Err(ContractError::NoEvHandlerResponse);
+                        // Don't crash the node - log and continue with empty response.
+                        // This can happen during startup if stale delegate state references
+                        // data that is no longer valid (e.g., missing attested contract).
+                        Vec::new()
                     }
                 };
 


### PR DESCRIPTION
## Problem

When a delegate request fails during execution (e.g., due to stale state or missing attested contract), the node crashes with `ContractError::NoEvHandlerResponse`. This was observed on the technic peer after PR #2617 changed auth token handling from HTTP parameter to HTML injection - the peer was crash-looping because old delegate state expected attested contracts that were no longer available.

## Why CI didn't catch this

This issue manifests when:
1. A node has persisted delegate state from a previous version
2. A new version changes how attested contracts are provided
3. On startup, the old delegate state tries to process with the new code path

CI tests always start fresh without persisted state, so this upgrade path isn't tested.

## Solution

Make delegate request error handling resilient:
- Log the error but don't crash the node
- Return an empty response and continue processing other requests
- This allows the node to start even if some stale delegate state is invalid

The failing delegate will eventually be cleaned up or re-registered correctly, but the node remains operational.

## Testing

- Manual validation: Fixed the crash-looping technic peer
- The change is minimal and doesn't affect the happy path

## Other

Also fixes a pre-existing clippy lint in a benchmark file (`single_element_loop`).

[AI-assisted - Claude]