### PR TITLE
fix: respect transient flag for outbound connections

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2481,8 +2481,9 @@ impl P2pConnManager {
                     state.peer_backoff.record_success(peer_addr);
                 }
 
-                // For outbound connections, we always know who we're connecting to
-                self.handle_successful_connection(Some(peer), connection, state, None, false)
+                // For outbound connections, respect the transient flag from the handshake.
+                // Gateway connections should remain transient until CONNECT acceptance.
+                self.handle_successful_connection(Some(peer), connection, state, None, transient)
                     .await?;
             }
             HandshakeEvent::OutboundFailed {


### PR DESCRIPTION
## Problem

When a peer starts up and connects to gateways, outbound connections were immediately promoted to the ring topology on transport success. This happened **before** receiving any CONNECT acceptance from the remote peer.

This caused a state mismatch:
- **Joiner's view**: "I have a ring connection to the gateway"
- **Gateway's view**: "This is a transient connection (30s TTL)"

The consequence was that GET operations routed through these "ring connections" would fail because the gateway dropped the transient connection before responses could be delivered. Users would see their first GET requests timeout after 60 seconds, even though the gateway had successfully sent the response.

### Timeline of the bug (observed on technic.locut.us):
```
21:44:53.795  Outbound connection established, transient=false (hardcoded!)
21:44:53.795  handle_successful_connection: promoting connection into ring
21:45:09     GET request sent through "ring connection"
21:45:09     Gateway sends 3.7MB response
21:45:23     Gateway drops transient connection (30s TTL expired)
21:45:54     BIDIRECTIONAL LIVENESS FAILURE detected
21:46:13     GET times out (response never received)
```

### Why CI didn't catch this

The 6-peer simulation test uses a controlled environment where all peers successfully complete CONNECT handshakes. The bug only manifests when:
1. A gateway refuses to accept a direct connection (routes uphill instead)
2. The joiner tries to use that connection for non-CONNECT operations

This is a startup race condition that's hard to reproduce in deterministic tests.

## Approach

The fix is minimal: use the `transient` flag from the `OutboundEstablished` event instead of hardcoding `false`.

```rust
// Before (line 2485)
self.handle_successful_connection(Some(peer), connection, state, None, false)

// After
self.handle_successful_connection(Some(peer), connection, state, None, transient)
```

Gateway connections should remain transient until CONNECT acceptance is received. The `transient` flag is already correctly set by the handshake layer; it was just being ignored.

### Alternative considered

Adding a minimum connection age before routing operations through it. Rejected because:
- Arbitrary delay doesn't actually verify bidirectional communication
- The transient flag mechanism already exists for this exact purpose

## Testing

- [x] `cargo fmt --check` - passed
- [x] `cargo clippy --all-targets --all-features -p freenet` - passed  
- [x] `cargo test -p freenet --lib` - 1278 tests passed

Manual verification: The River UI was failing to load on technic.locut.us due to this bug. After this fix, gateway connections will remain transient and won't be used for routing until properly promoted via CONNECT acceptance.

[AI-assisted - Claude]