### PR TITLE
fix: wasm timeout should not kill entire contract handling loop

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -1069,19 +1069,20 @@ mod tests {
             let err = ExecutorError::other(anyhow::anyhow!("not a request"));
             let _unwrapped = err.unwrap_request(); // Should panic
         }
-    }
 
-    #[test]
-    fn test_max_compute_time_exceeded_is_not_fatal() {
-        use crate::wasm_runtime::{ContractError, ContractExecError, RuntimeInnerError};
-        let contract_err: ContractError =
-            RuntimeInnerError::ContractExecError(ContractExecError::MaxComputeTimeExceeded).into();
-        // op: None simulates validate_state() path where the bug manifested
-        let err = ExecutorError::execution(contract_err, None);
-        assert!(
-            !err.is_fatal(),
-            "MaxComputeTimeExceeded must not be fatal - it would kill the entire contract handler"
-        );
+        #[test]
+        fn test_max_compute_time_exceeded_is_not_fatal() {
+            use crate::wasm_runtime::{ContractError, ContractExecError, RuntimeInnerError};
+            let contract_err: ContractError =
+                RuntimeInnerError::ContractExecError(ContractExecError::MaxComputeTimeExceeded)
+                    .into();
+            // op: None simulates validate_state() path where the bug manifested
+            let err = ExecutorError::execution(contract_err, None);
+            assert!(
+                !err.is_fatal(),
+                "MaxComputeTimeExceeded must not be fatal - it would kill the entire contract handler"
+            );
+        }
     }
 
     mod test_fixtures_tests {


### PR DESCRIPTION
## Problem

On technic.locut.us, the Freenet node stopped processing River contract updates despite receiving them over the network. A WASM execution timeout for one contract (`Gsd2311...`) caused the `contract_handling()` async task to exit entirely, stopping ALL contract processing for ALL contracts. Only a service restart restored functionality.

`MaxComputeTimeExceeded` was classified as a **fatal** error in `ExecutorError::execution()`, which propagated to `contract_handling()` at `mod.rs:470` and killed the handler task spawned at `p2p_impl.rs:321`.

## Solution

WASM timeouts are per-operation failures, not system-wide. The executor pool already has a healthy replacement mechanism (`return_checked` → `create_replacement_executor`).

Removed the `MaxComputeTimeExceeded → fatal = true` classification so timeouts are treated as regular errors that fail the individual operation without killing the handler loop.

## Testing

- Added regression test `test_max_compute_time_exceeded_is_not_fatal` verifying the `validate_state()` path (`op: None`) does not produce a fatal error
- `cargo fmt && cargo clippy --all-targets --all-features && cargo test -p freenet` all pass

[AI-assisted - Claude]