### PR TITLE
fix: seed GlobalRng in SimNetwork::new() for deterministic locations

### DIFF
--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -3727,12 +3727,12 @@ mod tests {
         // Create first network
         let sim1 = SimNetwork::new(
             "determinism-test-1",
-            2, // 2 gateways
-            3, // 3 regular nodes
-            7, // ring_max_htl
-            3, // rnd_if_htl_above
+            2,  // 2 gateways
+            3,  // 3 regular nodes
+            7,  // ring_max_htl
+            3,  // rnd_if_htl_above
             10, // max_connections
-            2, // min_connections
+            2,  // min_connections
             SEED,
         )
         .await;


### PR DESCRIPTION
Fixes #2759

## Problem
Peer locations were non-deterministic between SimNetwork configuration
and running nodes. The same seed produced different gateway locations
across runs:
- Run 1: 0.3375
- Run 2: 0.9028
- Run 3: 0.6609

This broke deterministic simulation testing guarantees.

## Root Cause
SimNetwork::new() accepted a `seed` parameter but never called
GlobalRng::set_seed(seed) before generating peer locations.

When config_gateways() called Location::random() (which uses GlobalRng),
the RNG was either unseeded or had stale state from previous tests,
causing non-deterministic location generation.

## Solution
Added GlobalRng::set_seed(seed) at the start of SimNetwork::new(),
ensuring all Location::random() calls during gateway/node configuration
use deterministic randomness.

## Testing
- Added regression test test_deterministic_peer_locations() that
  verifies identical locations across multiple runs with the same seed
- Test passes: locations are now deterministic
- Existing tests continue to work (they called setup_deterministic_state
  before SimNetwork::new, so this change is compatible)

## Related
- Issue #2759: Peer locations non-deterministic
- PR #2758: Temporary workaround (this PR fixes the root cause)