### PR TITLE
feat: fast CONNECT recovery for NATed peers via TTL=0 gateway fallback

### DIFF
--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -1602,14 +1602,14 @@ async fn handle_aborted_op(
                         }
 
                         tracing::debug!("Retrying connection to gateway {}", gateway);
-                        connect::join_ring_request(&gateway, op_manager).await?;
+                        connect::join_ring_request(&gateway, op_manager, None).await?;
                     }
                 }
                 Ok(Some(OpEnum::Connect(_))) => {
                     if op_manager.ring.open_connections() == 0 && op_manager.ring.is_gateway() {
                         tracing::warn!("Retrying joining the ring with an other gateway");
                         if let Some(gateway) = gateways.iter().shuffle().next() {
-                            connect::join_ring_request(gateway, op_manager).await?
+                            connect::join_ring_request(gateway, op_manager, None).await?
                         }
                     }
                 }

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1686,6 +1686,7 @@ fn ring_distance(a: Option<Location>, b: Option<Location>) -> Option<f64> {
 pub(crate) async fn join_ring_request(
     gateway: &PeerKeyLocation,
     op_manager: &OpManager,
+    ttl_override: Option<u8>,
 ) -> Result<(), OpError> {
     use crate::node::ConnectionError;
     let gateway_location = gateway.location().ok_or_else(|| {
@@ -1717,11 +1718,12 @@ pub(crate) async fn join_ring_request(
     // to the same unreachable peer. Ring-optimal connections are established later
     // through connection_maintenance/adjust_topology once the peer has bootstrapped.
     let desired_location = Location::random();
-    let ttl = op_manager
+    let default_ttl = op_manager
         .ring
         .max_hops_to_live
         .max(1)
         .min(u8::MAX as usize) as u8;
+    let ttl = ttl_override.unwrap_or(default_ttl);
     let target_connections = op_manager.ring.connection_manager.min_connections;
 
     let failed_addrs = op_manager.ring.connection_manager.recently_failed_addrs();
@@ -1884,15 +1886,29 @@ pub(crate) async fn initial_join_procedure(
                     unconnected_count - eligible_count
                 );
                 let select_all = FuturesUnordered::new();
-                for gateway in eligible_gateways
+                let no_open_connections = open_conns == 0;
+                for (i, gateway) in eligible_gateways
                     .into_iter()
                     .shuffle()
                     .take(number_of_parallel_connections)
+                    .enumerate()
                 {
+                    let ttl_override = if no_open_connections && i == 0 {
+                        tracing::info!(
+                            %gateway,
+                            "Sending TTL=0 request for fast gateway-direct bootstrap"
+                        );
+                        Some(0)
+                    } else {
+                        None
+                    };
                     tracing::info!(%gateway, "Attempting connection to gateway");
                     let op_manager = op_manager.clone();
                     select_all.push(async move {
-                        (join_ring_request(gateway, &op_manager).await, gateway)
+                        (
+                            join_ring_request(gateway, &op_manager, ttl_override).await,
+                            gateway,
+                        )
                     });
                 }
                 select_all


### PR DESCRIPTION
## Problem

After suspend/resume (or any isolation event), a NATed peer tries to reconnect via `initial_join_procedure`. The gateway routes CONNECT requests to ring peers, but if those peers are also behind NAT, the joiner can't reach them (NAT-to-NAT hole punching fails). Each failed attempt takes ~10s (transport handshake timeout) before the bloom filter is updated. With many NATed peers in the gateway's ring, reconnection can take many minutes.

**Observed on technic:** Zero ring connections after suspend, stuck in isolation loop with NAT traversal failing to all acceptor peers routed by the gateway.

## Approach

When the joiner has zero ring connections, include one CONNECT request with **TTL=0** alongside normal requests. TTL=0 forces the gateway to accept directly (no forwarding to potentially NATed acceptors). Since the joiner already has a transient connection to the gateway, no NAT traversal is needed.

### Why TTL=0 works

1. Gateway receives `ConnectRequest { ttl: 0 }`
2. `can_forward = self.forwarded_to.is_none() && self.request.ttl > 0` → `false`
3. `is_terminus = true` → gateway checks `should_accept()` → accepts (has capacity)
4. Sends `ConnectResponse` with gateway as acceptor
5. Joiner calls `ConnectPeer { is_gw: false }` → promotes existing transient connection to ring
6. **No NAT traversal needed** — connection already exists

### Key design decisions

- **TTL=0 is additive**: One TTL=0 request + remaining normal-TTL requests run in parallel. If gateway rejects (at max_connections), normal routing still works.
- **Only when `open_conns == 0`**: Normal topology optimization continues for non-isolated peers.
- **No protocol changes**: TTL=0 is a valid value that the existing state machine handles correctly.
- **No duplicate connection risk**: `should_accept()` and `handle_connect_peer()` have idempotent guards.

## Changes

- `join_ring_request()`: Added `ttl_override: Option<u8>` parameter to allow callers to override the default TTL
- `initial_join_procedure()`: When `open_conns == 0`, first gateway request uses TTL=0 for fast direct bootstrap
- `handle_aborted_op()`: Updated two call sites to pass `None` (no TTL override)

## Testing

- `cargo fmt && cargo clippy --all-targets` — clean
- All 1371 tests pass (`cargo test -p freenet`)
- `test_multiple_clients_subscription` fails on unmodified main too (pre-existing, unrelated)

[AI-assisted - Claude]