### PR TITLE
feat: thread blocking_subscribe through PUT/GET operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,7 +1518,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1711,7 +1711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2104,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3bbd528424decbabdb69699972b09182d7204413f07045763a3862c4d62e20"
+checksum = "0d79f52f125696aa168a659899bb55f4fd5ad8020a9c1d2c1d76f7c8a53cc533"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -2795,7 +2795,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2828,7 +2828,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3069,7 +3069,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3625,7 +3625,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4445,7 +4445,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4482,9 +4482,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4942,7 +4942,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5851,7 +5851,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7202,7 +7202,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tracing-subscriber = "0.3"
 wasmer = "7.0.1"
 wasmer-compiler-singlepass = "7.0.1"
 
-freenet-stdlib = { version = "0.1.32" }
+freenet-stdlib = "0.1.33"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/apps/freenet-ping/app/src/main.rs
+++ b/apps/freenet-ping/app/src/main.rs
@@ -67,6 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
                 state: WrappedState::new(serialized),
                 related_contracts: RelatedContracts::new(),
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -81,6 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
                 key: *contract_key.id(),
                 return_contract_code: true,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 

--- a/apps/freenet-ping/app/tests/common/mod.rs
+++ b/apps/freenet-ping/app/tests/common/mod.rs
@@ -620,6 +620,7 @@ pub async fn deploy_contract(
             state: wrapped_state,
             related_contracts: RelatedContracts::new(),
             subscribe,
+            blocking_subscribe: false,
         }))
         .await?;
     wait_for_put_response(client, &contract_key)
@@ -649,6 +650,7 @@ pub async fn get_contract_state(
             key: *key.id(),
             return_contract_code: fetch_contract,
             subscribe: false,
+            blocking_subscribe: false,
         }))
         .await?;
     wait_for_get_response(client, &key)
@@ -686,6 +688,7 @@ pub async fn get_all_ping_states(
             key: *key.id(),
             return_contract_code: false,
             subscribe: false,
+            blocking_subscribe: false,
         }))
         .await?;
 
@@ -694,6 +697,7 @@ pub async fn get_all_ping_states(
             key: *key.id(),
             return_contract_code: false,
             subscribe: false,
+            blocking_subscribe: false,
         }))
         .await?;
 
@@ -702,6 +706,7 @@ pub async fn get_all_ping_states(
             key: *key.id(),
             return_contract_code: false,
             subscribe: false,
+            blocking_subscribe: false,
         }))
         .await?;
 

--- a/apps/freenet-ping/app/tests/run_app.rs
+++ b/apps/freenet-ping/app/tests/run_app.rs
@@ -744,6 +744,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                 state: wrapped_state.clone(),
                 related_contracts: RelatedContracts::new(),
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -760,6 +761,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: true,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -776,6 +778,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: true,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -917,6 +920,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                     key: *contract_key.id(),
                     return_contract_code: false,
                     subscribe: false,
+                    blocking_subscribe: false,
                 }))
                 .await?;
             let state_gw = wait_for_get_response(&mut client_gw, &contract_key)
@@ -928,6 +932,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                     key: *contract_key.id(),
                     return_contract_code: false,
                     subscribe: false,
+                    blocking_subscribe: false,
                 }))
                 .await?;
             let state_node1 = wait_for_get_response(&mut client_node1, &contract_key)
@@ -939,6 +944,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                     key: *contract_key.id(),
                     return_contract_code: false,
                     subscribe: false,
+                    blocking_subscribe: false,
                 }))
                 .await?;
             let state_node2 = wait_for_get_response(&mut client_node2, &contract_key)
@@ -989,6 +995,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: false,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -997,6 +1004,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: false,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -1005,6 +1013,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: false,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -1446,6 +1455,7 @@ async fn test_ping_application_loop() -> anyhow::Result<()> {
                 state: wrapped_state.clone(),
                 related_contracts: RelatedContracts::new(),
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -1462,6 +1472,7 @@ async fn test_ping_application_loop() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: true,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -1478,6 +1489,7 @@ async fn test_ping_application_loop() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: true,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 

--- a/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
+++ b/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
@@ -367,6 +367,7 @@ async fn run_blocked_peers_test_inner(
                 state: wrapped_state.clone(),
                 related_contracts: RelatedContracts::new(),
                 subscribe: config.subscribe_immediately,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -386,6 +387,7 @@ async fn run_blocked_peers_test_inner(
                 key: *contract_key.id(),
                 return_contract_code: true,
                 subscribe: config.subscribe_immediately,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -405,6 +407,7 @@ async fn run_blocked_peers_test_inner(
                 key: *contract_key.id(),
                 return_contract_code: true,
                 subscribe: config.subscribe_immediately,
+                blocking_subscribe: false,
             }))
             .await?;
 

--- a/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
+++ b/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
@@ -327,6 +327,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
                 state: wrapped_state.clone(),
                 related_contracts: RelatedContracts::new(),
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -355,6 +356,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
                     key: *contract_key.id(),
                     return_contract_code: true,
                     subscribe: false,
+                    blocking_subscribe: false,
                 }))
                 .await?;
             get_requests.push(i);
