### PR TITLE
fix: prevent streaming dedup from permanently losing operation state

### DIFF
--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -648,6 +648,22 @@ impl Operation for UpdateOp {
                                 stream_id = %stream_id,
                                 "UPDATE RequestUpdateStreaming skipped — stream already claimed (dedup)"
                             );
+                            // Push the operation state back since load_or_init popped it.
+                            // Without this, duplicate metadata messages (from embedded fragment #1)
+                            // permanently lose the operation state.
+                            if self.state.is_some() {
+                                let _ = op_manager
+                                    .push(
+                                        *id,
+                                        OpEnum::Update(UpdateOp {
+                                            id: *id,
+                                            state: self.state,
+                                            stats,
+                                            upstream_addr: self.upstream_addr,
+                                        }),
+                                    )
+                                    .await;
+                            }
                             return Err(OpError::OpNotPresent(*id));
                         }
                         Err(e) => {
@@ -657,6 +673,20 @@ impl Operation for UpdateOp {
                                 error = %e,
                                 "Failed to claim stream from orphan registry for UPDATE"
                             );
+                            // Push the operation state back to prevent loss
+                            if self.state.is_some() {
+                                let _ = op_manager
+                                    .push(
+                                        *id,
+                                        OpEnum::Update(UpdateOp {
+                                            id: *id,
+                                            state: self.state,
+                                            stats,
+                                            upstream_addr: self.upstream_addr,
+                                        }),
+                                    )
+                                    .await;
+                            }
                             return Err(OpError::OrphanStreamClaimFailed);
                         }
                     };
@@ -831,6 +861,22 @@ impl Operation for UpdateOp {
                                 stream_id = %stream_id,
                                 "UPDATE BroadcastToStreaming skipped — stream already claimed (dedup)"
                             );
+                            // Push the operation state back since load_or_init popped it.
+                            // Without this, duplicate metadata messages (from embedded fragment #1)
+                            // permanently lose the operation state.
+                            if self.state.is_some() {
+                                let _ = op_manager
+                                    .push(
+                                        *id,
+                                        OpEnum::Update(UpdateOp {
+                                            id: *id,
+                                            state: self.state,
+                                            stats,
+                                            upstream_addr: self.upstream_addr,
+                                        }),
+                                    )
+                                    .await;
+                            }
                             return Err(OpError::OpNotPresent(*id));
                         }
                         Err(e) => {
@@ -840,6 +886,20 @@ impl Operation for UpdateOp {
                                 error = %e,
                                 "Failed to claim stream from orphan registry for broadcast"
                             );
+                            // Push the operation state back to prevent loss
+                            if self.state.is_some() {
+                                let _ = op_manager
+                                    .push(
+                                        *id,
+                                        OpEnum::Update(UpdateOp {
+                                            id: *id,
+                                            state: self.state,
+                                            stats,
+                                            upstream_addr: self.upstream_addr,
+                                        }),
+                                    )
+                                    .await;
+                            }
                             return Err(OpError::OrphanStreamClaimFailed);
                         }
                     };


### PR DESCRIPTION
## Problem

When streaming is enabled (the default for `#[freenet_test]` macro tests), duplicate metadata messages arrive from embedded fragment #1 (fix #2757). The second copy pops the operation state via `load_or_init`, fails with `AlreadyClaimed` on stream claim, and returns `OpNotPresent`. This silently discards the popped state — the operation is permanently lost from `ops.put/get/update` while `under_progress` still tracks the transaction ID.

When the downstream peer sends the response (e.g., `PutResponseStreaming`), every retry attempt finds the transaction in `under_progress` → returns `Running` → the message handler retries 15 times over ~8.3 seconds, then drops the response. The originator times out after 60 seconds (OPERATION_TTL) waiting for a response that the gateway already received but could never forward.

This caused the `test_multiple_clients_subscription` CI failure — the PUT response was dropped on the gateway, so `node-a` timed out.

## Approach

In all `AlreadyClaimed` and `OrphanStreamClaimFailed` error paths across PUT, GET, and UPDATE streaming handlers: push the operation state back to the `OpManager` before returning the error. This preserves the operation state so that when the real response arrives, it can be matched and forwarded.

Also added `ResponseStreaming` to the `load_or_init` response check in PUT and GET, preventing phantom operation creation when a `ResponseStreaming` message arrives for an already-timed-out operation.

## Testing

- `test_multiple_clients_subscription` now passes consistently (ran twice locally)
- Full `cargo test -p freenet` suite passes
- `cargo clippy --all-targets` clean

## Fixes

Fixes the CI failure on PR #2997 (`test_multiple_clients_subscription` timeout)

[AI-assisted - Claude]