### PR TITLE
build: release v0.1.95

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.68"
+version = "0.3.69"
 dependencies = [
  "anyhow",
  "axum",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.94"
+version = "0.1.95"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.94"
+version = "0.1.95"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.68"
+version = "0.3.69"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary
Release v0.1.95

### Changes since v0.1.94:
- fix(transport): preserve min_rtt on timeout to prevent death spiral (#2699)

### Version bumps:
- freenet: 0.1.94 → 0.1.95
- fdev: 0.3.68 → 0.3.69