### PR TITLE
fix: make topology tests robust to non-deterministic peer locations

### DIFF
--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -1287,7 +1287,7 @@ fn test_topology_single_seeder() {
     // Note: get_peer_locations() returns locations from SimNetwork config, but actual
     // running nodes may have different locations due to how ConnectionManager is initialized.
     // We use a fixed contract seed and validate based on actual topology snapshot locations.
-    // See: https://github.com/freenet/freenet-core/issues/2755 for related determinism issues.
+    // See: https://github.com/freenet/freenet-core/issues/2759 for the peer location non-determinism issue.
     let _ = gateway_location; // Silence unused variable warning
 
     // Use a fixed contract seed - we'll determine source status from actual topology


### PR DESCRIPTION
## Problem

After PR #2756 merged, the big-picture review agent found that `test_topology_single_seeder` was failing. Investigation revealed a non-determinism issue:

- `get_peer_locations()` returns locations from `SimNetwork`'s `NodeConfig.location`
- But actual running nodes get their locations from `ConnectionManager.own_location()`
- These can differ, causing the test's "gateway is source" calculation to be wrong

This meant the test could pass or fail depending on whether the gateway happened to be within `SOURCE_THRESHOLD` of the contract - which varied between runs.

## This Solution

Made the test robust to both scenarios:

1. **Use `setup_deterministic_state(SEED)`** instead of `reset_all_simulation_state()` - ensures GlobalRng is seeded before SimNetwork creation

2. **Use a fixed contract seed** instead of calculating one based on gateway location - removes dependency on potentially-wrong location

3. **Increase post-operation wait from 10s to 45s** - orphan recovery runs every 30 seconds, so we need to wait long enough for it

4. **Make assertions conditional on actual topology state**:
   - Primary assertion (no cycles with single seeder) always runs
   - Secondary assertions (no orphans, healthy topology) only run if gateway IS actually a source based on the topology snapshot's distance calculation

5. **Document the issue** with reference to #2759 for future investigation

## Testing

```
cargo test -p freenet --test simulation_integration -- test_topology --test-threads=1 --nocapture
```

Both `test_topology_single_seeder` and `test_bidirectional_cycle` pass consistently.

## Related

- Follows PR #2756 which added Turmoil deterministic pattern
- Works around #2759 (peer location non-determinism between config and running nodes)
- Related to #2755 (orphan/disconnected seeders) but doesn't fix that routing bug