### PR TITLE
fix: pass event_wait_ms to simulation and compute duration dynamically

### DIFF
--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -3377,6 +3377,7 @@ impl SimNetwork {
         max_contract_num: usize,
         iterations: usize,
         simulation_duration: Duration,
+        event_wait: Duration,
     ) -> anyhow::Result<()>
     where
         R: RandomEventGenerator + Send + 'static,
@@ -3573,7 +3574,7 @@ impl SimNetwork {
                 }
 
                 // Wait between events (Turmoil handles this deterministically)
-                tokio::time::sleep(Duration::from_millis(200)).await;
+                tokio::time::sleep(event_wait).await;
             }
 
             // Wait for events to fully propagate through the network

--- a/crates/fdev/src/testing/single_process.rs
+++ b/crates/fdev/src/testing/single_process.rs
@@ -20,13 +20,21 @@ pub(super) fn run(config: &super::TestConfig) -> anyhow::Result<(), super::Error
     let seed = config.seed();
     let max_contract_num = config.max_contract_number.unwrap_or(config.nodes * 10);
     let iterations = config.events as usize;
+    let event_wait = Duration::from_millis(config.event_wait_ms.unwrap_or(200));
+
+    // Calculate simulation duration from event timing:
+    // total virtual time = startup(2s) + events * wait + propagation(2s) + convergence(10s) + 20% buffer
+    let event_time_secs = (iterations as u64 * event_wait.as_millis() as u64) / 1000;
+    let base_duration_secs = 2 + event_time_secs + 2 + 10;
+    let simulation_duration = Duration::from_secs(base_duration_secs + base_duration_secs / 5);
 
     std::thread::spawn(move || {
         simulated_network.run_fdev_test::<rand::rngs::SmallRng>(
             seed,
             max_contract_num,
             iterations,
-            Duration::from_secs(300), // 5 minute simulation timeout
+            simulation_duration,
+            event_wait,
         )
     })
     .join()


### PR DESCRIPTION
## Problem

The first two nightly simulation tests (`nightly-medium-50-1h` with seed `0xDEADBEEF` and `nightly-medium-50-1h-alt` with seed `0xCAFEBABE`) have been failing consistently with:

```
Error: Turmoil simulation failed: "Ran for duration: 300s steps: 300002 without completing"
```

This has been failing for at least the last 5 consecutive nightly runs.

## Root Cause

Two hardcoded values in the single-process simulation runner didn't respect CLI configuration:

1. **Hardcoded 200ms event wait** in `run_fdev_test` (`testing_impl.rs:3576`) — the `--event-wait-ms` CLI parameter (1800ms for nightly tests) was never passed through to the simulation
2. **Hardcoded 300s simulation duration** in `single_process.rs:29` — insufficient even for the hardcoded timing: 2000 events × 200ms = 400s > 300s

The nightly tests configure `--events 2000 --event-wait-ms 1800`, expecting 1 hour of virtual time (2000 × 1.8s = 3600s), but the simulation was capped at 300s of virtual time.

## This Solution

- Added `event_wait` parameter to `run_fdev_test` and use it for the sleep between events instead of the hardcoded 200ms
- Calculate `simulation_duration` dynamically based on: `(startup + events × wait + propagation + convergence) × 1.2` (20% buffer)
- For the nightly config, this yields ~4336s of virtual time — sufficient for the 1-hour simulation

## Testing

Both nightly tests verified locally:
- `nightly-medium-50-1h` (seed `0xDEADBEEF`) — exit code 0
- `nightly-medium-50-1h-alt` (seed `0xCAFEBABE`) — exit code 0

## Fixes

Closes #2725