### PR TITLE
build: explicitly pin CI workflows to Rust 1.93.0

### DIFF
--- a/.github/workflows/benchmarks-extended.yml
+++ b/.github/workflows/benchmarks-extended.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.93.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.93.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.93.0
           components: rustfmt
 
       - name: Check code formatting
@@ -110,6 +111,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.93.0
           components: clippy
           targets: wasm32-unknown-unknown
 
@@ -152,6 +154,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.93.0
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
@@ -237,6 +240,8 @@ jobs:
           path: river-src
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.93.0
           targets: x86_64-unknown-linux-musl
 
       - uses: Swatinem/rust-cache@v2
@@ -59,7 +59,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.93.0
           targets: aarch64-unknown-linux-musl
 
       - uses: Swatinem/rust-cache@v2
@@ -96,7 +96,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.93.0
 
       - uses: Swatinem/rust-cache@v2
 
@@ -142,7 +142,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.93.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
 
       - name: Update Cargo.lock
         run: cargo update --workspace
@@ -207,6 +209,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
 
       - name: Publish freenet to crates.io
         env:

--- a/.github/workflows/river_pr_merge_notify.yml
+++ b/.github/workflows/river_pr_merge_notify.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
 
       - name: Install riverctl
         run: cargo install riverctl

--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.93.0
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Problem

While rust-toolchain.toml (#2948) pins the Rust version for local development, CI workflows were still using `dtolnay/rust-toolchain@stable` without explicitly specifying the toolchain version. This creates potential inconsistencies:
- CI could use a different Rust version than local development
- Workflows aren't self-documenting about which Rust version they use
- Automatic updates to stable could cause unexpected CI failures

## Solution

Explicitly add `toolchain: 1.93.0` to all `dtolnay/rust-toolchain@stable` actions across all CI workflows. This ensures:
- CI uses the exact same Rust version as local development (via rust-toolchain.toml)
- Workflows are self-documenting about the Rust version
- Rust version updates are intentional and reviewable

## Changes

Updated 7 workflow files to explicitly specify `toolchain: 1.93.0`:
- `.github/workflows/ci.yml` (4 jobs: fmt_check, clippy_check, test_all, six_peer_regression)
- `.github/workflows/benchmarks.yml` (1 job)
- `.github/workflows/benchmarks-extended.yml` (1 job)
- `.github/workflows/cross-compile.yml` (4 jobs: x86_64-linux-musl, aarch64-linux-musl, x86_64-macos, aarch64-macos)
- `.github/workflows/release.yml` (2 jobs: create_release_branch, publish_crates)
- `.github/workflows/river_pr_merge_notify.yml` (1 job)
- `.github/workflows/simulation-nightly.yml` (1 job, updated from 1.91.0)

## Testing

✅ All workflow YAML files validated
✅ Pre-commit hooks passed
✅ Verified all toolchain references updated: `grep -A 2 "dtolnay/rust-toolchain@stable" .github/workflows/*.yml | grep toolchain`

## Related

- Complements #2948 which added rust-toolchain.toml for local development
- Ensures consistent Rust version across all environments (local + CI)