### PR TITLE
feat: add --system flag for system-wide service install

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -7,7 +7,8 @@
 use anyhow::{Context, Result};
 use clap::Subcommand;
 use freenet::config::ConfigPaths;
-use std::{path::Path, sync::Arc};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use super::report::ReportCommand;
 
@@ -150,6 +151,38 @@ fn has_user_service() -> bool {
         .unwrap_or(false)
 }
 
+/// Recursively chown a directory to the given user (best-effort).
+/// Used after creating directories with sudo so the service user can write to them.
+#[cfg(target_os = "linux")]
+fn chown_to_user(path: &Path, username: &str) {
+    let _ = std::process::Command::new("chown")
+        .args(["-R", username, &path.display().to_string()])
+        .status();
+}
+
+/// Look up a user's home directory from /etc/passwd via `getent passwd`.
+/// Falls back to `/home/{username}` if getent is unavailable.
+#[cfg(target_os = "linux")]
+fn home_dir_for_user(username: &str) -> PathBuf {
+    // Try getent passwd which works with NSS (LDAP, NIS, etc.)
+    if let Ok(output) = std::process::Command::new("getent")
+        .args(["passwd", username])
+        .output()
+    {
+        if output.status.success() {
+            let line = String::from_utf8_lossy(&output.stdout);
+            // Format: username:x:uid:gid:gecos:home:shell
+            if let Some(home) = line.split(':').nth(5) {
+                let home = home.trim();
+                if !home.is_empty() {
+                    return PathBuf::from(home);
+                }
+            }
+        }
+    }
+    PathBuf::from(format!("/home/{username}"))
+}
+
 /// Resolve whether to use system or user mode.
 /// If `--system` is passed, use system mode. Otherwise auto-detect based on
 /// which service file exists, defaulting to user mode.
@@ -269,20 +302,23 @@ fn install_system_service() -> Result<()> {
              or run with sudo (which sets SUDO_USER).",
         )?;
 
-    // When running with sudo, dirs::home_dir() returns /root.
-    // We need the actual user's home directory.
-    let home_dir = if std::env::var("SUDO_USER").is_ok() {
-        // Look up the original user's home from /etc/passwd via HOME or fallback
-        std::env::var("SUDO_HOME")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|_| std::path::PathBuf::from(format!("/home/{username}")))
-    } else {
-        dirs::home_dir().context("Failed to get home directory")?
-    };
+    if username == "root" {
+        anyhow::bail!(
+            "Refusing to install system service running as root.\n\
+             Run with sudo from a non-root user account so SUDO_USER is set,\n\
+             or set the USER environment variable to the desired service user."
+        );
+    }
 
-    // Create log directory
+    // Look up the user's home directory from /etc/passwd.
+    // When running with sudo, dirs::home_dir() returns /root which is wrong.
+    let home_dir = home_dir_for_user(&username);
+
+    // Create log directory and fix ownership (we're running as root via sudo,
+    // but the service will run as the target user).
     let log_dir = home_dir.join(".local/state/freenet");
     fs::create_dir_all(&log_dir).context("Failed to create log directory")?;
+    chown_to_user(&log_dir, &username);
 
     let service_content = generate_system_service_file(&exe_path, &log_dir, &username, &home_dir);
 

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -8,10 +8,10 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-#[cfg(target_os = "linux")]
-use super::service::generate_user_service_file;
 #[cfg(target_os = "macos")]
 use super::service::generate_wrapper_script;
+#[cfg(target_os = "linux")]
+use super::service::{generate_system_service_file, generate_user_service_file};
 
 const GITHUB_API_URL: &str = "https://api.github.com/repos/freenet/freenet-core/releases/latest";
 
