### PR TITLE
build: release v0.1.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.62"
+version = "0.3.63"
 dependencies = [
  "anyhow",
  "axum",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.88"
+version = "0.1.89"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.62"
+version = "0.3.63"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary
Release v0.1.89

### Changes since v0.1.88:
- fix: put broadcasts to subscribers based on subscription tree, not seeding cache (#2657)
- fix: transaction ID convergence checking logic (#2653)
- fix: enable DST removing all sources of non-determinism (#2635)
- refactor(transport): split ledbat.rs into modular subfiles (#2648)
- refactor(transport): reorganize unit tests across split modules (#2655)
- test(dst): add multi-gateway determinism test and Matrix notifications (#2658)
- test(dst): run determinism test 3 times for safety (#2652)
- chore: remove ignore flag from determinism test (#2654)

### Version bumps:
- freenet: 0.1.88 → 0.1.89
- fdev: 0.3.62 → 0.3.63