### PR TITLE
fix: prevent double-compilation race and increase stream claim timeout

### DIFF
--- a/crates/core/src/operations/orphan_streams.rs
+++ b/crates/core/src/operations/orphan_streams.rs
@@ -43,7 +43,12 @@ use crate::transport::peer_connection::StreamId;
 pub const ORPHAN_STREAM_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Default timeout when waiting for a stream to arrive after metadata.
-pub const STREAM_CLAIM_TIMEOUT: Duration = Duration::from_secs(10);
+///
+/// On resource-constrained CI runners, stream fragments can be delayed by
+/// seconds due to CPU contention and network virtualization overhead.
+/// 30 seconds provides enough headroom while still failing promptly on
+/// genuinely broken connections.
+pub const STREAM_CLAIM_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Registry for handling race conditions between stream fragments and metadata messages.
 ///


### PR DESCRIPTION
## Problem

Two sources of CI test flakiness observed during PR #2937 (shared module cache):

1. **Double-compilation race**: When two RuntimePool executors both miss the shared module cache simultaneously, they serialize through the shared Engine Mutex and both compile the same contract. The second compilation wastes seconds of Engine Mutex time, blocking all other executors from compiling or creating instances.

2. **Orphan stream claim timeout too tight**: `STREAM_CLAIM_TIMEOUT` was 10 seconds. On resource-constrained CI runners (Ubicloud shared infrastructure), stream fragments can be delayed by CPU contention, network virtualization overhead, and I/O contention. `test_ping_application_loop` failed with "failed to claim orphan stream" when fragment delivery exceeded 10s.

## Solution

1. **Check-after-compile pattern**: After compilation completes, re-check the shared module cache before inserting. If another executor already compiled and cached the same module while we were blocked on the Engine Mutex, use the cached version. This avoids wasting Engine Mutex time on duplicate compilations.

2. **Increase `STREAM_CLAIM_TIMEOUT` from 10s to 30s**: Matches `ORPHAN_STREAM_TIMEOUT` (the GC timeout) and provides adequate headroom for slow CI environments while still failing promptly on genuinely broken connections.

## Testing

- All 1330+ unit/integration tests pass locally
- `test_ping_application_loop` passes locally (72s)
- `operations_before_join` passes locally

[AI-assisted - Claude]