### PR TITLE
fix: show friendly connecting page for PEER_NOT_JOINED error

### DIFF
--- a/crates/core/src/server/errors.rs
+++ b/crates/core/src/server/errors.rs
@@ -7,6 +7,7 @@ use std::fmt::{Display, Formatter};
 /// Marker string used to identify EmptyRing errors without needing to modify freenet-stdlib.
 /// If this string changes in ring/mod.rs, update it here too.
 const EMPTY_RING_ERROR: &str = "No ring connections found";
+const PEER_NOT_JOINED_ERROR: &str = "PEER_NOT_JOINED";
 
 #[derive(Debug)]
 pub(super) enum WebSocketApiError {
@@ -64,10 +65,10 @@ impl From<WebSocketApiError> for Response {
 
 impl IntoResponse for WebSocketApiError {
     fn into_response(self) -> Response {
-        // Check for EmptyRing error (peer still connecting to network)
+        // Check for errors that indicate the peer is still connecting to the network
         if let WebSocketApiError::AxumError { ref error } = self {
             let error_str = format!("{error}");
-            if error_str.contains(EMPTY_RING_ERROR) {
+            if error_str.contains(EMPTY_RING_ERROR) || error_str.contains(PEER_NOT_JOINED_ERROR) {
                 return (StatusCode::SERVICE_UNAVAILABLE, Html(connecting_page())).into_response();
             }
         }


### PR DESCRIPTION
## Problem

When a user's browser requests a web app before the peer has joined the network, they see a raw error string:

> error while executing operation in the network: PEER_NOT_JOINED: peer has not joined the network yet - retry after node joins

This is confusing and unfriendly for end users.

## Approach

The PEER_NOT_JOINED error represents the same situation as the existing EmptyRing ("No ring connections found") error — the peer is still connecting to the network. We already have a friendly `connecting_page()` with the Freenet logo, a spinner, and auto-refresh for the EmptyRing case.

This PR simply adds PEER_NOT_JOINED to the same check so both errors show the friendly "Connecting to Freenet..." page.

## Testing

- `cargo fmt` / `cargo clippy` clean
- Existing `operations_before_join` test validates the WebSocket API path still returns PEER_NOT_JOINED correctly
- The HTTP path handler in `errors.rs` now catches both error strings and returns the 503 connecting page

[AI-assisted - Claude]