### PR TITLE
build: release v0.1.90

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "anyhow",
  "axum",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.89"
+version = "0.1.90"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.89"
+version = "0.1.90"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.63"
+version = "0.3.64"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary
Release v0.1.90

### Changes since v0.1.89:
- feat: implement connection backoff for ConnectOp failures (#2663)
- fix: re-seed network when Subscribe receives NotFound but has local cache (#2665)
- test: polish DST tests and fdev framework fixes (#2662)
- Various Matrix notification fixes for nightly simulation
- build(deps): bump tracing-subscriber, rsa

### Version bumps:
- freenet: 0.1.89 → 0.1.90
- fdev: 0.3.63 → 0.3.64