### PR TITLE
fix: ws_api address should respect operation mode like network_api

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -528,8 +528,10 @@ impl ConfigArgs {
                 bbr_startup_rate: self.network_api.bbr_startup_rate,
             },
             ws_api: WebsocketApiConfig {
-                // the websocket API is always local
-                address: self.ws_api.address.unwrap_or_else(default_local_address),
+                address: self.ws_api.address.unwrap_or_else(|| match mode {
+                    OperationMode::Local => default_local_address(),
+                    OperationMode::Network => default_listening_address(),
+                }),
                 port: self
                     .ws_api
                     .ws_api_port


### PR DESCRIPTION
## Problem

When running `freenet` in network mode, the WebSocket API defaults to binding to `127.0.0.1` (localhost only), while the network API correctly defaults to `0.0.0.0` (all interfaces). This inconsistency means remote clients cannot connect to the WebSocket API without explicitly passing `--ws-api-address 0.0.0.0`.

Reported by @fluffomatF on Matrix.

## Approach

Apply the same mode-based logic to ws_api that network_api already uses:
- **Local mode**: bind to `127.0.0.1` (localhost)
- **Network mode**: bind to `0.0.0.0` (all interfaces)

This makes the default behavior consistent between the two APIs.

## Testing

- Manual verification: `freenet` now binds ws_api to `0.0.0.0` in network mode by default
- No automated test needed - this is a configuration default change

[AI-assisted - Claude]