### PR TITLE
feat: use TransportPublicKey for higher-level peer identification

### DIFF
--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -982,9 +982,22 @@ where
                 // Update propagation uses the proximity cache directly, and subscriptions
                 // are lease-based with automatic expiry.
 
+                // Resolve source SocketAddr to TransportPublicKey for proximity cache
+                let source_pub_key = op_manager
+                    .ring
+                    .connection_manager
+                    .get_peer_by_addr(source)
+                    .map(|pkl| pkl.pub_key().clone());
+                let Some(source_pub_key) = source_pub_key else {
+                    tracing::warn!(
+                        %source,
+                        "ProximityCache: could not resolve source addr to pub_key, skipping"
+                    );
+                    break;
+                };
                 if let Some(response) = op_manager
                     .proximity_cache
-                    .handle_message(source, message.clone())
+                    .handle_message(&source_pub_key, message.clone())
                 {
                     // Send response back to sender
                     let response_msg =

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -1140,7 +1140,7 @@ impl P2pConnManager {
                                     ctx.bridge
                                         .op_manager
                                         .proximity_cache
-                                        .on_peer_disconnected(&peer_addr);
+                                        .on_peer_disconnected(peer.pub_key());
 
                                     // Clean up interest tracking for disconnected peer
                                     ctx.bridge
@@ -3059,7 +3059,7 @@ impl P2pConnManager {
                     .bridge
                     .op_manager
                     .proximity_cache
-                    .on_ring_connection_established(peer_addr)
+                    .on_ring_connection_established(peer.pub_key())
                 {
                     let msg = NetMessage::V1(NetMessageV1::ProximityCache { message: cache_msg });
                     if let Err(e) = self.bridge.send(peer_addr, msg).await {

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -472,6 +472,7 @@ async fn test_subscription_validates_k_closest_usage() {
                 instance_id: *contract_key.id(),
             }),
             requester_addr: None,
+            requester_pub_key: None,
             is_renewal: false,
         };
 
@@ -570,6 +571,7 @@ fn test_subscribe_op_state_lifecycle() {
             is_renewal: false,
         }),
         requester_addr: None,
+        requester_pub_key: None,
         is_renewal: false,
     };
 
@@ -590,6 +592,7 @@ fn test_subscribe_op_state_lifecycle() {
             instance_id,
         }),
         requester_addr: None,
+        requester_pub_key: None,
         is_renewal: false,
     };
 
@@ -612,6 +615,7 @@ fn test_subscribe_op_state_lifecycle() {
         id: tx_id,
         state: Some(SubscribeState::Completed { key: contract_key }),
         requester_addr: None,
+        requester_pub_key: None,
         is_renewal: false,
     };
 
@@ -644,6 +648,7 @@ fn test_subscribe_op_failed_state_returns_error() {
         id: tx_id,
         state: None,
         requester_addr: None,
+        requester_pub_key: None,
         is_renewal: false,
     };
 
@@ -677,6 +682,7 @@ fn test_local_subscription_completion_state() {
         id: tx_id,
         state: Some(SubscribeState::Completed { key: contract_key }),
         requester_addr: None, // Local subscription, no network requester
+        requester_pub_key: None,
         is_renewal: false,
     };
 
@@ -712,6 +718,7 @@ fn test_is_renewal_flag() {
         id: tx,
         state: Some(SubscribeState::Completed { key: contract_key }),
         requester_addr: None,
+        requester_pub_key: None,
         is_renewal: true,
     };
     assert!(renewal_op.is_renewal());
@@ -720,6 +727,7 @@ fn test_is_renewal_flag() {
         id: tx,
         state: Some(SubscribeState::Completed { key: contract_key }),
         requester_addr: None,
+        requester_pub_key: None,
         is_renewal: false,
     };
     assert!(!client_op.is_renewal());
@@ -737,6 +745,7 @@ fn test_op_enum_is_subscription_renewal() {
         id: tx,
         state: Some(SubscribeState::Completed { key: contract_key }),
         requester_addr: None,
+        requester_pub_key: None,
         is_renewal: true,
     });
     assert!(renewal.is_subscription_renewal());
@@ -745,6 +754,7 @@ fn test_op_enum_is_subscription_renewal() {
         id: tx,
         state: Some(SubscribeState::Completed { key: contract_key }),
         requester_addr: None,
+        requester_pub_key: None,
         is_renewal: false,
     });
     assert!(!non_renewal.is_subscription_renewal());


### PR DESCRIPTION
## Problem

`SocketAddr` is mutable (NAT traversal, reconnection) but was used as the primary key in `ProximityCacheManager` and for peer lookups during subscription interest registration. During NAT traversal there's a ~1-2 second timing window where:

1. Transport layer knows the peer's external address (from UDP packet source)
2. Ring layer has `PeerAddr::Unknown` or an internal NAT address
3. Address-based lookups fail during this window

This causes:
- Subscription registration failures ("could not find peer to register interest")
- Zero broadcast targets in UPDATE propagation
- Stale proximity cache entries for reconnected peers

Discovered during PR #2883 review discussion.

## Approach

**Targeted fix for higher-level structures only.** A wholesale switch to `TransportPublicKey` as primary identifier would add a mandatory addr→pubkey lookup on every incoming packet for no benefit at the transport level. Instead, use pubkey-based keys in the specific structures where address instability causes problems, while keeping `SocketAddr` at transport and connection management layers.

### Changes

| File | Change |
|------|--------|
| `proximity_cache.rs` | `DashMap<SocketAddr, ...>` → `DashMap<TransportPublicKey, ...>` — entries survive address changes |
| `subscribe.rs` | Add `requester_pub_key` field, resolve at init time (when connection is freshest), use for interest registration with addr fallback |
| `update.rs` | Use `get_peer_by_pub_key()` for proximity cache results instead of `get_peer_by_addr()` |
| `p2p_protoc.rs` | Pass `pub_key` to proximity cache disconnect/connect methods |
| `node/mod.rs` | Resolve addr→pubkey before proximity cache `handle_message` call |

### What stays the same

- Transport-level routing (sending messages) stays by `SocketAddr`
- `ConnectionManager` primary data structures unchanged
- `get_peer_by_addr()` kept for connection management and message routing
- `InterestManager` already uses `PeerKey(TransportPublicKey)` — no changes needed

## Testing

- All 1290 lib unit tests pass (0 failures, 7 ignored)
- 17/17 proximity cache tests pass (rewritten with `TransportPublicKey`)
- All subscribe and update tests pass
- `cargo clippy --all-targets --all-features` clean (0 warnings)
- Integration test failures (`127.1.x.x` loopback binding) are pre-existing macOS environment issues, unrelated to this change

## Fixes

Closes #2886

[AI-assisted - Claude]