@@ -567,19 +567,36 @@ fn verify_binary(binary_path: &Path) -> Result<()> {
 /// This ensures users who installed before v0.1.75 get the ExecStopPost hook.
 #[cfg(target_os = "linux")]
 fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
-    let home_dir = match dirs::home_dir() {
-        Some(dir) => dir,
-        None => return Ok(()), // Can't update service file without home dir
-    };
+    // Try user service first
+    let home_dir = dirs::home_dir();
+    let user_service_path = home_dir
+        .as_ref()
+        .map(|h| h.join(".config/systemd/user/freenet.service"));
 
-    let service_path = home_dir.join(".config/systemd/user/freenet.service");
-
-    // Only update if service file exists (user has installed as service)
-    if !service_path.exists() {
-        return Ok(());
+    if let Some(ref service_path) = user_service_path {
+        if service_path.exists() {
+            return update_service_file(binary_path, service_path, false, quiet);
+        }
     }
 
-    let content = fs::read_to_string(&service_path).context("Failed to read service file")?;
+    // Try system service
+    let system_service_path = Path::new("/etc/systemd/system/freenet.service");
+    if system_service_path.exists() {
+        return update_service_file(binary_path, system_service_path, true, quiet);
+    }
+
+    Ok(())
+}
+
+/// Update a specific service file if it's missing the auto-update hook.
+#[cfg(target_os = "linux")]
+fn update_service_file(
+    binary_path: &Path,
+    service_path: &Path,
+    system_mode: bool,
+    quiet: bool,
+) -> Result<()> {
+    let content = fs::read_to_string(service_path).context("Failed to read service file")?;
 
     // Check if the auto-update hook is present
     if content.contains("ExecStopPost=") {
@@ -592,7 +609,7 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
 
     // Create backup of existing service file in case user had customizations
     let backup_path = service_path.with_extension("service.bak");
-    if let Err(e) = fs::copy(&service_path, &backup_path) {
+    if let Err(e) = fs::copy(service_path, &backup_path) {
         if !quiet {
             eprintln!(
                 "Warning: Failed to backup service file: {}. Continuing anyway.",
@@ -604,20 +621,44 @@ fn ensure_service_file_updated(binary_path: &Path, quiet: bool) -> Result<()> {
     }
 
     // Generate new service file content
-    let log_dir = home_dir.join(".local/state/freenet");
-    let new_content = generate_user_service_file(binary_path, &log_dir);
+    let new_content = if system_mode {
+        // Extract User= and Environment=HOME= from existing file
+        let username = content
+            .lines()
+            .find_map(|l| l.strip_prefix("User="))
+            .unwrap_or("freenet");
+        let home_dir = content
+            .lines()
+            .find_map(|l| l.strip_prefix("Environment=HOME="))
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(format!("/home/{username}")));
+        let log_dir = home_dir.join(".local/state/freenet");
+        generate_system_service_file(binary_path, &log_dir, username, &home_dir)
+    } else {
+        let home_dir = dirs::home_dir().context("Failed to get home directory")?;
+        let log_dir = home_dir.join(".local/state/freenet");
+        generate_user_service_file(binary_path, &log_dir)
+    };
 
     // Write the updated service file
-    fs::write(&service_path, new_content).context("Failed to write updated service file")?;
+    fs::write(service_path, new_content).context("Failed to write updated service file")?;
 
     // Reload systemd daemon
-    let status = Command::new("systemctl")
-        .args(["--user", "daemon-reload"])
-        .status()
-        .context("Failed to reload systemd")?;
+    let mut cmd = Command::new("systemctl");
+    if !system_mode {
+        cmd.arg("--user");
+    }
+    cmd.arg("daemon-reload");
+    let status = cmd.status().context("Failed to reload systemd")?;
 
     if !status.success() && !quiet {
-        eprintln!("Warning: Failed to reload systemd daemon. Run 'systemctl --user daemon-reload' manually.");
+        if system_mode {
+            eprintln!(
+                "Warning: Failed to reload systemd daemon. Run 'systemctl daemon-reload' manually."
+            );
+        } else {
+            eprintln!("Warning: Failed to reload systemd daemon. Run 'systemctl --user daemon-reload' manually.");
+        }
     } else if !quiet {
         println!("Service file updated with auto-update hook.");
     }


### PR DESCRIPTION
## Problem

Users running Freenet in containers (LXC/Docker), headless servers, or environments without a user systemd session bus cannot use `freenet service install`. The current implementation exclusively uses `systemctl --user`, which requires `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, and an active user session — none of which are available in unprivileged LXC containers.

Reported by a user on Matrix who was trying to install Freenet on a Proxmox Ubuntu LXC.

## Approach

Add a `--system` flag to `freenet service install` (and related subcommands) that installs to `/etc/systemd/system/` instead of `~/.config/systemd/user/`. The system service file includes:
- `User=` directive (detected from `$SUDO_USER` / `$USER`)
- `Environment=HOME=` (so config/data paths resolve correctly)
- `WantedBy=multi-user.target` (starts on boot, not on login)

For `start`/`stop`/`restart`/`status`, auto-detection checks which service file exists so users don't need to pass `--system` every time after install.

When `systemctl --user` fails, the error message now detects common session bus failures and suggests `--system` as a fix.

On macOS and Windows, `--system` is rejected with a clear message pointing to the default approach.

## Testing

- Existing `test_systemd_user_service_file_generation` updated (renamed from `test_systemd_service_file_generation`)
- New `test_systemd_system_service_file_generation` validates `User=`, `HOME=`, `WantedBy=multi-user.target`
- Both tests pass locally: `cargo test --bin freenet -- systemd`
- `cargo fmt`, `cargo clippy --all-targets --all-features` clean
- Manual verification of `--help` output confirms `--system` flag is visible

[AI-assisted - Claude]