### PR TITLE
fix: add macOS x86_64 (Intel) build to release workflow

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -131,6 +131,51 @@ jobs:
           name: binaries-arm64-macos-fdev
           path: target/release/fdev
 
+  build-x86_64-macos:
+    name: Build for x86_64-apple-darwin
+    runs-on: macos-latest  # Cross-compile from Apple Silicon to x86_64
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
+          targets: x86_64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Compile for x86_64-apple-darwin
+        env:
+          # Support macOS 11 (Big Sur) and later - the last version to support Intel Macs
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
+          # Force static linking of liblzma to avoid dependency on Homebrew's xz
+          LZMA_API_STATIC: "1"
+        run: cargo build --release --target x86_64-apple-darwin -p freenet -p fdev
+
+      - name: Ad-hoc sign binaries
+        run: |
+          # Ad-hoc sign binaries so they can run without Gatekeeper blocking
+          codesign -s - --force target/x86_64-apple-darwin/release/freenet
+          codesign -s - --force target/x86_64-apple-darwin/release/fdev
+          # Verify signatures
+          codesign -v target/x86_64-apple-darwin/release/freenet
+          codesign -v target/x86_64-apple-darwin/release/fdev
+
+      - name: Upload freenet binary
+        uses: actions/upload-artifact@v6
+        with:
+          name: binaries-x86_64-macos-freenet
+          path: target/x86_64-apple-darwin/release/freenet
+
+      - name: Upload fdev binary
+        uses: actions/upload-artifact@v6
+        with:
+          name: binaries-x86_64-macos-fdev
+          path: target/x86_64-apple-darwin/release/fdev
+
   build-x86_64-windows:
     name: Build for x86_64-pc-windows-msvc
     runs-on: windows-latest
@@ -165,7 +210,7 @@ jobs:
     name: Attach binaries to GitHub release
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-x86_64-linux, build-arm64-linux, build-arm64-macos, build-x86_64-windows]
+    needs: [build-x86_64-linux, build-arm64-linux, build-arm64-macos, build-x86_64-macos, build-x86_64-windows]
     if: startsWith(github.ref, 'refs/tags/v')
 
     permissions:
@@ -211,6 +256,19 @@ jobs:
           name: binaries-arm64-macos-fdev
           path: artifacts/arm64-macos-fdev
 
+      # macOS x86_64
+      - name: Download x86_64 macOS freenet binary
+        uses: actions/download-artifact@v7
+        with:
+          name: binaries-x86_64-macos-freenet
+          path: artifacts/x86_64-macos-freenet
+
+      - name: Download x86_64 macOS fdev binary
+        uses: actions/download-artifact@v7
+        with:
+          name: binaries-x86_64-macos-fdev
+          path: artifacts/x86_64-macos-fdev
+
       # Windows x86_64
       - name: Download x86_64 Windows freenet binary
         uses: actions/download-artifact@v7
@@ -238,6 +296,10 @@ jobs:
           # macOS ARM64
           cd artifacts/arm64-macos-freenet && tar -czvf ../../freenet-aarch64-apple-darwin.tar.gz freenet && cd ../..
           cd artifacts/arm64-macos-fdev && tar -czvf ../../fdev-aarch64-apple-darwin.tar.gz fdev && cd ../..
+
+          # macOS x86_64
+          cd artifacts/x86_64-macos-freenet && tar -czvf ../../freenet-x86_64-apple-darwin.tar.gz freenet && cd ../..
+          cd artifacts/x86_64-macos-fdev && tar -czvf ../../fdev-x86_64-apple-darwin.tar.gz fdev && cd ../..
 
           # Windows x86_64 (use zip for Windows)
           cd artifacts/x86_64-windows-freenet && zip ../../freenet-x86_64-pc-windows-msvc.zip freenet.exe && cd ../..
@@ -270,6 +332,8 @@ jobs:
             fdev-aarch64-unknown-linux-musl.tar.gz \
             freenet-aarch64-apple-darwin.tar.gz \
             fdev-aarch64-apple-darwin.tar.gz \
+            freenet-x86_64-apple-darwin.tar.gz \
+            fdev-x86_64-apple-darwin.tar.gz \
             freenet-x86_64-pc-windows-msvc.zip \
             fdev-x86_64-pc-windows-msvc.zip \
             SHA256SUMS.txt \


### PR DESCRIPTION
The install script correctly detects macOS x86_64 and constructs the
target triple x86_64-apple-darwin, but no Intel Mac binary was being
built or published in releases, causing a 404 error during installation.

Add a build-x86_64-macos job that cross-compiles from Apple Silicon to
x86_64-apple-darwin, with the same LZMA static linking and ad-hoc code
signing as the ARM64 macOS build. Wire the new artifacts through the
release packaging and upload steps.

Fixes #3010

https://claude.ai/code/session_019b5x66nhXtDA6owfp6zfes