### PR TITLE
fix: reduce notification channel congestion and add event loop diagnostics

### DIFF
--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -146,13 +146,16 @@ pub fn reset_channel_id_counter() {
     CHANNEL_ID_COUNTER.store(0, std::sync::atomic::Ordering::SeqCst);
 }
 
+/// Channel capacity for event loop notification and op execution channels.
+const EVENT_LOOP_CHANNEL_CAPACITY: usize = 2048;
+
 pub(crate) fn event_loop_notification_channel(
 ) -> (EventLoopNotificationsReceiver, EventLoopNotificationsSender) {
     use std::sync::atomic::Ordering;
 
     let _channel_id = CHANNEL_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
-    let (notification_tx, notification_rx) = mpsc::channel(2048);
-    let (op_execution_tx, op_execution_rx) = mpsc::channel(2048);
+    let (notification_tx, notification_rx) = mpsc::channel(EVENT_LOOP_CHANNEL_CAPACITY);
+    let (op_execution_tx, op_execution_rx) = mpsc::channel(EVENT_LOOP_CHANNEL_CAPACITY);
 
     tracing::info!(
         channel_id = _channel_id,
@@ -196,6 +199,13 @@ pub(crate) struct EventLoopNotificationsSender {
 impl EventLoopNotificationsSender {
     pub(crate) fn notifications_sender(&self) -> &Sender<Either<NetMessage, NodeEvent>> {
         &self.notifications_sender
+    }
+
+    /// Returns the number of messages currently queued in the notification channel.
+    pub(crate) fn notification_channel_pending(&self) -> usize {
+        self.notifications_sender
+            .max_capacity()
+            .saturating_sub(self.notifications_sender.capacity())
     }
 
     #[allow(dead_code)] // FIXME: enable async sub-transactions

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -618,10 +618,10 @@ impl P2pConnManager {
         // vs unexpected stream end
         let mut graceful_shutdown = false;
 
-        // Event loop instrumentation: track processing stats for diagnostics
-        let mut loop_iteration_count: u64 = 0;
-        let mut slow_event_count: u64 = 0;
-        let mut last_stats_log = std::time::Instant::now();
+        // Event loop instrumentation
+        let mut loop_iteration_count = 0u64;
+        let mut slow_event_count = 0u64;
+        let mut last_stats_log = Instant::now();
         const STATS_LOG_INTERVAL: Duration = Duration::from_secs(30);
         const SLOW_EVENT_THRESHOLD: Duration = Duration::from_millis(100);
 
@@ -639,7 +639,7 @@ impl P2pConnManager {
                 priority_select::SelectResult::ExecutorTransaction(_) => "executor_transaction",
             };
 
-            let process_start = std::time::Instant::now();
+            let process_start = Instant::now();
 
             // Process the result using the existing handler
             let event = ctx
@@ -658,20 +658,18 @@ impl P2pConnManager {
 
             // Periodic stats logging
             if last_stats_log.elapsed() > STATS_LOG_INTERVAL {
-                let notification_capacity =
-                    op_manager.to_event_listener.notifications_sender.capacity();
-                let notification_pending = 2048usize.saturating_sub(notification_capacity);
+                let notifier = &op_manager.to_event_listener;
                 tracing::info!(
                     iterations = loop_iteration_count,
                     slow_events = slow_event_count,
-                    notification_channel_pending = notification_pending,
-                    notification_channel_capacity = notification_capacity,
+                    notification_channel_pending = notifier.notification_channel_pending(),
+                    notification_channel_capacity = notifier.notifications_sender.capacity(),
                     active_connections = ctx.connections.len(),
                     "Event loop stats"
                 );
                 loop_iteration_count = 0;
                 slow_event_count = 0;
-                last_stats_log = std::time::Instant::now();
+                last_stats_log = Instant::now();
             }
 
             match event {

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -503,13 +503,11 @@ impl OpManager {
             Ok(Ok(())) => {}
             Ok(Err(_)) => return Err(OpError::NotificationError),
             Err(_) => {
-                let remaining_capacity = self.to_event_listener.notifications_sender().capacity();
-                let pending = 2048usize.saturating_sub(remaining_capacity);
                 tracing::error!(
                     tx = %tx,
                     timeout_secs = Self::NOTIFICATION_SEND_TIMEOUT.as_secs(),
-                    channel_pending = pending,
-                    channel_remaining = remaining_capacity,
+                    channel_pending = self.to_event_listener.notification_channel_pending(),
+                    channel_remaining = self.to_event_listener.notifications_sender().capacity(),
                     "notify_op_change: Notification channel full for too long, event loop may be stuck"
                 );
                 return Err(OpError::NotificationChannelError(
@@ -545,12 +543,10 @@ impl OpManager {
             Ok(Ok(())) => Ok(()),
             Ok(Err(e)) => Err(e.into()),
             Err(_) => {
-                let remaining_capacity = self.to_event_listener.notifications_sender().capacity();
-                let pending = 2048usize.saturating_sub(remaining_capacity);
                 tracing::error!(
                     timeout_secs = Self::NOTIFICATION_SEND_TIMEOUT.as_secs(),
-                    channel_pending = pending,
-                    channel_remaining = remaining_capacity,
+                    channel_pending = self.to_event_listener.notification_channel_pending(),
+                    channel_remaining = self.to_event_listener.notifications_sender().capacity(),
                     "notify_node_event: Notification channel full for too long, event loop may be stuck"
                 );
                 Err(OpError::NotificationChannelError(

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -446,10 +446,8 @@ impl Ring {
                 if ring.mark_subscription_pending(contract) {
                     attempted += 1;
 
-                    // Stagger spawns to avoid bursting 20 operations onto the
-                    // notification channel simultaneously. Each renewal gets a
-                    // random 0-500ms delay, spreading the load over ~10 seconds
-                    // instead of hitting the event loop all at once.
+                    // Stagger spawns to avoid bursting all renewals onto the
+                    // notification channel simultaneously.
                     let jitter_ms = GlobalRng::random_range(0u64..=500);
 
                     let op_manager_clone = op_manager.clone();


### PR DESCRIPTION
## Problem

Both gateways (nova and vega) were showing "notify_op_change: Notification channel full for too long" errors every 30 seconds after v0.1.117 deployed. While the OOM fix in #2929 successfully bounded memory (~365-430MB vs 6.5GB before), the event loop was still congested.

Root cause: The notification channel (capacity 100) was a bottleneck when subscription renewals (20/30s), transaction timeouts (10+/5s GC tick), and inbound connections all competed for it simultaneously. This caused a cascade:
1. Channel fills up from burst of 20 subscription renewals + timeout notifications
2. Renewals timeout waiting for channel capacity → trigger exponential backoff
3. Subscriptions expire → node loses contract updates
4. `skipped_rate_limited` grows monotonically: 9→14→24→34→66→140→159

## Approach

Three-pronged fix targeting different aspects of the congestion:

1. **Increase channel capacity** (100→2048): Absorbs bursts without fundamentally changing backpressure semantics. The channel drains fast once the event loop processes events, so this prevents transient spikes from causing cascading failures.

2. **Stagger subscription renewals** (0-500ms jitter): Instead of firing 20 subscription operations simultaneously, each gets a random 0-500ms delay. This spreads the load over ~10 seconds instead of hitting the notification channel all at once.

3. **Non-blocking timeout notifications** (`try_send` instead of `.send().await`): The GC task already cleans up timed-out transactions from the ops maps. The event loop notification only cleans up `tx_to_client` mappings — informational, not critical. Using `try_send` prevents the GC loop from blocking when the channel is full.

Plus **event loop instrumentation** to help diagnose future congestion:
- Periodic stats (every 30s): iteration count, slow events, channel depth, active connections
- Slow event detection (>100ms) with event type identification
- Channel depth in timeout error messages

## Testing

- `cargo fmt` - clean
- `cargo clippy --all-targets --all-features` - clean
- `cargo test -p freenet` - all tests pass
- Updated existing `notify_transaction_timeout` tests for the sync (non-async) signature

## Fixes

Addresses notification channel congestion observed in production after #2929 merge.

[AI-assisted - Claude]