### PR TITLE
fix: commit contract updates locally before network broadcast in PUT path

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1543,6 +1543,12 @@ impl Executor<Runtime> {
             // (e.g. fdev publish), the client needs a timely response. The network
             // broadcast is fire-and-forget — if it fails, subscribers will still get
             // the update via their next sync.
+            //
+            // NOTE: This simplified path does not handle contracts that require related
+            // contracts for update_state or validate_state. If update_state returns
+            // MissingRelated (new_state=None with non-empty related), it is treated as
+            // "no change". This is acceptable because no current contracts use related
+            // contracts (see issue #2870 for completing that mechanism).
             let current_state = self
                 .state_store
                 .get(&key)


### PR DESCRIPTION
## Problem

When publishing updates to an existing contract via `fdev publish` (e.g. updating River's web container), the gateway consistently returns timeout or error responses even though the update actually succeeds:

1. `perform_contract_put` detects the contract already exists and delegates to `perform_contract_update`
2. In network mode, `perform_contract_update` calls `op_request()` which blocks for up to 120s waiting for the network broadcast to complete
3. For large contracts (~5MB) or freshly restarted gateways with few peers, the broadcast exceeds 120s
4. fdev receives a timeout error, but the operation continues and succeeds in the background — consuming the version number
5. Retrying with the same version fails with "must be higher than current version"

This makes `cargo make publish-river` unreliable — every publish attempt reports failure and requires manual version bumping.

## Solution

When `perform_contract_put` finds the contract already exists, handle the update inline instead of delegating to `perform_contract_update`'s network mode path:

- Compute the merged state via `update_state`
- Validate the result via `validate_state`
- Commit locally (persist to disk + notify local subscribers)
- Fire `BroadcastStateChange` asynchronously (non-blocking, failure is a warning)
- Return success to client immediately

This matches the pattern already used for **new** contracts in the same function, where broadcast failure is treated as a non-fatal warning. The `perform_contract_update` network mode path (`op_request`) is preserved for peer-to-peer update propagation where synchronous completion is needed.

**Note:** PR #2982 (validate state before persisting) is a complementary fix — this PR addresses the timeout/response issue while #2982 addresses the validation ordering issue. Both can merge independently.

## Testing

- All 1337 unit tests pass (`cargo test -p freenet --lib`)
- `cargo clippy --all-targets` clean
- `cargo fmt` clean
- The specific scenario (publish timeout on existing contract) requires a running gateway — verified manually that the previous behavior caused the timeout

[AI-assisted - Claude]