### PR TITLE
build: release v0.1.96

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.69"
+version = "0.3.70"
 dependencies = [
  "anyhow",
  "axum",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.95"
+version = "0.1.96"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.95"
+version = "0.1.96"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.69"
+version = "0.3.70"
 edition = "2021"
 rust-version = "1.80"
 publish = true
@@ -44,7 +44,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 http = "1.4"
 
 # internal
-freenet = { path = "../core", version = "0.1.86" }
+freenet = { path = "../core", version = "0.1.96" }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary
Release v0.1.96

### Changes since v0.1.95:
- fix(transport): disable keepalive for VirtualTime to prevent spurious failures (#2707)
- fix(transport): increase token bucket burst capacity to fix localhost tests (#2708)

### Version bumps:
- freenet: 0.1.95 → 0.1.96
- fdev: 0.3.69 → 0.3.70

[AI-assisted - Claude]