### PR TITLE
build: release v0.1.87

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.60"
+version = "0.3.61"
 dependencies = [
  "anyhow",
  "axum",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.86"
+version = "0.1.87"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.86"
+version = "0.1.87"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.60"
+version = "0.3.61"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary

Release v0.1.87 - critical bug fix for delegate request handling.

### Changes in this release:
- **fix: make delegate request error handling resilient** (#2630)
  - Don't crash the node when a delegate request fails during event log replay
  - Log errors and continue with empty response instead of crashing
  - This fixes crash-looping on peers with stale delegate state referencing missing attested contracts

### Version bumps:
- freenet: 0.1.86 → 0.1.87
- fdev: 0.3.60 → 0.3.61

🤖 Generated with [Claude Code](https://claude.com/claude-code)