### PR TITLE
fix: create parent directory before saving gateways config file

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -1561,6 +1561,10 @@ impl Gateways {
     }
 
     pub fn save_to_file(&self, path: &Path) -> anyhow::Result<()> {
+        // Ensure parent directory exists (fixes Windows first-run where config dir may not exist)
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
         let content = toml::to_string(self)?;
         fs::write(path, content)?;
         Ok(())


### PR DESCRIPTION
## Problem

On Windows, fresh installations fail to save updated gateways because the config directory doesn't exist yet. Users see:

```
Failed to save updated gateways to file error=Impossibile trovare il percorso specificato. (os error 3)
file="C:\Users\...\AppData\Local\The Freenet Project Inc\Freenet\config\gateways.toml"
```

This was discovered via diagnostic report `KYW6GV` from a Windows user (v0.1.107) who couldn't get River to load. The node was failing to persist remotely-fetched gateways on first run because `fs::write()` fails when parent directories don't exist.

## Solution

Add `fs::create_dir_all(parent)` before writing the file in `Gateways::save_to_file()`. This is safe because:
- `create_dir_all` is idempotent (no-op if already exists)
- The path comes from `ConfigPaths::gateways_file()` which should always have a parent

## Why CI didn't catch this

CI runs on Linux where the data directories are typically created during package installation or first config load. On Windows, the installer or first-run may not create all subdirectories, and this code path only triggers when remotely-loaded gateways are saved (which requires successful network access).

## Testing

- Verified clippy passes
- Verified config tests pass
- The fix is minimal and follows standard Rust idiom for ensuring parent directories exist

[AI-assisted - Claude]