### PR TITLE
fix: record subscription failure when set_upstream fails for backoff

### DIFF
--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -998,6 +998,8 @@ impl Operation for SubscribeOp {
                                         upstream = %sender_addr,
                                         "SUBSCRIPTION_UPSTREAM_MISSING: failed to find upstream peer after retries"
                                     );
+                                    // Issue #2741: Record failure for backoff, same as set_upstream failure
+                                    op_manager.ring.complete_subscription_request(key, false);
                                 }
                             } else {
                                 tracing::warn!(
@@ -1005,6 +1007,8 @@ impl Operation for SubscribeOp {
                                     contract = %format!("{:.8}", key),
                                     "SUBSCRIPTION_NO_SOURCE_ADDR: no source address for upstream registration"
                                 );
+                                // Issue #2741: Record failure for backoff, same as set_upstream failure
+                                op_manager.ring.complete_subscription_request(key, false);
                             }
 
                             // Forward response to requester or complete


### PR DESCRIPTION
## Problem

When `set_upstream` fails (e.g., due to circular reference detection), the peer is left without an upstream but may have downstream subscribers. Before this fix, the failure was only logged but not recorded in the subscription tracking system.

This meant:
1. No backoff was applied for the failed contract
2. The same subscription could be attempted immediately again
3. Immediate retry would likely hit the same problematic peer (same routing)

### User Impact
"Disconnected upstream seeders" - peers that can forward updates to their downstream but can't receive updates themselves, creating stale branches in the subscription tree.

## Approach

When `set_upstream` fails, call `complete_subscription_request(key, false)` to record the failure:

1. **Applies backoff** - The standard subscription backoff mechanism kicks in
2. **Prevents spam** - Can't immediately retry the same problematic subscription
3. **Leverages existing recovery** - The periodic orphan recovery (every 30s, improved by PR #2740) will detect these contracts and attempt recovery through potentially different routing

### Why not immediate recovery?

I initially implemented `trigger_subscription_recovery` for immediate retry, but removed it because:
1. **Same routing problem** - Immediate retry would likely select the same problematic peer
2. **Potential infinite loop** - Without routing changes, it keeps failing
3. **Network dynamics** - By the next recovery cycle, topology may have changed favorably

## Testing

- Unit tests pass (1280 tests)
- The fix integrates with existing backoff/recovery mechanisms
- PR #2740 (merged) ensures orphan recovery finds contracts in this state

### Note on `test_bidirectional_cycle_issue_2720`

The ignored test still fails the `disconnected_upstream` check because:
- Test runs ~14 seconds
- Periodic recovery needs 30+ seconds to trigger

This is expected - the fix provides eventual consistency (within one recovery cycle) rather than immediate resolution. Immediate resolution would require smarter routing that tracks and avoids peers causing circular references.

Closes #2741

[AI-assisted - Claude]