### PR TITLE
fix: let event_wait_ms control turmoil interval, remove from nightly CI

### DIFF
--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -68,19 +68,18 @@ jobs:
       - name: Build fdev
         run: cargo build -p fdev --release
 
-      # Medium scale test (50 nodes) - 1 hour virtual time with realistic jitter
+      # Medium scale test (50 nodes, 2000 events)
       # Expects 100% success rate and 100% convergence
-      # Virtual time: 2000 events × 1800ms = 3600s (1 hour)
-      - name: Medium scale test (50 nodes, 1h, seed 0xDEADBEEF)
+      # Virtual time: 2000 events × 200ms (turmoil default) = 400s
+      - name: Medium scale test (50 nodes, seed 0xDEADBEEF)
         run: |
-          echo "Running medium scale simulation (50 nodes, 2000 events, 1 hour virtual time)"
+          echo "Running medium scale simulation (50 nodes, 2000 events)"
           cargo run -p fdev --release -- test \
-            --name "nightly-medium-50-1h" \
+            --name "nightly-medium-50" \
             --seed 0xDEADBEEF \
             --gateways 4 \
             --nodes 46 \
             --events 2000 \
-            --event-wait-ms 1800 \
             --ring-max-htl 12 \
             --max-connections 20 \
             --min-connections 6 \
@@ -92,18 +91,15 @@ jobs:
             single-process
 
       # Medium scale with different seed (explores different code paths)
-      # 1 hour virtual time with realistic jitter
-      # Virtual time: 2000 events × 1800ms = 3600s (1 hour)
-      - name: Medium scale test (50 nodes, 1h, seed 0xCAFEBABE)
+      - name: Medium scale test (50 nodes, seed 0xCAFEBABE)
         run: |
-          echo "Running medium scale simulation with alternate seed (2000 events, 1 hour virtual time)"
+          echo "Running medium scale simulation with alternate seed (2000 events)"
           cargo run -p fdev --release -- test \
-            --name "nightly-medium-50-1h-alt" \
+            --name "nightly-medium-50-alt" \
             --seed 0xCAFEBABE \
             --gateways 4 \
             --nodes 46 \
             --events 2000 \
-            --event-wait-ms 1800 \
             --ring-max-htl 12 \
             --max-connections 20 \
             --min-connections 6 \
@@ -114,20 +110,17 @@ jobs:
             --print-network-stats \
             single-process
 
-      # Fault tolerance test with aggressive message loss + realistic jitter
-      # 1 hour virtual time to catch time-dependent issues under load
+      # Fault tolerance test with aggressive message loss
       # Success rate can be <100% due to message loss, but convergence must be 100%
-      # Virtual time: 1000 events × 3600ms = 3600s (1 hour)
-      - name: Fault tolerance test (15% message loss, 1h)
+      - name: Fault tolerance test (15% message loss)
         run: |
-          echo "Running fault tolerance simulation with 15% message loss (1000 events, 1 hour virtual time)"
+          echo "Running fault tolerance simulation with 15% message loss (1000 events)"
           cargo run -p fdev --release -- test \
-            --name "nightly-fault-loss-1h" \
+            --name "nightly-fault-loss" \
             --seed 0xFA017001 \
             --gateways 3 \
             --nodes 27 \
             --events 1000 \
-            --event-wait-ms 3600 \
             --message-loss 0.15 \
             --latency-min 10 \
             --latency-max 50 \
@@ -136,19 +129,16 @@ jobs:
             --print-network-stats \
             single-process
 
-      # High latency test - 1 hour virtual time
-      # Tests behavior under sustained high latency conditions
-      # Virtual time: 500 events × 7200ms = 3600s (1 hour)
-      - name: High latency test (50-200ms latency, 1h)
+      # High latency test - tests behavior under sustained high latency conditions
+      - name: High latency test (50-200ms latency)
         run: |
-          echo "Running high latency simulation (500 events, 1 hour virtual time)"
+          echo "Running high latency simulation (500 events)"
           cargo run -p fdev --release -- test \
-            --name "nightly-high-latency-1h" \
+            --name "nightly-high-latency" \
             --seed 0x1A7E0C71 \
             --gateways 2 \
             --nodes 12 \
             --events 500 \
-            --event-wait-ms 7200 \
             --latency-min 50 \
             --latency-max 200 \
             --min-success-rate 0.95 \
@@ -156,19 +146,16 @@ jobs:
             --print-network-stats \
             single-process
 
-      # Large scale test (500 nodes) - 3 hour virtual time with realistic jitter
-      # Extended duration stress test to catch time-dependent scaling issues
-      # Virtual time: 10000 events × 1080ms = 10800s (3 hours)
-      - name: Large scale test (500 nodes, 3h)
+      # Large scale test (500 nodes) - stress test for scaling issues
+      - name: Large scale test (500 nodes)
         run: |
