### PR TITLE
feat: add debug_assert! invariant checks for PUT/UPDATE state consistency

### DIFF
--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1178,6 +1178,12 @@ async fn update_contract(
             new_value: Ok(new_val),
             state_changed,
         }) => {
+            // Invariant: after a successful UPDATE, the resulting state must be non-empty.
+            // A successful UpdateResponse with an empty value indicates a contract handler bug.
+            debug_assert!(
+                new_val.size() > 0,
+                "update_contract: state must be non-empty after successful UPDATE for contract {key}"
+            );
             let new_bytes = State::from(new_val.clone()).into_bytes();
             let summary = StateSummary::from(new_bytes);
 


### PR DESCRIPTION
Contract PUT and UPDATE operations now verify critical post-conditions
via debug_assert! statements that catch bugs during development/testing
with zero runtime cost in release builds:

- After put_contract(): stored state must be non-empty
- After seed_contract(): contract must be in seed list
- After update_contract(): resulting state must be non-empty

Both regular and streaming PUT paths are covered.

Closes #2013

https://claude.ai/code/session_01SYekFD5rGG56z77RUgipH4