### PR TITLE
ci: add concurrency to cancel duplicate cross-compile runs on main

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -7,6 +7,11 @@ on:
     branches: [main]
     tags: ['v*']
 
+# Cancel in-progress runs when a new commit is pushed to main
+concurrency:
+  group: cross-compile-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-x86_64-linux:
     name: Build for x86_64-unknown-linux-musl


### PR DESCRIPTION
Add concurrency settings to cross-compile.yml to automatically cancel in-progress workflow runs when a new push occurs to main. This matches the existing behavior in benchmarks.yml and benchmarks-extended.yml.