### PR TITLE
fix: reduce default fixedrate from 100 Mbps to 10 Mbps per connection

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -842,7 +842,7 @@ pub struct NetworkArgs {
     /// Congestion control algorithm for transport connections.
     ///
     /// Available algorithms:
-    /// - `fixedrate` (default): Fixed-rate transmission at 100 Mbps, ignores network feedback
+    /// - `fixedrate` (default): Fixed-rate transmission at 10 Mbps per connection, ignores network feedback
     /// - `bbr`: BBR (Bottleneck Bandwidth and RTT) - model-based, tolerates packet loss
     /// - `ledbat`: LEDBAT++ - delay-based, yields to foreground traffic
     ///
@@ -1003,7 +1003,7 @@ pub struct NetworkApiConfig {
     /// Congestion control algorithm for transport connections.
     ///
     /// Available algorithms:
-    /// - `fixedrate` (default): Fixed-rate transmission at 100 Mbps
+    /// - `fixedrate` (default): Fixed-rate transmission at 10 Mbps per connection
     /// - `bbr`: BBR (Bottleneck Bandwidth and RTT)
     /// - `ledbat`: LEDBAT++ (Low Extra Delay Background Transport)
     #[serde(default = "default_congestion_control", rename = "congestion-control")]

--- a/crates/core/src/transport/congestion_control.rs
+++ b/crates/core/src/transport/congestion_control.rs
@@ -14,8 +14,8 @@
 //! ## Supported Algorithms
 //!
 //! - **FixedRate** (default): Non-adaptive congestion control that transmits at
-//!   a constant rate (default 100 Mbps). A pragmatic fallback while adaptive
-//!   algorithms are being stabilized.
+//!   a constant rate (default 10 Mbps per connection). A pragmatic fallback
+//!   while adaptive algorithms are being stabilized.
 //! - **BBR**: Model-based congestion control that estimates bandwidth
 //!   and RTT, tolerating packet loss as long as bandwidth remains stable.
 //! - **LEDBAT++**: Low Extra Delay Background Transport, optimized for
@@ -85,7 +85,7 @@ pub enum CongestionControlAlgorithm {
     ///
     /// Transmits at a constant rate regardless of network feedback.
     /// A pragmatic fallback when adaptive algorithms have bugs or instabilities.
-    /// Default rate: 100 Mbps.
+    /// Default rate: 10 Mbps.
     #[default]
     FixedRate,
 }
@@ -833,7 +833,7 @@ pub enum AlgorithmConfig {
 
 impl Default for CongestionControlConfig {
     fn default() -> Self {
-        // Default to FixedRate (100 Mbps) - pragmatic choice while adaptive algorithms are unstable
+        // Default to FixedRate (10 Mbps) - pragmatic choice while adaptive algorithms are unstable
         use super::fixed_rate::DEFAULT_RATE_BYTES_PER_SEC;
         Self {
             algorithm: CongestionControlAlgorithm::FixedRate,

--- a/crates/core/src/transport/fixed_rate/controller.rs
+++ b/crates/core/src/transport/fixed_rate/controller.rs
@@ -5,20 +5,22 @@ use std::time::Duration;
 
 use crate::simulation::{RealTime, TimeSource};
 
-/// Default rate: 100 Mbps in bytes/sec (100 * 1_000_000 / 8)
+/// Default rate: 10 Mbps in bytes/sec (10 * 1_000_000 / 8)
 ///
 /// This rate is chosen to:
-/// - Support fast contract retrieval (user-visible critical path)
+/// - Support contract retrieval without saturating residential connections
 /// - Account for sequential multi-hop transfer (3-5x slower than single hop)
-/// - Remain conservative enough not to degrade other network usage
-/// - Work reliably across real network paths (validated on nova↔vega)
-pub const DEFAULT_RATE_BYTES_PER_SEC: usize = 12_500_000;
+/// - With 10 connections, total throughput is ~100 Mbps — within most residential
+///   upload bandwidth limits
+/// - Previous 100 Mbps per-connection rate caused residential ISPs/routers to
+///   throttle or drop all connections (see diagnostic report MEB6RV)
+pub const DEFAULT_RATE_BYTES_PER_SEC: usize = 1_250_000;
 
 /// Configuration for the fixed-rate controller.
 #[derive(Debug, Clone)]
 pub struct FixedRateConfig {
     /// Target transmission rate in bytes per second.
-    /// Default: 100 Mbps (12,500,000 bytes/sec)
+    /// Default: 10 Mbps (1,250,000 bytes/sec)
     pub rate_bytes_per_sec: usize,
 }
 
@@ -161,13 +163,13 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = FixedRateConfig::default();
-        assert_eq!(config.rate_bytes_per_sec, 12_500_000); // 100 Mbps
+        assert_eq!(config.rate_bytes_per_sec, 1_250_000); // 10 Mbps
     }
 
     #[test]
     fn test_from_mbps() {
-        let config = FixedRateConfig::from_mbps(100);
-        assert_eq!(config.rate_bytes_per_sec, 12_500_000); // 100 Mbps
+        let config = FixedRateConfig::from_mbps(10);
+        assert_eq!(config.rate_bytes_per_sec, 1_250_000); // 10 Mbps
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The default `fixedrate` congestion control sends at 100 Mbps (12.5 MB/s) **per connection** with no backoff. With 10 connections, a node can attempt to push 1 Gbps — far exceeding typical residential upload bandwidth (10-50 Mbps).

This was validated on server-to-server links (nova↔vega) but causes serious problems for home users:
- Saturates upload bandwidth, killing all other internet traffic (including TCP ACKs for downloads)
- ISPs/routers detect the aggressive traffic pattern and throttle or drop connections
- User diagnostic report MEB6RV showed all 4 connections dropping simultaneously within 80ms, followed by inability to reconnect — classic ISP traffic shaping response

## Solution

Reduce `DEFAULT_RATE_BYTES_PER_SEC` from 12,500,000 (100 Mbps) to 1,250,000 (10 Mbps) per connection.

With 10 connections, total throughput is ~100 Mbps — still fast enough for contract retrieval but within most residential bandwidth limits. Users with faster connections can still override via config.

## Testing

- All fixed_rate controller tests pass (8/8)
- All congestion_control tests pass (27/27)
- All config congestion control tests pass (4/4)

[AI-assisted - Claude]