-          echo "Running large scale simulation (500 nodes, 10000 events, 3 hours virtual time)"
+          echo "Running large scale simulation (500 nodes, 10000 events)"
           cargo run -p fdev --release -- test \
-            --name "nightly-large-500-3h" \
+            --name "nightly-large-500" \
             --seed 0x500BEEF \
             --gateways 10 \
             --nodes 490 \
             --events 10000 \
-            --event-wait-ms 1080 \
             --ring-max-htl 15 \
             --max-connections 30 \
             --min-connections 10 \

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -3377,6 +3377,7 @@ impl SimNetwork {
         max_contract_num: usize,
         iterations: usize,
         simulation_duration: Duration,
+        event_wait: Duration,
     ) -> anyhow::Result<()>
     where
         R: RandomEventGenerator + Send + 'static,
@@ -3573,7 +3574,7 @@ impl SimNetwork {
                 }
 
                 // Wait between events (Turmoil handles this deterministically)
-                tokio::time::sleep(Duration::from_millis(200)).await;
+                tokio::time::sleep(event_wait).await;
             }
 
             // Wait for events to fully propagate through the network

--- a/crates/fdev/src/testing/single_process.rs
+++ b/crates/fdev/src/testing/single_process.rs
@@ -21,15 +21,13 @@ pub(super) fn run(config: &super::TestConfig) -> anyhow::Result<(), super::Error
     let max_contract_num = config.max_contract_number.unwrap_or(config.nodes * 10);
     let iterations = config.events as usize;
 
-    // In turmoil (SingleProcess) mode, 200ms between events is sufficient for the
-    // deterministic network to process each event. The --event-wait-ms CLI parameter
-    // controls pacing in Network mode (real-time), but turmoil's virtual time doesn't
-    // need long waits — it just needs enough time for event propagation.
-    const TURMOIL_EVENT_WAIT: Duration = Duration::from_millis(200);
+    // Use --event-wait-ms if provided, otherwise default to 200ms which is sufficient
+    // for turmoil's deterministic network to process each event.
+    let event_wait = Duration::from_millis(config.event_wait_ms.unwrap_or(200));
 
     // Calculate simulation duration: startup(2s) + events*wait + propagation(2s) +
     // convergence(10s) + 20% buffer
-    let event_time_secs = (iterations as u64 * TURMOIL_EVENT_WAIT.as_millis() as u64) / 1000;
+    let event_time_secs = (iterations as u64 * event_wait.as_millis() as u64) / 1000;
     let base_duration_secs = 2 + event_time_secs + 2 + 10;
     let simulation_duration = Duration::from_secs(base_duration_secs + base_duration_secs / 5);
 
@@ -39,6 +37,7 @@ pub(super) fn run(config: &super::TestConfig) -> anyhow::Result<(), super::Error
             max_contract_num,
             iterations,
             simulation_duration,
+            event_wait,
         )
     })
     .join()


### PR DESCRIPTION
## Problem

Follow-up to #2850. Three issues with the nightly simulation tests:

1. **Initial fix passed `--event-wait-ms` (1800ms) to turmoil** — creating 3600s of virtual time per test. With 50 concurrent nodes, turmoil polls all task trees per virtual ms, making tests take 40-70+ min wall clock each.

2. **Nightly workflow had redundant tests** — `replica_validation_and_stepwise_consistency` and `dense_network_replication` already run on every PR via regular CI.

3. **Long-running 1h test had a useless idle gap** — fired 200 events in the first 40 seconds, then sat idle for 3556 seconds. Never verified the network still worked after the idle period.

## Changes

### event_wait_ms controls turmoil interval (default 200ms)
- `--event-wait-ms` now controls turmoil's inter-event sleep when specified
- `simulation_duration` is computed dynamically from the actual interval
- Removed `--event-wait-ms` from nightly CI (previous 1800-7200ms values were too slow for turmoil)
- Added `event_wait` parameter to `run_simulation` (same pattern as `run_fdev_test`)

### Cleaned up nightly workflow
- Removed duplicate `replica_validation` and `dense_network` steps (already in CI)
- Moved 500-node large scale test to last position (slowest, shouldn't block other tests)

### Improved long-running 1h test
- Now distributes 360 events across the full hour (1 event every 10s)
- Network must remain functional throughout — not just survive idle
- Catches connection timeouts, keep-alive failures, and state drift

### Convergence required by default
- Changed all test config presets (`small`, `medium`, `large`) to `require_convergence: true`
- If a simulation can't converge, that's a bug

### Pre-existing clippy fixes
- Fixed `clone_on_copy` and `enum_variant_names` warnings in `delegate.rs`

## Testing

Both nightly tests verified locally:
- `nightly-medium-50` (seed `0xDEADBEEF`) — exit code 0 (~5 min)
- `nightly-medium-50-alt` (seed `0xCAFEBABE`) — exit code 0 (~5 min)
- CI simulation tests (`ci_quick_simulation`, `ci_medium_simulation`) — pass with convergence

## Fixes

Closes #2725