### PR TITLE
build: release v0.1.94

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "anyhow",
  "axum",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.93"
+version = "0.1.94"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.67"
+version = "0.3.68"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary
Release v0.1.94

### Changes since v0.1.93:
- feat: add fixed-rate congestion control as default (#2698)
- test(bbr): parametrize issue #2697 regression tests with rstest (#2703)
- test(bbr): add regression tests for issue #2697 timeout death spiral (#2702)
- chore: clean up, refactor and improve DST related tests (#2701)

### Version bumps:
- freenet: 0.1.93 → 0.1.94
- fdev: 0.3.67 → 0.3.68