### PR TITLE
feat: add freenet-autoupdate script to the nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,18 @@
       overlays.default = _: pkgs: {
         freenet = pkgs.callPackage (import ./package.nix) { };
         freenet-autoupdate = pkgs.writeShellScriptBin "freenet-autoupdate" ''
-          while true; 
-          do 
-              nix run github:freenet/freenet-core#freenet;
+          trap "" INT
+
+          while true; do
+              nix run github:freenet/freenet-core#freenet
+              exit_code=$?
+
+              if [ $exit_code -eq 42 ]; then
+                  echo "Autoupdate triggered. Restarting..."
+              else
+                  echo "Non-autoupdate exit code: $exit_code. Stopping."
+                  break
+              fi
           done
         '';
       };


### PR DESCRIPTION
Added a simple auto update script that reruns the `nix run` command when the program terminates with exit code 42, which it does when it detects a version mismatch. Rerunning `nix run` will update the program to the latest commit in the main branch.