### PR TITLE
build: release v0.1.88

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.61"
+version = "0.3.62"
 dependencies = [
  "anyhow",
  "axum",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.87"
+version = "0.1.88"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.61"
+version = "0.3.62"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary
Release v0.1.88

### Changes since v0.1.87:
- perf: reduce minimum RTO to 200ms and add TLP (Tail Loss Probe) (#2645)
- fix(websocket): handle stale auth tokens gracefully after node restart (#2644)
- Various dependency updates

### Version bumps:
- freenet: 0.1.87 → 0.1.88
- fdev: 0.3.61 → 0.3.62