@@ -370,6 +372,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
                     key: *contract_key.id(),
                     return_contract_code: true,
                     subscribe: false,
+                    blocking_subscribe: false,
                 }))
                 .await?;
             gw_get_requests.push(i);
@@ -471,6 +474,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
                         key: *contract_key.id(),
                         return_contract_code: true,
                         subscribe: false,
+                        blocking_subscribe: false,
                     }))
                     .await?;
                 final_get_requests.push(i);
@@ -704,6 +708,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
                         key: *contract_key.id(),
                         return_contract_code: false,
                         subscribe: false,
+                        blocking_subscribe: false,
                     }))
                     .await?;
                 get_state_requests.push(i);
@@ -721,6 +726,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
                         key: *contract_key.id(),
                         return_contract_code: false,
                         subscribe: false,
+                        blocking_subscribe: false,
                     }))
                     .await?;
                 gw_get_state_requests.push(i);

--- a/apps/freenet-ping/app/tests/test_50_node_operations.rs
+++ b/apps/freenet-ping/app/tests/test_50_node_operations.rs
@@ -348,6 +348,7 @@ async fn test_put_propagation(
             state: wrapped_state.clone(),
             related_contracts: RelatedContracts::new(),
             subscribe: false,
+            blocking_subscribe: false,
         });
 
         match client.send(put_request.clone()).await {
@@ -409,6 +410,7 @@ async fn test_concurrent_gets(
             key: *contract_key.id(),
             return_contract_code: false,
             subscribe: false,
+            blocking_subscribe: false,
         });
 
         match timeout(Duration::from_secs(30), async {
@@ -614,6 +616,7 @@ async fn test_update_propagation(
             key: *contract_key.id(),
             return_contract_code: false,
             subscribe: false,
+            blocking_subscribe: false,
         });
 
         match timeout(Duration::from_secs(30), async {

--- a/apps/freenet-ping/app/tests/test_limited_connectivity_get.rs
+++ b/apps/freenet-ping/app/tests/test_limited_connectivity_get.rs
@@ -173,6 +173,7 @@ async fn test_limited_connectivity_get_nonexistent_contract() -> anyhow::Result<
                 key: nonexistent_id,
                 return_contract_code: false,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 

--- a/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
+++ b/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
@@ -192,6 +192,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
                 state: wrapped_state.clone(),
                 related_contracts: RelatedContracts::new(),
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -229,6 +230,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: false,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -248,6 +250,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: true,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 
@@ -272,6 +275,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: true,
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
         println!(
@@ -324,6 +328,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
                 key: *contract_key.id(),
                 return_contract_code: true, // Same as first GET for consistency
                 subscribe: false,
+                blocking_subscribe: false,
             }))
             .await?;
 

--- a/crates/core/src/client_events/mod.rs
+++ b/crates/core/src/client_events/mod.rs
@@ -582,6 +582,7 @@ async fn process_open_request(
                         contract,
                         related_contracts,
                         subscribe,
+                        blocking_subscribe,
                     } => {
                         let peer_id = ensure_peer_ready(&op_manager)?;
 
@@ -624,6 +625,7 @@ async fn process_open_request(
                                 state.clone(),
                                 op_manager.ring.max_hops_to_live,
                                 subscribe,
+                                blocking_subscribe,
                             );
                             let op_id = op.id;
 
@@ -686,6 +688,7 @@ async fn process_open_request(
                                 related_contracts: related_contracts.clone(),
                                 state: state.clone(),
                                 subscribe,
+                                blocking_subscribe,
                                 client_id,
                                 request_id,
                             };
@@ -727,6 +730,7 @@ async fn process_open_request(
                                     state.clone(),
                                     op_manager.ring.max_hops_to_live,
                                     subscribe,
+                                    blocking_subscribe,
                                     transaction_id,
                                 );
 
@@ -804,6 +808,7 @@ async fn process_open_request(
                                 state.clone(),
                                 op_manager.ring.max_hops_to_live,
                                 subscribe,
+                                blocking_subscribe,
                             );
                             let op_id = op.id;
 
@@ -1062,6 +1067,7 @@ async fn process_open_request(
                         key,
                         return_contract_code,
                         subscribe,
+                        blocking_subscribe,
                     } => {
                         let peer_id = ensure_peer_ready(&op_manager)?;
 
@@ -1213,6 +1219,7 @@ async fn process_open_request(
                                 key,
                                 return_contract_code,
                                 subscribe,
+                                blocking_subscribe,
                                 client_id,
                                 request_id,
                             };
@@ -1254,6 +1261,7 @@ async fn process_open_request(
                                     key,
                                     return_contract_code,
                                     subscribe,
+                                    blocking_subscribe,
                                     transaction_id,
                                 );
 
@@ -1334,7 +1342,12 @@ async fn process_open_request(
                             );
 
                             // Legacy mode: direct operation without deduplication
-                            let op = get::start_op(key, return_contract_code, subscribe);
+                            let op = get::start_op(
+                                key,
+                                return_contract_code,
+                                subscribe,
+                                blocking_subscribe,
+                            );
                             let op_id = op.id;
 
                             op_manager
@@ -2106,6 +2119,7 @@ pub(crate) mod test {
                             state: WrappedState::new(self.random_byte_vec()),
                             related_contracts: RelatedContracts::new(),
                             subscribe: true,
+                            blocking_subscribe: false,
                         };
                         state.existing_contracts.push(contract);
                         if !for_this_peer {
@@ -2126,6 +2140,7 @@ pub(crate) mod test {
                                 // Subscribe to ensure this peer joins the subscription tree
                                 // and can receive/propagate updates
                                 subscribe: true,
+                                blocking_subscribe: false,
                             };
 
                             tracing::debug!(
@@ -2145,6 +2160,7 @@ pub(crate) mod test {
                                 key: *key.id(),
                                 return_contract_code: true,
                                 subscribe: false,
+                                blocking_subscribe: false,
                             };
                             return Some(request.into());
                         }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -592,7 +592,7 @@ struct GetContract {
 
 impl ComposeNetworkMessage<operations::get::GetOp> for GetContract {
     fn initiate_op(self, _op_manager: &OpManager) -> operations::get::GetOp {
-        operations::get::start_op(self.instance_id, self.return_contract_code, false)
+        operations::get::start_op(self.instance_id, self.return_contract_code, false, false)
     }
 
     async fn resume_op(op: operations::get::GetOp, op_manager: &OpManager) -> Result<(), OpError> {

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1147,6 +1147,7 @@ impl Executor<Runtime> {
                     state,
                     related_contracts,
                     subscribe: false,
+                    blocking_subscribe: false,
                 },
                 cli_id,
                 None,

--- a/crates/core/src/node/message_processor.rs
+++ b/crates/core/src/node/message_processor.rs
@@ -99,7 +99,7 @@ mod tests {
     fn create_success_host_result() -> Option<HostResult> {
         use freenet_stdlib::prelude::ContractInstanceId;
         let instance_id = ContractInstanceId::new([1u8; 32]);
-        let get_op = get::start_op(instance_id, false, false);
+        let get_op = get::start_op(instance_id, false, false, false);
         Some(OpEnum::Get(get_op).to_host_result())
     }
 

--- a/crates/core/src/node/request_router.rs
+++ b/crates/core/src/node/request_router.rs
@@ -151,6 +151,9 @@ pub enum DeduplicatedRequest {
         key: ContractInstanceId,
         return_contract_code: bool,
         subscribe: bool,
+        /// Not used for deduplication, but carried through for future use.
+        #[allow(dead_code)]
+        blocking_subscribe: bool,
         client_id: ClientId,
         request_id: RequestId,
     },
@@ -160,6 +163,9 @@ pub enum DeduplicatedRequest {
         related_contracts: freenet_stdlib::prelude::RelatedContracts<'static>,
         state: freenet_stdlib::prelude::WrappedState,
         subscribe: bool,
+        /// Not used for deduplication, but carried through for future use.
+        #[allow(dead_code)]
+        blocking_subscribe: bool,
         client_id: ClientId,
         request_id: RequestId,
     },
@@ -493,6 +499,7 @@ mod tests {
             key: instance_id,
             return_contract_code: true,
             subscribe: false,
+            blocking_subscribe: false,
             client_id: client_id_1,
             request_id: request_id_1,
         };
@@ -502,6 +509,7 @@ mod tests {
             key: instance_id,
             return_contract_code: true,
             subscribe: false,
+            blocking_subscribe: false,
             client_id: client_id_2,
             request_id: request_id_2,
         };
@@ -529,6 +537,7 @@ mod tests {
             key: instance_id,
             return_contract_code: true,
             subscribe: false,
+            blocking_subscribe: false,
             client_id,
             request_id: request_id_1,
         };
@@ -538,6 +547,7 @@ mod tests {
             key: instance_id,
             return_contract_code: false,
             subscribe: false,
+            blocking_subscribe: false,
             client_id,
             request_id: request_id_2,
         };
@@ -597,6 +607,7 @@ mod tests {
             related_contracts: related_contracts.clone(),
             state: state.clone(),
             subscribe: false,
+            blocking_subscribe: false,
             client_id: client_id_1,
             request_id: request_id_1,
         };
@@ -608,6 +619,7 @@ mod tests {
             related_contracts: related_contracts.clone(),
             state: state.clone(),
             subscribe: false,
+            blocking_subscribe: false,
             client_id: client_id_2,
             request_id: request_id_2,
         };
@@ -641,6 +653,7 @@ mod tests {
             related_contracts: related_contracts.clone(),
             state: state1,
             subscribe: false,
+            blocking_subscribe: false,
             client_id,
             request_id: request_id_1,
         };
@@ -652,6 +665,7 @@ mod tests {
             related_contracts: related_contracts.clone(),
             state: state2,
             subscribe: false,
+            blocking_subscribe: false,
             client_id,
             request_id: request_id_2,
         };
@@ -682,6 +696,7 @@ mod tests {
             related_contracts: related_contracts.clone(),
             state: state.clone(),
             subscribe: false,
+            blocking_subscribe: false,
             client_id,
             request_id: request_id_1,
         };
@@ -693,6 +708,7 @@ mod tests {
             related_contracts: related_contracts.clone(),
             state: state.clone(),
             subscribe: true,
+            blocking_subscribe: false,
             client_id,
             request_id: request_id_2,
         };
@@ -981,6 +997,7 @@ mod tests {
             key: instance_id,
             return_contract_code: true,
             subscribe: false,
+            blocking_subscribe: false,
             client_id: client_id_1,
             request_id: request_id_1,
         };
@@ -997,6 +1014,7 @@ mod tests {
             key: instance_id,
             return_contract_code: true,
             subscribe: false,
+            blocking_subscribe: false,
             client_id: client_id_2,
             request_id: request_id_2,
         };
@@ -1024,6 +1042,7 @@ mod tests {
             key: instance_id,
             return_contract_code: true,
             subscribe: false,
+            blocking_subscribe: false,
             client_id,
             request_id,
         };
@@ -1074,6 +1093,7 @@ mod tests {
             key: instance_id,
             return_contract_code: true,
             subscribe: false,
+            blocking_subscribe: false,
             client_id,
             request_id,
         };
@@ -1114,6 +1134,7 @@ mod tests {
                         key: instance_id,
                         return_contract_code: true,
                         subscribe: false,
+                        blocking_subscribe: false,
                         client_id,
                         request_id,
                     };
@@ -1184,6 +1205,7 @@ mod tests {
             key: instance_id,
             return_contract_code: true,
             subscribe: false,
+            blocking_subscribe: false,
             client_id: client_id_1,
             request_id: request_id_1,
         };
@@ -1201,6 +1223,7 @@ mod tests {
             key: instance_id,
             return_contract_code: true,
             subscribe: false,
+            blocking_subscribe: false,
             client_id: client_id_2,
             request_id: request_id_2,
         };

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -244,6 +244,7 @@ impl SimOperation {
                 state: WrappedState::new(state),
                 related_contracts: RelatedContracts::new(),
                 subscribe,
+                blocking_subscribe: false,
             }),
             SimOperation::Get {
                 contract_id,
@@ -253,6 +254,7 @@ impl SimOperation {
                 key: contract_id,
                 return_contract_code,
                 subscribe,
+                blocking_subscribe: false,
             }),
             SimOperation::Subscribe { contract_id } => {
                 ClientRequest::ContractOp(ContractRequest::Subscribe {

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -34,6 +34,7 @@ pub(crate) fn start_op(
     instance_id: ContractInstanceId,
     fetch_contract: bool,
     subscribe: bool,
+    blocking_subscribe: bool,
 ) -> GetOp {
     let contract_location = Location::from(&instance_id);
     let id = Transaction::new::<GetMsg>();
@@ -43,6 +44,7 @@ pub(crate) fn start_op(
         id,
         fetch_contract,
         subscribe,
+        blocking_subscribe,
     });
     GetOp {
         id,
@@ -64,6 +66,7 @@ pub(crate) fn start_op_with_id(
     instance_id: ContractInstanceId,
     fetch_contract: bool,
     subscribe: bool,
+    blocking_subscribe: bool,
     id: Transaction,
 ) -> GetOp {
     let contract_location = Location::from(&instance_id);
@@ -73,6 +76,7 @@ pub(crate) fn start_op_with_id(
         id,
         fetch_contract,
         subscribe,
+        blocking_subscribe,
     });
     GetOp {
         id,
@@ -226,6 +230,7 @@ pub(crate) async fn request_get(
             instance_id: _,
             id: _,
             subscribe,
+            blocking_subscribe,
         }) => {
             let mut tried_peers = HashSet::new();
             if let Some(addr) = target.socket_addr() {
@@ -239,6 +244,7 @@ pub(crate) async fn request_get(
                 requester: None,
                 current_hop: op_manager.ring.max_hops_to_live,
                 subscribe,
+                blocking_subscribe,
                 next_hop: target.clone(),
                 tried_peers,
                 alternatives: candidates,
@@ -298,6 +304,7 @@ enum GetState {
         id: Transaction,
         fetch_contract: bool,
         subscribe: bool,
+        blocking_subscribe: bool,
     },
     /// Awaiting response from petition.
     AwaitingResponse {
@@ -309,6 +316,7 @@ enum GetState {
         retries: usize,
         current_hop: usize,
         subscribe: bool,
+        blocking_subscribe: bool,
         /// Peer we are currently trying to reach.
         /// Note: With connection-based routing, this is only used for state tracking,
         /// not for response routing (which uses upstream_addr instead).
@@ -336,6 +344,7 @@ impl Display for GetState {
                 id,
                 fetch_contract,
                 subscribe,
+                ..
             } => {
                 write!(
                     f,
@@ -440,6 +449,7 @@ impl GetOp {
             retries,
             current_hop,
             subscribe,
+            blocking_subscribe,
             next_hop: failed_peer,
             mut tried_peers,
             mut alternatives,
@@ -474,6 +484,7 @@ impl GetOp {
                     retries,
                     current_hop,
                     subscribe,
+                    blocking_subscribe,
                     next_hop: next_target,
                     tried_peers,
                     alternatives,
@@ -539,6 +550,7 @@ impl GetOp {
                         retries: retries + 1,
                         current_hop,
                         subscribe,
+                        blocking_subscribe,
                         next_hop: next_target,
                         tried_peers: new_tried_peers,
                         alternatives: new_candidates,
@@ -1177,6 +1189,7 @@ impl Operation for GetOp {
                             requester,
                             current_hop,
                             subscribe,
+                            blocking_subscribe,
                             mut tried_peers,
                             mut alternatives,
                             attempts_at_hop,
@@ -1230,6 +1243,7 @@ impl Operation for GetOp {
                                     requester: requester.clone(),
                                     current_hop,
                                     subscribe,
+                                    blocking_subscribe,
                                     tried_peers: updated_tried_peers.clone(),
                                     alternatives,
                                     attempts_at_hop: attempts_at_hop + 1,
@@ -1289,6 +1303,7 @@ impl Operation for GetOp {
                                         requester: requester.clone(),
                                         current_hop,
                                         subscribe,
+                                        blocking_subscribe,
                                         tried_peers: new_tried_peers,
                                         alternatives: new_candidates,
                                         attempts_at_hop: 1,
@@ -1614,11 +1629,16 @@ impl Operation for GetOp {
                     let is_original_requester = self.upstream_addr.is_none();
 
                     // Check if subscription was requested
-                    let subscribe_requested =
-                        if let Some(GetState::AwaitingResponse { subscribe, .. }) = &self.state {
-                            *subscribe
+                    let (subscribe_requested, blocking_sub) =
+                        if let Some(GetState::AwaitingResponse {
+                            subscribe,
+                            blocking_subscribe,
+                            ..
+                        }) = &self.state
+                        {
+                            (*subscribe, *blocking_subscribe)
                         } else {
-                            false
+                            (false, false)
                         };
 
                     // Always cache contracts we encounter - LRU will handle eviction
@@ -1715,10 +1735,11 @@ impl Operation for GetOp {
                             if crate::ring::AUTO_SUBSCRIBE_ON_GET {
                                 // Only start new subscription if not already subscribed
                                 if access_result.is_new || !op_manager.ring.is_subscribed(&key) {
+                                    let blocking = subscribe_requested && blocking_sub;
                                     let child_tx = super::start_subscription_request(
-                                        op_manager, id, key, false,
+                                        op_manager, id, key, blocking,
                                     );
-                                    tracing::debug!(tx = %id, %child_tx, blocking = false, "started subscription");
+                                    tracing::debug!(tx = %id, %child_tx, %blocking, "started subscription");
                                 }
                             }
                         } else {
@@ -1798,9 +1819,10 @@ impl Operation for GetOp {
                                         if crate::ring::AUTO_SUBSCRIBE_ON_GET {
                                             // Only start new subscription if not already subscribed
                                             if access_result.is_new || !op_manager.ring.is_subscribed(&key) {
+                                                let blocking = subscribe_requested && blocking_sub;
                                                 let child_tx =
-                                                    super::start_subscription_request(op_manager, id, key, false);
-                                                tracing::debug!(tx = %id, %child_tx, blocking = false, "started subscription");
+                                                    super::start_subscription_request(op_manager, id, key, blocking);
+                                                tracing::debug!(tx = %id, %child_tx, %blocking, "started subscription");
                                             }
                                         }
                                     }
@@ -2411,6 +2433,7 @@ async fn try_forward_or_return(
                 fetch_contract,
                 current_hop: new_htl,
                 subscribe: false,
+                blocking_subscribe: false,
                 next_hop: target.clone(),
                 tried_peers,
                 alternatives,

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -277,10 +277,19 @@ impl Operation for PutOp {
                     .get_peer_location_by_addr(addr)
             });
 
-            // Extract subscribe flag from state (only relevant for originator)
+            // Extract subscribe flags from state (only relevant for originator)
             let subscribe = match &self.state {
                 Some(PutState::PrepareRequest { subscribe, .. }) => *subscribe,
                 Some(PutState::AwaitingResponse { subscribe, .. }) => *subscribe,
+                _ => false,
+            };
+            let blocking_subscribe = match &self.state {
+                Some(PutState::PrepareRequest {
+                    blocking_subscribe, ..
+                }) => *blocking_subscribe,
+                Some(PutState::AwaitingResponse {
+                    blocking_subscribe, ..
+                }) => *blocking_subscribe,
                 _ => false,
             };
 
@@ -452,10 +461,11 @@ impl Operation for PutOp {
                             )
                         };
 
-                        // Transition to AwaitingResponse, preserving subscribe flag for originator
+                        // Transition to AwaitingResponse, preserving subscribe flags for originator
                         // Store next_hop so handle_notification_msg can route the message
                         let new_state = Some(PutState::AwaitingResponse {
                             subscribe,
+                            blocking_subscribe,
                             next_hop: Some(next_addr),
                             current_htl: htl,
                         });
@@ -497,9 +507,14 @@ impl Operation for PutOp {
                             }
 
                             // Start subscription if requested
-                            // TODO: blocking_subscription should come from ContractRequest once stdlib is updated
                             if subscribe {
-                                start_subscription_after_put(op_manager, id, key, false).await;
+                                start_subscription_after_put(
+                                    op_manager,
+                                    id,
+                                    key,
+                                    blocking_subscribe,
+                                )
+                                .await;
                             }
 
                             Ok(OperationResult {
@@ -590,9 +605,9 @@ impl Operation for PutOp {
                         }
 
                         // Start subscription if requested
-                        // TODO: blocking_subscription should come from ContractRequest once stdlib is updated
                         if subscribe {
-                            start_subscription_after_put(op_manager, id, *key, false).await;
+                            start_subscription_after_put(op_manager, id, *key, blocking_subscribe)
+                                .await;
                         }
 
                         Ok(OperationResult {
@@ -889,6 +904,7 @@ impl Operation for PutOp {
 
                         let new_state = Some(PutState::AwaitingResponse {
                             subscribe: *msg_subscribe,
+                            blocking_subscribe: false,
                             next_hop: Some(next_addr),
                             current_htl: htl,
                         });
@@ -940,6 +956,7 @@ impl Operation for PutOp {
 
                         let new_state = Some(PutState::AwaitingResponse {
                             subscribe: *msg_subscribe,
+                            blocking_subscribe: false,
                             next_hop: Some(next_addr),
                             current_htl: htl,
                         });
@@ -978,7 +995,13 @@ impl Operation for PutOp {
                             }
 
                             if *msg_subscribe {
-                                start_subscription_after_put(op_manager, id, key, false).await;
+                                start_subscription_after_put(
+                                    op_manager,
+                                    id,
+                                    key,
+                                    blocking_subscribe,
+                                )
+                                .await;
                             }
 
                             Ok(OperationResult {
@@ -1073,7 +1096,8 @@ impl Operation for PutOp {
 
                         // Start subscription if requested
                         if subscribe {
-                            start_subscription_after_put(op_manager, id, *key, false).await;
+                            start_subscription_after_put(op_manager, id, *key, blocking_subscribe)
+                                .await;
                         }
 
                         tracing::info!(
@@ -1129,8 +1153,8 @@ impl Operation for PutOp {
 ///   is sent immediately
 /// - When true: PUT response waits for subscription to complete
 ///
-/// This parameter is intended to come from the client request (ContractRequest::Put)
-/// once stdlib is updated. For now, callers should pass `false` for non-blocking behavior.
+/// This value comes from the client request's `blocking_subscribe` field
+/// (`ContractRequest::Put`).
 async fn start_subscription_after_put(
     op_manager: &OpManager,
     parent_tx: Transaction,
@@ -1167,6 +1191,7 @@ pub(crate) fn start_op(
     value: WrappedState,
     htl: usize,
     subscribe: bool,
+    blocking_subscribe: bool,
 ) -> PutOp {
     let key = contract.key();
     let contract_location = Location::from(&key);
@@ -1179,6 +1204,7 @@ pub(crate) fn start_op(
         value,
         htl,
         subscribe,
+        blocking_subscribe,
     });
 
     PutOp {
@@ -1195,6 +1221,7 @@ pub(crate) fn start_op_with_id(
     value: WrappedState,
     htl: usize,
     subscribe: bool,
+    blocking_subscribe: bool,
     id: Transaction,
 ) -> PutOp {
     let key = contract.key();
@@ -1207,6 +1234,7 @@ pub(crate) fn start_op_with_id(
         value,
         htl,
         subscribe,
+        blocking_subscribe,
     });
 
     PutOp {
@@ -1237,11 +1265,15 @@ pub enum PutState {
         htl: usize,
         /// If true, start a subscription after PUT completes
         subscribe: bool,
+        /// If true, the PUT response waits for the subscription to complete
+        blocking_subscribe: bool,
     },
     /// Waiting for response from downstream node.
     AwaitingResponse {
         /// If true, start a subscription after PUT completes (originator only)
         subscribe: bool,
+        /// If true, the PUT response waits for the subscription to complete
+        blocking_subscribe: bool,
         /// Next hop address for routing the outbound message
         next_hop: Option<std::net::SocketAddr>,
         /// Current HTL (remaining hops) for hop_count calculation.
@@ -1254,31 +1286,34 @@ pub enum PutState {
 /// Request to insert/update a value into a contract.
 /// Called when a client initiates a PUT operation.
 pub(crate) async fn request_put(op_manager: &OpManager, put_op: PutOp) -> Result<(), OpError> {
-    let (id, contract, value, related_contracts, htl, subscribe) = match &put_op.state {
-        Some(PutState::PrepareRequest {
-            contract,
-            value,
-            related_contracts,
-            htl,
-            subscribe,
-        }) => (
-            put_op.id,
-            contract.clone(),
-            value.clone(),
-            related_contracts.clone(),
-            *htl,
-            *subscribe,
-        ),
-        _ => {
-            tracing::error!(
-                tx = %put_op.id,
-                state = ?put_op.state,
-                phase = "error",
-                "request_put called with unexpected state"
-            );
-            return Err(OpError::UnexpectedOpState);
-        }
-    };
+    let (id, contract, value, related_contracts, htl, subscribe, blocking_subscribe) =
+        match &put_op.state {
+            Some(PutState::PrepareRequest {
+                contract,
+                value,
+                related_contracts,
+                htl,
+                subscribe,
+                blocking_subscribe,
+            }) => (
+                put_op.id,
+                contract.clone(),
+                value.clone(),
+                related_contracts.clone(),
+                *htl,
+                *subscribe,
+                *blocking_subscribe,
+            ),
+            _ => {
+                tracing::error!(
+                    tx = %put_op.id,
+                    state = ?put_op.state,
+                    phase = "error",
+                    "request_put called with unexpected state"
+                );
+                return Err(OpError::UnexpectedOpState);
+            }
+        };
 
     let key = contract.key();
 
@@ -1307,6 +1342,7 @@ pub(crate) async fn request_put(op_manager: &OpManager, put_op: PutOp) -> Result
         id,
         state: Some(PutState::AwaitingResponse {
             subscribe,
+            blocking_subscribe,
             next_hop: None,
             current_htl: htl,
         }),
@@ -1554,6 +1590,7 @@ mod tests {
     fn put_op_not_finalized_when_awaiting_response() {
         let op = make_put_op(Some(PutState::AwaitingResponse {
             subscribe: false,
+            blocking_subscribe: false,
             next_hop: None,
             current_htl: 10,
         }));
@@ -1588,6 +1625,7 @@ mod tests {
     fn put_op_to_host_result_error_when_not_finished() {
         let op = make_put_op(Some(PutState::AwaitingResponse {
             subscribe: false,
+            blocking_subscribe: false,
             next_hop: None,
             current_htl: 10,
         }));
@@ -1624,6 +1662,7 @@ mod tests {
     fn put_op_is_not_completed_when_in_progress() {
         let op = make_put_op(Some(PutState::AwaitingResponse {
             subscribe: false,
+            blocking_subscribe: false,
             next_hop: None,
             current_htl: 10,
         }));

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -71,7 +71,7 @@ async fn fetch_contract_if_missing(
     }
 
     // Start a GET operation to fetch the contract
-    let get_op = get::start_op(instance_id, true, false);
+    let get_op = get::start_op(instance_id, true, false, false);
     let visited = super::VisitedPeers::new(&get_op.id);
     get::request_get(op_manager, get_op, visited).await?;
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -65,6 +65,7 @@ pub(super) async fn contract_home(
                     key: instance_id,
                     return_contract_code: true,
                     subscribe: false,
+                    blocking_subscribe: false,
                 }
                 .into(),
             ),

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -321,6 +321,7 @@ pub async fn make_put(
             state: state.clone(),
             related_contracts: RelatedContracts::default(),
             subscribe,
+            blocking_subscribe: false,
         }))
         .await?;
     Ok(())
@@ -361,6 +362,7 @@ pub async fn make_get(
             key: *key.id(),
             return_contract_code,
             subscribe,
+            blocking_subscribe: false,
         }))
         .await?;
     Ok(())

--- a/crates/core/tests/error_notification.rs
+++ b/crates/core/tests/error_notification.rs
@@ -132,6 +132,7 @@ async fn test_put_error_notification(ctx: &mut TestContext) -> TestResult {
         state: invalid_state,
         related_contracts: Default::default(),
         subscribe: false,
+        blocking_subscribe: false,
     });
 
     client.send(put_request).await?;
@@ -497,6 +498,7 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
             state: wrapped_state.clone(),
             related_contracts: Default::default(),
             subscribe: false,
+            blocking_subscribe: false,
         });
 
         client.send(put_request).await?;

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -2871,6 +2871,7 @@ async fn test_get_notfound_no_forwarding_targets(ctx: &mut TestContext) -> TestR
         key: nonexistent_instance_id,
         return_contract_code: true,
         subscribe: false,
+        blocking_subscribe: false,
     });
     client_api.send(get_request).await?;
 

--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -173,6 +173,7 @@ async fn put_contract(
         state: state.to_vec().into(),
         related_contracts,
         subscribe: config.subscribe,
+        blocking_subscribe: false,
     }
     .into();
     tracing::debug!("Starting WebSocket client connection");

--- a/crates/fdev/src/wasm_runtime/user_events.rs
+++ b/crates/fdev/src/wasm_runtime/user_events.rs
@@ -219,6 +219,7 @@ impl From<CommandInfo> for OpenRequest<'static> {
                 key: *key.id(),
                 return_contract_code: false,
                 subscribe: false,
+                blocking_subscribe: false,
             }
             .into(),
             Command::Put => {
@@ -228,6 +229,7 @@ impl From<CommandInfo> for OpenRequest<'static> {
                     state: WrappedState::new(state.into_bytes()),
                     related_contracts: Default::default(),
                     subscribe: false,
+                    blocking_subscribe: false,
                 }
                 .into()
             }
@@ -309,6 +311,7 @@ impl ClientEventsProxy for StdInput {
                                 key: *key.id(),
                                 return_contract_code: true,
                                 subscribe: false,
+                                blocking_subscribe: false,
                             }))
                             .await
                             .map_err(|e| {

--- a/crates/fdev/tests/websocket_response.rs
+++ b/crates/fdev/tests/websocket_response.rs
@@ -103,6 +103,7 @@ async fn test_websocket_client_waits_for_put_response() {
         state: WrappedState::new(vec![]),
         related_contracts: RelatedContracts::default(),
         subscribe: false,
+        blocking_subscribe: false,
     });
 
     client.send(request).await.expect("send request");


### PR DESCRIPTION
## Problem

When clients use `subscribe=true` on PUT/GET operations, subscriptions happen asynchronously. The blocking subscription infrastructure already exists (`start_subscription_after_put()` and `start_subscription_request()` both accept a `blocking_subscription: bool`), but the value was always hardcoded to `false` with TODO comments saying it should come from `ContractRequest` once stdlib was updated.

## Solution

With freenet-stdlib 0.1.33 now providing `blocking_subscribe: bool` on `ContractRequest::Put` and `ContractRequest::Get`, this PR wires the field through the entire operation pipeline:

- **put.rs**: Added `blocking_subscribe` to `PutState::PrepareRequest` / `AwaitingResponse`, `start_op()` / `start_op_with_id()` signatures, and replaced all hardcoded `false` in `start_subscription_after_put()` calls (4 sites)
- **get.rs**: Added `blocking_subscribe` to `GetState::PrepareRequest` / `AwaitingResponse`, `start_op()` / `start_op_with_id()` signatures, and wired it through `start_subscription_request()` calls (2 sites, guarded by `subscribe_requested && blocking_sub`)
- **client_events/mod.rs**: Extracts `blocking_subscribe` from `ContractRequest` and threads it through all PUT/GET code paths (local-only, dedup router, legacy)
- **request_router.rs**: Added `blocking_subscribe` field to `DeduplicatedRequest::Get` and `DeduplicatedRequest::Put`
- Updated all call sites across core, fdev, and ping app with `blocking_subscribe: false` default

Backward compatible: the field defaults to `false` in both FlatBuffers and serde, so existing clients are unaffected.

## Testing

- `cargo fmt` — clean
- `cargo clippy --all-targets --all-features` — no warnings
- `cargo test -p freenet --lib` — 1280 passed, 0 failed
- All request_router unit tests pass (18/18)

## Dependencies

- Requires freenet-stdlib 0.1.33: https://github.com/freenet/freenet-stdlib/pull/50