### PR TITLE
fix: initialize proximity cache from hosted contracts on startup

### DIFF
--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -147,6 +147,14 @@ impl ContractHandler for NetworkContractHandler {
             }
         }
 
+        // Populate proximity cache from hosted contracts so CacheStateResponse
+        // reports our full contract set when ring connections establish.
+        let hosted_keys = op_manager.ring.hosting_contract_keys();
+        let hosted_ids = hosted_keys.iter().map(|k| *k.id());
+        op_manager
+            .proximity_cache
+            .initialize_from_hosting_cache(hosted_ids);
+
         Ok(Self { executor, channel })
     }
 


### PR DESCRIPTION
## Problem

`ProximityCacheManager::my_cache` (DashSet) starts empty on node startup. The hosting cache loads contracts from disk via `load_hosting_cache()`, but never populates `my_cache`. This means:

- `CacheStateResponse` returns zero contracts to neighbors
- Overlap calculations find zero matches
- Proximity-based UPDATE forwarding fails — measured 1.8 fanout per hop vs expected ~25, with 22% of subscribers receiving zero updates

## Solution

After `load_hosting_cache()` completes in `handler.rs`, iterate hosted contracts and populate `my_cache` via a new `initialize_from_hosting_cache()` method. This runs before ring connections establish, so `CacheStateResponse` reports the full contract set from the first neighbor exchange.

Changes:
- Added `ProximityCacheManager::initialize_from_hosting_cache()` method in `proximity_cache.rs`
- Called it from `NetworkContractHandler::build()` in `handler.rs` after both redb and sqlite `load_hosting_cache()` paths
- Added unit test verifying initialization, cache state response, and deduplication behavior

## Testing

- New unit test `test_initialize_from_hosting_cache` validates:
  - Cache starts empty
  - After initialization, `local_cache_size()` and `is_cached_locally()` report correctly
  - `CacheStateRequest` returns all initialized contracts
  - `on_contract_cached()` returns `None` for already-initialized contracts (no duplicate announcement)
- All 18 existing proximity cache tests continue to pass
- `cargo fmt` and `cargo clippy` clean

[AI-assisted - Claude]