### PR TITLE
perf: optimize simulation test timing for faster execution

### DIFF
--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -1981,8 +1981,9 @@ impl SimNetwork {
             // Yield to tokio so tasks can process delivered messages
             tokio::task::yield_now().await;
 
-            // Small real-time sleep to allow task scheduling without spinning CPU
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            // Minimal real-time sleep to allow task scheduling without spinning CPU
+            // Reduced from 10ms to 1ms for faster simulation execution
+            tokio::time::sleep(Duration::from_millis(1)).await;
 
             // Check which nodes have connected
             for node in self.number_of_gateways..num_nodes + self.number_of_gateways {

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -1235,7 +1235,7 @@ const MULTI_SUBSCRIBER_NETWORK: &str = "multi-subscriber-test";
 ///
 /// # Timing
 /// - `step`: 100ms virtual time advancement per iteration
-/// - Real-time sleep: 10ms per iteration to allow task scheduling
+/// - Real-time sleep: 1ms per iteration to allow task scheduling (reduced from 10ms)
 async fn let_network_run_for_topology(sim: &mut SimNetwork, duration: Duration) {
     let step = Duration::from_millis(100);
     let mut elapsed = Duration::ZERO;
@@ -1245,8 +1245,8 @@ async fn let_network_run_for_topology(sim: &mut SimNetwork, duration: Duration) 
         sim.advance_time(step);
         // Yield to tokio so tasks can process delivered messages
         tokio::task::yield_now().await;
-        // Also give a small real-time sleep for task scheduling
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        // Minimal real-time sleep for task scheduling (reduced from 10ms to 1ms)
+        tokio::time::sleep(Duration::from_millis(1)).await;
         elapsed += step;
     }
 }

--- a/crates/core/tests/simulation_smoke.rs
+++ b/crates/core/tests/simulation_smoke.rs
@@ -35,8 +35,8 @@ async fn let_network_run(sim: &mut SimNetwork, duration: Duration) {
         sim.advance_time(step);
         // Yield to tokio so tasks can process delivered messages
         tokio::task::yield_now().await;
-        // Also give a small real-time sleep for task scheduling
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        // Minimal real-time sleep for task scheduling (reduced from 10ms to 1ms)
+        tokio::time::sleep(Duration::from_millis(1)).await;
         elapsed += step;
     }
 }


### PR DESCRIPTION
The simulation tests were taking too long due to real-time sleeps that
didn't contribute to simulation correctness. This change significantly
reduces test execution time by:

1. **Event wait time (biggest improvement)**: Replace the 200ms real-time
   sleep between events with VirtualTime advancement + 1ms yield sleep.
   Previously: 2000 events × 200ms = 400 seconds (6.7 minutes)
   Now: 2000 events × 1ms = 2 seconds + VirtualTime simulation

2. **Connectivity check delay**: Reduce the real-time sleep from 10ms to
   1ms per iteration. The sleep is only needed to prevent busy-looping
   and allow the tokio scheduler to run tasks.

3. **Post-connectivity stabilization**: Reduce real-time sleep from 10ms
   to 1ms per iteration (600 iterations × 10ms = 6s → 600ms).

4. **Convergence polling**: Reduce from 500ms to 100ms for faster
   completion detection.

The key insight is that the VirtualTime system handles all the simulation
timing for message delivery. The real-time sleeps are only needed for:
- Yielding to the tokio scheduler to let tasks process messages
- Preventing busy-looping (1ms is sufficient)

Test files updated to match the new timing approach.