### PR TITLE
fix: make connectivity check async and advance VirtualTime

### DIFF
--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -1078,7 +1078,7 @@ fn test_high_latency_timeout_regression() {
         }
 
         // Check connectivity with a longer timeout due to high latency
-        match sim.check_partial_connectivity(Duration::from_secs(60), 0.5) {
+        match sim.check_partial_connectivity(Duration::from_secs(60), 0.5).await {
             Ok(()) => {
                 tracing::info!("High-latency network established connectivity");
             }

--- a/crates/core/tests/simulation_smoke.rs
+++ b/crates/core/tests/simulation_smoke.rs
@@ -184,7 +184,7 @@ async fn test_smoke_small_network() {
     );
 
     // Check partial connectivity
-    match sim.check_partial_connectivity(Duration::from_secs(10), 0.5) {
+    match sim.check_partial_connectivity(Duration::from_secs(10), 0.5).await {
         Ok(()) => {
             tracing::info!("Small network achieved connectivity");
         }

--- a/crates/fdev/src/testing/network.rs
+++ b/crates/fdev/src/testing/network.rs
@@ -208,7 +208,7 @@ pub async fn start_server(supervisor: Arc<Supervisor>) -> Result<(), NetworkSimu
 pub async fn run_network(
     supervisor: Arc<Supervisor>,
     test_config: &TestConfig,
-    network: SimNetwork,
+    mut network: SimNetwork,
 ) -> Result<(), Error> {
     tracing::info!("Starting network");
 
@@ -238,7 +238,9 @@ pub async fn run_network(
             connectivity_timeout.as_millis(),
             network_connection_percent * 100.0
         );
-        network.check_partial_connectivity(connectivity_timeout, network_connection_percent)?;
+        network
+            .check_partial_connectivity(connectivity_timeout, network_connection_percent)
+            .await?;
         // FIXME: we are getting connectivity check that is not real since peers are not reporting if they
         // are connected or not to other peers
         tracing::info!("Network is sufficiently connected, start sending events");

--- a/crates/fdev/src/testing/single_process.rs
+++ b/crates/fdev/src/testing/single_process.rs
@@ -28,7 +28,8 @@ pub(super) async fn run(config: &super::TestConfig) -> anyhow::Result<(), super:
         network_connection_percent * 100.0
     );
     simulated_network
-        .check_partial_connectivity(connectivity_timeout, network_connection_percent)?;
+        .check_partial_connectivity(connectivity_timeout, network_connection_percent)
+        .await?;
 
     // event_chain now borrows &mut self, so we can still access simulated_network after
     // Use Option so we can drop the stream when events complete, signaling peers to disconnect


### PR DESCRIPTION
The connectivity check was using std::time::Instant (real wall-clock time) but never advanced VirtualTime. Since simulations use VirtualTime for deterministic message delivery, connection handshake messages were never delivered, causing connectivity checks to fail with "found disconnected nodes".

This change:
- Makes check_connectivity and check_partial_connectivity async
- Changes them to take &mut self instead of &self
- Advances VirtualTime in small steps (100ms) during the check
- Yields to tokio to allow tasks to process delivered messages
- Adds small real-time sleeps to prevent CPU spinning

This enables the connectivity check to actually wait for connections to be established in VirtualTime-based simulations.

Part of fix for #2725