### PR TITLE
fix: include all seeded contracts in orphan subscription recovery

### DIFF
--- a/crates/core/src/ring/seeding.rs
+++ b/crates/core/src/ring/seeding.rs
@@ -389,14 +389,20 @@ impl SeedingManager {
     }
 
     /// Get all contracts that we're seeding but don't have an upstream subscription for,
-    /// AND where we have active interest (local client subscriptions or downstream peers).
+    /// AND where we have active interest (local client subscriptions, downstream peers,
+    /// or an existing subscription entry indicating we're part of the subscription tree).
     ///
     /// These are contracts where we may be "isolated" from the subscription tree and
     /// should attempt to establish an upstream connection when possible.
     ///
-    /// IMPORTANT: We only want to re-subscribe if we have active interest. If a client
-    /// disconnects and pruning occurs, we should NOT try to re-subscribe just because
-    /// the contract is still in our cache.
+    /// A contract is considered to have active interest if ANY of:
+    /// - It has local client subscriptions (clients actively want updates)
+    /// - It has downstream peers (we need updates to forward to them)
+    /// - It has an existing subscription entry (we're part of the subscription tree
+    ///   and should recover our upstream connection, e.g., after upstream disconnected)
+    ///
+    /// Contracts that were intentionally pruned (no clients, no downstream, no entry)
+    /// should NOT be auto-recovered to avoid re-subscribing after cleanup.
     ///
     /// PERFORMANCE NOTE: This method iterates all seeded contracts. Callers should use
     /// `can_request_subscription()` to filter results before spawning subscription
@@ -408,7 +414,7 @@ impl SeedingManager {
 
         // Filter to contracts that:
         // 1. Don't have an upstream subscription
-        // 2. Have active interest (local clients OR downstream peers)
+        // 2. Have active interest (local clients, downstream peers, or subscription entry)
         let mut result: Vec<ContractKey> = seeded_contracts
             .into_iter()
             .filter(|key| {
@@ -424,7 +430,12 @@ impl SeedingManager {
                     .map(|subs| subs.iter().any(|e| e.role == SubscriberType::Downstream))
                     .unwrap_or(false);
 
-                has_clients || has_downstream
+                // Also check if we have any subscription entry at all - this means we were
+                // part of the subscription tree and should try to recover. This covers
+                // the case where we had upstream that disconnected but no clients/downstream.
+                let has_subscription_entry = self.subscriptions.contains_key(key);
+
+                has_clients || has_downstream || has_subscription_entry
             })
             .collect();
 
@@ -1591,7 +1602,7 @@ mod tests {
     // ========== Tests for contracts_without_upstream filtering ==========
 
     #[test]
-    fn test_contracts_without_upstream_requires_active_interest() {
+    fn test_contracts_without_upstream_requires_active_interest_or_subscription_entry() {
         use super::super::seeding_cache::AccessType;
 
         let manager = SeedingManager::new();
@@ -1600,11 +1611,12 @@ mod tests {
         // Add contract to cache (seeding it)
         manager.record_contract_access(contract, 1000, AccessType::Put);
 
-        // Contract is cached but has no active interest (no clients, no downstream)
+        // Contract is cached but has no active interest (no clients, no downstream, no subscription entry)
+        // This ensures intentionally pruned contracts don't get auto-recovered
         let contracts = manager.contracts_without_upstream();
         assert!(
             contracts.is_empty(),
-            "Should not include contracts without active interest"
+            "Contracts without active interest should not be recovered"
         );
 
         // Add a client subscription - now it has active interest
@@ -1613,6 +1625,46 @@ mod tests {
 
         let contracts = manager.contracts_without_upstream();
         assert_eq!(contracts.len(), 1);
+        assert_eq!(contracts[0], contract);
+    }
+
+    #[test]
+    fn test_contracts_without_upstream_includes_orphaned_subscription_entry() {
+        use super::super::seeding_cache::AccessType;
+
+        let manager = SeedingManager::new();
+        let contract = make_contract_key(1);
+        let upstream = test_peer_loc(1);
+
+        // Add contract to cache
+        manager.record_contract_access(contract, 1000, AccessType::Put);
+
+        // Set upstream (creates subscription entry)
+        manager
+            .set_upstream(&contract, upstream.clone(), None)
+            .unwrap();
+
+        // Verify it has upstream - should NOT be in the list
+        let contracts = manager.contracts_without_upstream();
+        assert!(
+            contracts.is_empty(),
+            "Contract with upstream should not be returned"
+        );
+
+        // Now simulate upstream disconnect: remove the upstream but keep the subscription entry
+        // This is what happens when upstream peer disconnects
+        if let Some(mut subs) = manager.subscriptions.get_mut(&contract) {
+            subs.retain(|e| e.role != SubscriberType::Upstream);
+        }
+
+        // Now the contract has a subscription entry (even if empty) but no upstream
+        // This represents an orphaned seeder that should be recovered
+        let contracts = manager.contracts_without_upstream();
+        assert_eq!(
+            contracts.len(),
+            1,
+            "Orphaned contract with subscription entry should be recovered"
+        );
         assert_eq!(contracts[0], contract);
     }
 


### PR DESCRIPTION
## Problem

Peer 2QagR9Wn3iQPNvVHW had `{is_seeding: true, upstream: null, downstream: []}` for 4+ hours. The `contracts_without_upstream()` filter at `seeding.rs:427` required client subscriptions OR downstream subscribers before considering a contract for upstream recovery. Seeders that lost their upstream connection but had no client subscriptions or downstream peers were never recovered, leaving them permanently orphaned.

## Root Cause

The `contracts_without_upstream()` method filtered seeded contracts to only include those with:
- Client subscriptions (`has_clients`), OR
- Downstream peers (`has_downstream`)

This logic excluded seeders that were part of the subscription tree (had a subscription entry) but lost their upstream due to network issues while having no clients or downstream.

## This Solution

Add a third condition to the active interest check: contracts with ANY subscription entry (even if the entry only has no upstream after disconnection) are now candidates for recovery.

The key insight is that having a subscription entry means the peer was part of the subscription tree and should try to recover its position. Contracts that were intentionally pruned (client disconnect → no downstream → send Unsubscribed) have their subscription entry removed during cleanup, so they won't be auto-recovered.

This maintains the existing pruning behavior while fixing the orphan recovery issue.

## Testing

- Added `test_contracts_without_upstream_includes_orphaned_subscription_entry` to verify orphaned entries are recovered
- Updated `test_contracts_without_upstream_requires_active_interest_or_subscription_entry` to verify intentionally pruned contracts aren't recovered
- All 39 seeding module tests pass
- All 1260 freenet lib tests pass
- Clippy and fmt checks pass

## Fixes

Closes #2719

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]