### PR TITLE
test: update test_bidirectional_cycle to properly validate Issue #2755

### DIFF
--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -1717,7 +1717,7 @@ fn test_orphan_seeders_no_source() {
         let orphans_excluding_root: Vec<_> = result
             .orphan_seeders
             .iter()
-            .filter(|addr| **addr != root_snap.peer_addr)
+            .filter(|(addr, cid)| *addr != root_snap.peer_addr && *cid == contract_id)
             .collect();
 
         assert!(
@@ -1736,7 +1736,7 @@ fn test_orphan_seeders_no_source() {
         let disconnected_excluding_root: Vec<_> = result
             .disconnected_upstream
             .iter()
-            .filter(|addr| **addr != root_snap.peer_addr)
+            .filter(|(addr, cid)| *addr != root_snap.peer_addr && *cid == contract_id)
             .collect();
 
         assert!(
@@ -1749,13 +1749,19 @@ fn test_orphan_seeders_no_source() {
             disconnected_excluding_root
         );
 
-        // Assert: No unreachable seeders
+        // Assert: No unreachable seeders for this contract
+        let unreachable_for_contract: Vec<_> = result
+            .unreachable_seeders
+            .iter()
+            .filter(|(_, cid)| *cid == contract_id)
+            .collect();
+
         assert!(
-            result.unreachable_seeders.is_empty(),
+            unreachable_for_contract.is_empty(),
             "ISSUE #2755: Found {} unreachable seeders: {:?}. \
              All seeders should be reachable in a valid topology.",
-            result.unreachable_seeders.len(),
-            result.unreachable_seeders
+            unreachable_for_contract.len(),
+            unreachable_for_contract
         );
 
         tracing::info!(


### PR DESCRIPTION
## Changes

- **Renamed**: `test_bidirectional_cycle` → `test_orphan_seeders_no_source`
- **Marked as ignored**: Added `#[ignore]` with reason: "Issue #2755: Orphan/disconnected seeders when no peer is within SOURCE_THRESHOLD"
- **Updated assertions**: Now properly validates expected behavior from Issue #2755

## What the test validates now

1. **Issue #2720 (still passing)**: No bidirectional cycles exist
2. **Issue #2755 (will fail)**: When no peer is within SOURCE_THRESHOLD, topology should still form a valid DAG toward the closest peer

## Expected behavior (per Issue #2755)

Even when no peer is within SOURCE_THRESHOLD (5%), peers should:
- Form a directed acyclic graph toward the geographically closest peer
- The closest peer becomes the de-facto "root"
- All non-root seeders have upstream connections
- No orphan seeders or disconnected upstream nodes (except root)

## Current behavior (the bug)

The test will fail because peers create fragmented topologies with:
- Orphan seeders with no upstream connection
- Disconnected upstream nodes with downstream but no upstream

## Related

- Issue #2755: Main issue being tested
- Issue #2720: Bidirectional cycles (fixed, still validated)
- Issue #2719: Orphan seeders without recovery

Fixes: Part of investigation for #2755