### PR TITLE
fix: expire stale pending_reservations to prevent permanent node isolation

### DIFF
--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -1084,6 +1084,13 @@ impl Ring {
                 last_backoff_cleanup = Instant::now();
             }
 
+            // Clean up stale pending reservations to prevent permanent isolation
+            // when CONNECT operations fail to complete cleanly.
+            let stale_removed = self.connection_manager.cleanup_stale_reservations();
+            if stale_removed > 0 {
+                tracing::warn!(stale_removed, "Cleaned up stale pending reservations");
+            }
+
             // Acquire new connections up to MAX_CONCURRENT_CONNECTIONS limit
             // Only count Connect transactions, not all operations (Get/Put/Subscribe/Update)
             let active_count = live_tx_tracker.active_connect_transaction_count();


### PR DESCRIPTION
## Problem

`pending_reservations` in `ConnectionManager` leaks entries when CONNECT operations fail to complete cleanly (relay routes uphill after accepting, transaction timeout without cleanup, etc.). When all gateway addresses accumulate stale entries, `is_not_connected()` filters them out, `initial_join_procedure` becomes a no-op, and nodes get permanently stuck with zero ring connections.

This is actively affecting users in production (confirmed on technic via telemetry, likely affecting others).

## Solution

Add a 60-second TTL to `pending_reservations` entries. Each entry is now timestamped at insertion (`Instant::now()`), and the `connection_maintenance` loop calls `cleanup_stale_reservations()` each tick to expire old entries. This allows nodes to recover and retry connections even when CONNECT operations fail silently.

Key changes:
- `pending_reservations` type: `BTreeMap<SocketAddr, Location>` → `BTreeMap<SocketAddr, (Location, Instant)>`
- New `cleanup_stale_reservations()` method using `retain()` with warn-level logging
- Called from `connection_maintenance` loop alongside existing backoff cleanup

The 60s TTL matches the production maintenance tick interval and exceeds any reasonable CONNECT handshake duration.

## Testing

- New unit test `test_stale_pending_reservations_are_cleaned_up` verifies fresh entries survive cleanup and expired entries are removed
- All 39 existing `connection_manager` tests pass unchanged
- `cargo fmt && cargo clippy --all-targets --all-features` clean

## Files changed

- `crates/core/src/ring/connection_manager.rs` — type change, timestamp insertion, cleanup method, unit test
- `crates/core/src/ring/mod.rs` — call cleanup from `connection_maintenance`

[AI-assisted - Claude]