### PR TITLE
test: use Turmoil for deterministic topology tests

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -74,10 +74,11 @@ pub mod dev_tool {
     pub use node::{
         testing_impl::{
             check_convergence_from_logs, run_turmoil_simulation, ContractDistribution,
-            ControlledEventChain, ConvergedContract, ConvergenceResult, DivergedContract,
-            EventChain, EventSummary, NetworkPeer, NodeLabel, OperationStats, OperationSummary,
-            PeerMessage, PeerStatus, PutOperationStats, RunningNode, ScheduledOperation,
-            SimNetwork, SimOperation, TurmoilConfig, TurmoilResult, UpdateOperationStats,
+            ControlledEventChain, ControlledSimulationResult, ConvergedContract, ConvergenceResult,
+            DivergedContract, EventChain, EventSummary, NetworkPeer, NodeLabel, OperationStats,
+            OperationSummary, PeerMessage, PeerStatus, PutOperationStats, RunningNode,
+            ScheduledOperation, SimNetwork, SimOperation, TurmoilConfig, TurmoilResult,
+            UpdateOperationStats,
         },
         InitPeerNode, NetworkStats, NodeConfig, PeerId,
     };
@@ -89,7 +90,8 @@ pub mod dev_tool {
         clear_all_topology_snapshots, clear_current_network_name, clear_topology_snapshots,
         get_all_topology_snapshots, get_current_network_name, get_topology_snapshot,
         register_topology_snapshot, set_current_network_name, validate_topology,
-        ContractSubscription, ProximityViolation, TopologySnapshot, TopologyValidationResult,
+        validate_topology_from_snapshots, ContractSubscription, ProximityViolation,
+        TopologySnapshot, TopologyValidationResult,
     };
     pub use wasm_runtime::{ContractStore, DelegateStore, Runtime, SecretsStore, StateStore};
 
@@ -127,6 +129,7 @@ pub mod dev_tool {
     /// - Socket registries
     /// - Address network mappings
     /// - Simulation time
+    /// - Topology snapshots
     pub fn reset_all_simulation_state() {
         // Reset RNG (caller should set seed after this)
         crate::config::GlobalRng::clear_seed();
@@ -148,6 +151,9 @@ pub mod dev_tool {
         crate::transport::in_memory_socket::clear_all_address_networks();
         crate::transport::in_memory_socket::clear_all_network_time_sources();
         crate::node::clear_all_fault_injectors();
+
+        // Clear topology snapshots from previous simulation runs
+        crate::ring::topology_registry::clear_all_topology_snapshots();
     }
 }
 

--- a/crates/core/src/ring/topology_registry.rs
+++ b/crates/core/src/ring/topology_registry.rs
@@ -205,6 +205,21 @@ pub fn validate_topology(
     contract_location: f64,
 ) -> TopologyValidationResult {
     let snapshots = get_all_topology_snapshots(network_name);
+    validate_topology_from_snapshots(&snapshots, contract_id, contract_location)
+}
+
+/// Validates the subscription topology for a contract from provided snapshots.
+///
+/// Use this variant when you have captured snapshots and the global registry
+/// may have been cleared (e.g., after SimNetwork::Drop).
+///
+/// Same validation as `validate_topology` but operates on the provided snapshots
+/// instead of fetching from the global registry.
+pub fn validate_topology_from_snapshots(
+    snapshots: &[TopologySnapshot],
+    contract_id: &ContractInstanceId,
+    contract_location: f64,
+) -> TopologyValidationResult {
     let mut result = TopologyValidationResult::default();
 
     // Build a map of peer -> (upstream, downstream) for this contract
@@ -213,7 +228,7 @@ pub fn validate_topology(
     let mut peer_locations: HashMap<SocketAddr, f64> = HashMap::new();
     let mut seeders: HashSet<SocketAddr> = HashSet::new();
 
-    for snapshot in &snapshots {
+    for snapshot in snapshots {
         peer_locations.insert(snapshot.peer_addr, snapshot.location);
 
         if let Some(sub) = snapshot.contracts.get(contract_id) {


### PR DESCRIPTION
## Problem

The simulation integration tests (`test_bidirectional_cycle`, `test_topology_single_seeder`) were using `#[tokio::test]` which runs outside of Turmoil's controlled simulation environment. This caused non-deterministic behavior because:

1. Time was not controlled by Turmoil's virtual time
2. Network operations were not going through Turmoil's simulated network
3. Random number generation was not properly seeded

The tests appeared to pass but were not exercising the deterministic simulation machinery correctly.

## Solution

Refactored the tests to use the proper Turmoil pattern:

1. **Sync test entry point**: Changed from async `#[tokio::test]` to sync `#[test_log::test]` with `create_runtime()` - this ensures we're using Turmoil's runtime, not tokio's
2. **New `run_controlled_simulation()` method**: Runs inside Turmoil's controlled environment with proper deterministic time control
3. **New `get_peer_locations()` method**: Retrieves peer locations without consuming the builder (needed for snapshot capture)
4. **New `ControlledSimulationResult` struct**: Captures topology snapshots before `SimNetwork::Drop` clears the registry
5. **New `validate_topology_from_snapshots()` function**: Works with captured snapshots instead of relying on global registry state

This pattern ensures:
- All network operations go through Turmoil's simulated network
- Time advances deterministically via `sim.run()`
- Random number generation uses seeded RNG
- Topology state is captured while still valid

## Changes

- `crates/core/src/lib.rs` - Export new functions
- `crates/core/src/node/testing_impl.rs` - Add `run_controlled_simulation()`, `get_peer_locations()`, `ControlledSimulationResult`
- `crates/core/src/ring/topology_registry.rs` - Add `validate_topology_from_snapshots()`
- `crates/core/tests/simulation_integration.rs` - Update tests to use new pattern

## Test Results

The `test_bidirectional_cycle` test now passes with:
- **cycles=0** - Confirms the fix from #2720 works correctly
- **orphans=1, disconnected=1** - Known issues tracked in #2755 (separate problem)

## Related

- Verifies fix from #2720 (bidirectional cycle bug)
- Documents known issues in #2755 (orphan/disconnected seeder issues - separate problem to address)