### PR TITLE
build: release v0.1.92

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.65"
+version = "0.3.66"
 dependencies = [
  "anyhow",
  "axum",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.91"
+version = "0.1.92"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.65"
+version = "0.3.66"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary
Release v0.1.92

### Changes since v0.1.91:
- feat(transport): add BBRv3 congestion control as default (#2674)
- feat(transport): add congestion control interface for algorithm selection (#2672)
- feat: add delta-based state synchronization (#2667)
- fix: allow bidirectional peer relationships in subscription tree (#2677)
- fix(fdev): increase network publish timeout and improve feedback (#2676)
- fix: re-enable replica_validation_and_stepwise_consistency test (#2678)

### Version bumps:
- freenet: 0.1.91 → 0.1.92
- fdev: 0.3.65 → 0.3.66