### PR TITLE
ci: revert temporary river branch ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: freenet/river
-          ref: feat/blocking-subscribe
           path: river-src
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Problem

PR #2879 temporarily pointed the six-peer-regression CI job at `freenet/river@feat/blocking-subscribe` because River needed updating for the new `blocking_subscribe` field in freenet-stdlib 0.1.33.

## Solution

River PR freenet/river#80 has been merged to main, so remove the `ref` override to go back to checking out River's default branch.

## Testing

CI will validate by running six-peer-regression against River main.