### PR TITLE
fix: propagate contract errors to client in UPDATE operations

### DIFF
--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -825,7 +825,7 @@ async fn update_contract(
             ..
         }) => {
             tracing::error!(contract = %key, error = %err, phase = "error", "Failed to update contract value");
-            Err(OpError::UnexpectedOpState)
+            Err(err.into())
         }
         Ok(ContractHandlerEvent::UpdateNoChange { .. }) => {
             // Helper to extract state from UpdateData variants that contain state


### PR DESCRIPTION
## Problem

When a contract's `update_state` function returns an error (e.g., `ContractError::InvalidUpdateWithInfo { reason: "..." }`), the error was being discarded and replaced with a generic "unexpected operation state" error. This made debugging contract validation failures extremely difficult since the actual error message from the contract was lost.

**User impact:** When a River user tries to ban a member and the operation fails, they see:
```
Error: UPDATE operation failed: unexpected operation state
```
instead of the actual validation error from the contract (e.g., "Invalid delta: Invalid bans: ...").

**Why CI didn't catch this:** The contract error was still being logged on the gateway side, but not propagated to the client. The test infrastructure uses the client API and expects contract errors to be returned.

## This Solution

Change from:
```rust
Err(OpError::UnexpectedOpState)
```
to:
```rust
Err(err.into())
```

`OpError` already has a `ContractError` variant with `#[from]` (see line 315 in mod.rs):
```rust
#[error(transparent)]
ContractError(#[from] ContractError),
```

So `err.into()` correctly converts the `ContractError` to `OpError::ContractError(err)`, preserving all error details.

Note that `put.rs` already does this correctly at line 871:
```rust
Err(OpError::from(err))
```

This fix makes `update.rs` consistent with `put.rs`.

## Testing

- Verified that the existing tests still pass
- The contract error will now be visible to clients via the WebSocket API

[AI-assisted - Claude]