### PR TITLE
fix: allow bidirectional peer relationships in subscription tree

### DIFF
--- a/apps/freenet-email-app/Cargo.toml
+++ b/apps/freenet-email-app/Cargo.toml
@@ -20,5 +20,5 @@ serde = "1"
 serde_json = "1"
 
 # freenet-stdlib = { version = "0.1.24" }
-freenet-stdlib = { version = "0.1.24" }
+freenet-stdlib = { version = "0.1.30" }
 freenet-aft-interface = { path = "../../modules/antiflood-tokens/interfaces" }

--- a/apps/freenet-microblogging/Cargo.toml
+++ b/apps/freenet-microblogging/Cargo.toml
@@ -14,7 +14,7 @@ panic = 'abort'
 strip = true
 
 [workspace.dependencies]
-freenet-stdlib = { version = "0.1.24", default-features = false, features = ["contract"] }
+freenet-stdlib = { version = "0.1.30", default-features = false, features = ["contract"] }
 
 #[target.wasm32-unknown-unknown]
 #rustflags = ["-C", "link-arg=--import-memory"]

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.85"
+version = "0.1.91"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/apps/freenet-ping/Cargo.toml
+++ b/apps/freenet-ping/Cargo.toml
@@ -4,7 +4,7 @@ members = ["contracts/ping", "app", "types"]
 
 [workspace.dependencies]
 # freenet-stdlib = { path = "./../../stdlib/rust", features = ["contract"] }
-freenet-stdlib = { version = "0.1.24" }
+freenet-stdlib = { version = "0.1.30" }
 freenet-ping-types = { path = "types", default-features = false }
 chrono = { version = "0.4", default-features = false }
 clap = "4"

--- a/apps/freenet-ping/app/Cargo.toml
+++ b/apps/freenet-ping/app/Cargo.toml
@@ -10,7 +10,7 @@ testing = ["freenet-stdlib/testing", "freenet/testing"]
 anyhow = "1.0"
 chrono = { workspace = true, features = ["default"] }
 clap = { workspace = true, features = ["derive"] }
-freenet-stdlib = { version = "0.1.24", features = ["net"] }
+freenet-stdlib = { version = "0.1.30", features = ["net"] }
 freenet-ping-types = { path = "../types", features = ["std", "clap"] }
 futures = "0.3.31"
 rand = "0.9.2"

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -698,7 +698,6 @@ impl Ring {
     ///
     /// # Errors
     /// - `SelfReference`: The subscriber address matches our own address
-    /// - `CircularReference`: The subscriber is already our upstream for this contract
     /// - `MaxSubscribersReached`: Maximum downstream subscribers limit reached
     pub fn add_downstream(
         &self,
@@ -715,7 +714,6 @@ impl Ring {
     ///
     /// # Errors
     /// - `SelfReference`: The upstream address matches our own address
-    /// - `CircularReference`: The upstream is already in our downstream list for this contract
     pub fn set_upstream(
         &self,
         contract: &ContractKey,


### PR DESCRIPTION
## Problem

Issue #2634: Peers subscribed to the same contract were not reaching eventual consistency.

When 3 nodes (Gateway, Node1, Node2) subscribed to the same contract, Node1 would not receive updates from Node2. The root cause was that `add_downstream()` and `set_upstream()` rejected "circular references" - when a peer was already upstream, it couldn't be added as downstream (and vice versa).

This rejection was incorrect because a peer CAN legitimately be both upstream AND downstream simultaneously. Network routing decisions may cause this bidirectional relationship, and it's valid.

## Solution

Remove the circular reference checks in `add_downstream()` and `set_upstream()`. This is safe because:

1. **Update propagation already filters the sender** - `get_broadcast_targets_update()` excludes the sender from broadcast targets (lines 693, 715, 732 in update.rs), preventing echo/loops
2. **Tree structure is preserved** - upstream remains unique per node (only one source of updates)
3. **Bidirectional relationships are valid** - a peer can receive updates FROM us (downstream) while we also receive updates FROM them (upstream)

## Changes

- `ring/seeding.rs`: Remove `CircularReference` check in `add_downstream()` and `set_upstream()`
- `ring/seeding.rs`: Remove `CircularReference` variant from `SubscriptionError`
- `ring/seeding.rs`: Add tests verifying bidirectional subscriptions work
- `ring/mod.rs`: Update docstrings

## Testing

- 38 unit tests pass in `ring::seeding::tests`
- Integration test `test_ping_multi_node` shows updates flowing correctly between all 3 nodes (logs show merged state with `ping-from-gw`, `ping-from-node1`, `ping-from-node2`)

## Fixes

Closes #2634