### PR TITLE
fix: add size limits to diagnostic report logs

### DIFF
--- a/crates/core/src/bin/commands/report.rs
+++ b/crates/core/src/bin/commands/report.rs
@@ -440,30 +440,39 @@ fn read_and_merge_log_files(files: &[PathBuf]) -> (Option<String>, u64) {
     }
 
     let mut total_original_size = 0u64;
-    let mut all_lines = Vec::new();
+    let mut all_content = Vec::new();
 
-    for file in files {
+    // Process files in reverse order (oldest first) so merged string is chronological.
+    // This way, most recent entries are at the end, and truncating from the beginning
+    // preserves the most recent (most relevant) logs.
+    for file in files.iter().rev() {
         let (content, size) = read_log_file(file);
         total_original_size += size;
         if let Some(content) = content {
-            all_lines.push(content);
+            all_content.push(content);
         }
     }
 
-    if all_lines.is_empty() {
+    if all_content.is_empty() {
         return (None, total_original_size);
     }
 
-    let merged = all_lines.join("\n");
+    let merged = all_content.join("\n");
 
     // If total size exceeds limit, truncate from beginning to keep most recent logs
     let result = if merged.len() > MAX_TOTAL_LOG_SIZE {
         let skip_bytes = merged.len() - MAX_TOTAL_LOG_SIZE;
-        // Find next newline to avoid cutting mid-line
-        let truncate_at = merged[skip_bytes..]
+        // Find a safe UTF-8 boundary, then find the next newline to avoid cutting mid-line
+        let safe_skip = merged
+            .char_indices()
+            .take_while(|(i, _)| *i <= skip_bytes)
+            .last()
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        let truncate_at = merged[safe_skip..]
             .find('\n')
-            .map(|pos| skip_bytes + pos + 1)
-            .unwrap_or(skip_bytes);
+            .map(|pos| safe_skip + pos + 1)
+            .unwrap_or(safe_skip);
         format!(
             "[... {} bytes truncated to fit size limit ...]\n{}",
             truncate_at,
@@ -518,9 +527,16 @@ fn read_log_file(path: &PathBuf) -> (Option<String>, u64) {
         if include_line {
             // Truncate very long lines (e.g., delegates logging full state as byte arrays)
             let line = if line.len() > MAX_LINE_LENGTH {
+                // Find a safe UTF-8 character boundary for truncation
+                let truncate_at = line
+                    .char_indices()
+                    .take_while(|(i, _)| *i < MAX_LINE_LENGTH)
+                    .last()
+                    .map(|(i, c)| i + c.len_utf8())
+                    .unwrap_or(0);
                 format!(
                     "{}... [truncated, {} total bytes]",
-                    &line[..MAX_LINE_LENGTH],
+                    &line[..truncate_at],
                     line.len()
                 )
             } else {


### PR DESCRIPTION
## Problem

Diagnostic report uploads were failing with "413 Payload Too Large" errors. Investigation found:

1. **River's chat-delegate** logs full byte arrays at INFO level (`value: [167, 109, 99, ...]`)
2. A 300KB state becomes a **316KB log line** (one number per byte)
3. This caused **25MB+ of logs per hour** on active nodes
4. Even with 30-minute filtering, reports exceeded the 10MB server limit

## Approach

Rather than just increase the server limit (which would mask the symptom), add client-side limits:

- **Per-line limit (10 KB)**: Truncates excessively long lines with `[truncated, N total bytes]` marker
- **Total limit (2 MB)**: Keeps most recent logs if total exceeds limit, with truncation notice

This ensures diagnostic reports are always uploadable while preserving the most recent (and usually most relevant) log entries.

## Root Cause Fix

The underlying verbosity issue is tracked in freenet/river#73 - chat-delegate should not log full state data at INFO level.

## Testing

- Manual testing with verbose logs confirmed truncation works correctly
- Compilation verified with `cargo check`

[AI-assisted - Claude]