### PR TITLE
fix: clean up request router on operation init failure

### DIFF
--- a/crates/core/src/client_events/mod.rs
+++ b/crates/core/src/client_events/mod.rs
@@ -313,6 +313,12 @@ async fn report_op_init_error(
             "Failed to send {op_name} error to result router"
         );
     }
+
+    // Clean up request router so subsequent requests for the same resource
+    // create a fresh operation instead of reusing this failed transaction.
+    // Without this, the resource→transaction mapping persists and new clients
+    // get stale cached errors indefinitely (see diagnostic report 8TSMXY).
+    op_manager.completed(tx);
 }
 
 /// Process client events.


### PR DESCRIPTION
## Problem

When a GET request fails during initialization (e.g., `RingError::EmptyRing` when no ring connections exist), the error is sent to the client but the `RequestRouter`'s resource→transaction mapping is never cleaned up. Subsequent browser retries for the same contract reuse the failed transaction, receiving stale cached 503 errors indefinitely — even after ring connections become available.

This was discovered via diagnostic report `8TSMXY` (mirrorwizard) where **660 GET requests over 30 minutes** all returned the same cached error from the initial failed attempt. The only workaround was restarting the node.

### Root cause

`report_op_init_error` sends the error to the `result_router_tx` for delivery to the client, but never calls `complete_operation` on the request router. The stale `resource→transaction` mapping persists, so `route_request` returns `(existing_tx, should_start=false)` for every subsequent request — no new operation is ever created.

## Solution

Call `op_manager.completed(tx)` in `report_op_init_error` after sending the error. This cleans up the router mapping so the next request creates a fresh operation. `completed()` is idempotent and safe to call even for operations that were never pushed to `under_progress`.

**1 line of functional code changed** (plus comment).

## Testing

- All 1,387 existing tests pass (0 failures)
- The fix is exercised by any test where an operation fails during init — the existing `test_request_after_completion_starts_new_operation` test validates that `complete_operation` enables fresh requests
- The `complete_operation` / `completed()` methods are already well-tested for idempotency

## Fixes

Related to user reports from 2026-02-08: ZTYPCQ, XP4ZZ2, 9FNS2E, 8TSMXY, AQDD89

[AI-assisted - Claude]