### PR TITLE
build: release 0.1.110

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdev"
-version = "0.3.83"
+version = "0.3.84"
 dependencies = [
  "anyhow",
  "axum",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.1.109"
+version = "0.1.110"
 edition = "2021"
 rust-version = "1.80"
 publish = true

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.83"
+version = "0.3.84"
 edition = "2021"
 rust-version = "1.80"
 publish = true


### PR DESCRIPTION
## Summary

Release version 0.1.110

### Notable changes in this release:
- **fix: stop pushing fragments after stream cancellation** (#2842) - Fixes log spam issue #2841 where cancelled streams continued generating warnings
- **feat: implement delegate GetContractRequest handling** (#2837)
- **feat: complete streaming feature with metadata reliability** (#2836)

## Test plan
- [ ] CI passes
- [ ] Local deployment succeeds
- [ ] Log monitoring confirms fix for #2841

[AI-assisted - Claude]