### PR TITLE
feat(bench): make congestion control configurable in benchmarks

### DIFF
--- a/crates/core/benches/transport/common.rs
+++ b/crates/core/benches/transport/common.rs
@@ -98,7 +98,10 @@ pub fn get_congestion_config() -> CongestionControlConfig {
 /// Call this at the start of benchmark runs to show which algorithm is being tested.
 pub fn print_congestion_config() {
     let algo = get_congestion_algorithm();
-    eprintln!("Benchmark congestion control: {} (set FREENET_CONGESTION_ALGO to switch)", algo);
+    eprintln!(
+        "Benchmark congestion control: {} (set FREENET_CONGESTION_ALGO to switch)",
+        algo
+    );
 }
 
 // =============================================================================

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -419,33 +419,6 @@ impl<S: Socket> OutboundConnectionHandler<S, crate::simulation::VirtualTime> {
         Ok((connection_handler, new_connection_notifier))
     }
 
-    pub(crate) fn new_test_with_time_source(
-        socket_addr: SocketAddr,
-        socket: Arc<S>,
-        keypair: TransportKeypair,
-        is_gateway: bool,
-        bandwidth_limit: Option<usize>,
-        time_source: crate::simulation::VirtualTime,
-    ) -> Result<
-        (
-            Self,
-            mpsc::Receiver<PeerConnection<S, crate::simulation::VirtualTime>>,
-        ),
-        TransportError,
-    > {
-        Self::config_listener_with_virtual_time(
-            socket,
-            keypair,
-            is_gateway,
-            socket_addr,
-            bandwidth_limit,
-            None,
-            None,
-            time_source,
-            None,
-        )
-    }
-
     /// Create a test connection handler with VirtualTime and custom congestion control.
     ///
     /// This allows benchmarks to test with different congestion control algorithms.
@@ -1630,9 +1603,7 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                                             let congestion_controller = congestion_config
                                                 .clone()
                                                 .unwrap_or_default()
-                                                .build_arc_with_time_source(
-                                                    time_source.clone(),
-                                                );
+                                                .build_arc_with_time_source(time_source.clone());
 
                                             // Initialize token bucket
                                             // Use global bandwidth manager if configured


### PR DESCRIPTION
Benchmarks now use BBR by default (the production default) and support switching to LEDBAT via the FREENET_CONGESTION_ALGO environment variable.

Changes:
- Add congestion_config field to UdpPacketsListener for custom congestion control in test/bench connections
- Add create_mock_peer_with_congestion_config for benchmark peer creation
- Add get_congestion_config() helper in common.rs to read env var
- Update slow_start benchmarks to use configurable congestion control
- Print active algorithm at benchmark start for visibility

Usage:
Run with BBR (default):

cargo bench --bench transport_ci --features bench

Run with LEDBAT for comparison FREENET_CONGESTION_ALGO=ledbat

cargo bench --bench transport_ci --features bench