### PR TITLE
fix: increase blocked peers test timeout to prevent CI flakiness

### DIFF
--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.91"
+version = "0.1.96"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1353,6 +1365,7 @@ dependencies = [
  "hostname",
  "itertools 0.14.0",
  "libc",
+ "lru",
  "notify",
  "once_cell",
  "opentelemetry",
@@ -1698,6 +1711,17 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "headers"
@@ -2340,6 +2364,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-cache"

--- a/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
+++ b/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
@@ -874,7 +874,10 @@ async fn test_ping_blocked_peers() -> TestResult {
     run_blocked_peers_test(BlockedPeersConfig {
         test_name: "baseline",
         initial_wait: Duration::from_secs(25),
-        operation_timeout: Duration::from_secs(45),
+        // Use 60s timeout to match solution test - 45s was causing flaky failures
+        // on busy CI machines where PUT operations take longer to complete.
+        // See issue #2712 for details.
+        operation_timeout: Duration::from_secs(60),
         update_rounds: 3,
         update_wait: Duration::from_secs(5),
         propagation_wait: Duration::from_secs(15),
@@ -893,7 +896,9 @@ async fn test_ping_blocked_peers_simple() -> TestResult {
     run_blocked_peers_test(BlockedPeersConfig {
         test_name: "simple",
         initial_wait: Duration::from_secs(25),
-        operation_timeout: Duration::from_secs(45),
+        // Use 60s timeout for consistency with other tests and to prevent flakiness
+        // on busy CI machines. See issue #2712 for details.
+        operation_timeout: Duration::from_secs(60),
         update_rounds: 1,
         update_wait: Duration::from_secs(5),
         propagation_wait: Duration::from_secs(15),


### PR DESCRIPTION
## Problem

The `test_ping_blocked_peers` test was failing intermittently in CI with:

```
error: anyhow::Error - Gateway put request timed out
```

This blocked PR #2711 (a simple one-line fix) until CI was manually rerun.

### Root Cause Analysis

From CI run [#21041134990](https://github.com/freenet/freenet-core/actions/runs/21041134990/job/60502986319):
- `test_ping_blocked_peers_solution` (60s timeout) → **passed**
- `test_ping_blocked_peers_simple` (45s timeout) → **passed**
- `test_ping_blocked_peers` (45s timeout) → **failed** with PUT timeout

The baseline test used a 45-second `operation_timeout`, but on busy CI machines the PUT operation can take longer due to resource contention. The solution test variant already uses 60 seconds and consistently passes.

### About the stretto cache errors

The CI logs showed many stretto cache errors:
```
[ERROR stretto::cache::sync] fail to handle clear event: fail to receive msg from channel...
```

These are **not the root cause** - they occur during shutdown when the async cache is dropped while background tasks are still running. Production code already suppresses these via `stretto=off` in the log filter. They're harmless noise that appears after the test failure.

## Solution

Increase `operation_timeout` from 45s to 60s for both `test_ping_blocked_peers` and `test_ping_blocked_peers_simple` tests, matching the timeout used by `test_ping_blocked_peers_solution` which has been reliable.

## Testing

- Ran `test_ping_blocked_peers` locally - passed in 52.51s
- All assertions pass and updates propagate correctly

## Fixes

Closes #2712

[AI-assisted - Claude]