### PR TITLE
refactor: rename HTTP client interface from "gateway" to "client_api"

### DIFF
--- a/apps/freenet-ping/app/tests/common/mod.rs
+++ b/apps/freenet-ping/app/tests/common/mod.rs
@@ -5,7 +5,7 @@ use freenet::{
     config::{ConfigArgs, InlineGwConfig, NetworkArgs, SecretArgs, WebsocketApiArgs},
     dev_tool::TransportKeypair,
     local_node::NodeConfig,
-    server::serve_gateway,
+    server::serve_client_api,
 };
 use freenet_ping_app::ping_client::{
     wait_for_get_response, wait_for_put_response, wait_for_subscribe_response,

--- a/apps/freenet-ping/app/tests/run_app.rs
+++ b/apps/freenet-ping/app/tests/run_app.rs
@@ -3,7 +3,7 @@ mod common;
 use std::{net::TcpListener, path::PathBuf, time::Duration};
 
 use anyhow::anyhow;
-use freenet::{local_node::NodeConfig, server::serve_gateway};
+use freenet::{local_node::NodeConfig, server::serve_client_api};
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
     client_api::{
@@ -264,7 +264,7 @@ async fn test_node_diagnostics_query() -> anyhow::Result<()> {
         let config = config_gw.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -275,7 +275,7 @@ async fn test_node_diagnostics_query() -> anyhow::Result<()> {
         let config = config_node.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -642,7 +642,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
         let config = config_gw.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -658,7 +658,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
         let config = config_node1.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -673,7 +673,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
         let config = config_node2.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -1343,7 +1343,7 @@ async fn test_ping_application_loop() -> anyhow::Result<()> {
         let config = config_gw.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -1358,7 +1358,7 @@ async fn test_ping_application_loop() -> anyhow::Result<()> {
         let config = config_node1.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -1373,7 +1373,7 @@ async fn test_ping_application_loop() -> anyhow::Result<()> {
         let config = config_node2.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }

--- a/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
+++ b/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
@@ -50,7 +50,7 @@ use common::{
 };
 use freenet::{
     local_node::NodeConfig,
-    server::serve_gateway,
+    server::serve_client_api,
     test_utils::{allocate_test_node_block, test_ip_for_node},
 };
 use freenet_ping_app::ping_client::{
@@ -261,7 +261,7 @@ async fn run_blocked_peers_test_inner(
         let config = config_gw.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -271,7 +271,7 @@ async fn run_blocked_peers_test_inner(
         let config = config_node1.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -281,7 +281,7 @@ async fn run_blocked_peers_test_inner(
         let config = config_node2.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }

--- a/apps/freenet-ping/app/tests/run_app_delegate_wasmtime.rs
+++ b/apps/freenet-ping/app/tests/run_app_delegate_wasmtime.rs
@@ -3,7 +3,7 @@ mod common;
 use std::{net::TcpListener, time::Duration};
 
 use anyhow::anyhow;
-use freenet::{local_node::NodeConfig, server::serve_gateway};
+use freenet::{local_node::NodeConfig, server::serve_client_api};
 use freenet_stdlib::{
     client_api::{ClientRequest, HostResponse},
     prelude::*,
@@ -81,7 +81,7 @@ async fn test_delegate_e2e_wasmtime() -> anyhow::Result<()> {
         let config = config_gw.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }

--- a/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
+++ b/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use anyhow::anyhow;
-use freenet::{local_node::NodeConfig, server::serve_gateway, test_utils::test_ip_for_node};
+use freenet::{local_node::NodeConfig, server::serve_client_api, test_utils::test_ip_for_node};
 use freenet_ping_app::ping_client::wait_for_put_response;
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
@@ -233,7 +233,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
         let gateway_future = async move {
             let config = config.build().await?;
             let node = NodeConfig::new(config.clone()).await?;
-            let gateway_service = serve_gateway(config.ws_api).await?;
+            let gateway_service = serve_client_api(config.ws_api).await?;
             let node = node.build(gateway_service).await?;
             node.run().await
         }
@@ -251,7 +251,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
         let regular_node_future = async move {
             let config = config.build().await?;
             let node = NodeConfig::new(config.clone()).await?;
-            let gateway_service = serve_gateway(config.ws_api).await?;
+            let gateway_service = serve_client_api(config.ws_api).await?;
             let node = node.build(gateway_service).await?;
             node.run().await
         }

--- a/apps/freenet-ping/app/tests/test_50_node_operations.rs
+++ b/apps/freenet-ping/app/tests/test_50_node_operations.rs
@@ -8,7 +8,7 @@
 mod common;
 
 use anyhow::anyhow;
-use freenet::{local_node::NodeConfig, server::serve_gateway, test_utils::test_ip_for_node};
+use freenet::{local_node::NodeConfig, server::serve_client_api, test_utils::test_ip_for_node};
 use freenet_ping_app::ping_client::wait_for_put_response;
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
@@ -177,7 +177,7 @@ async fn setup_50_node_network(
             let config = config.build().await?;
             let node = NodeConfig::new(config.clone())
                 .await?
-                .build(serve_gateway(config.ws_api).await?)
+                .build(serve_client_api(config.ws_api).await?)
                 .await?;
             node.run().await
         }
@@ -207,7 +207,7 @@ async fn setup_50_node_network(
                 let config = config.build().await?;
                 let node = NodeConfig::new(config.clone())
                     .await?
-                    .build(serve_gateway(config.ws_api).await?)
+                    .build(serve_client_api(config.ws_api).await?)
                     .await?;
                 node.run().await
             }

--- a/apps/freenet-ping/app/tests/test_connection_timing.rs
+++ b/apps/freenet-ping/app/tests/test_connection_timing.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use freenet::{local_node::NodeConfig, server::serve_gateway, test_utils::test_ip_for_node};
+use freenet::{local_node::NodeConfig, server::serve_client_api, test_utils::test_ip_for_node};
 use freenet_stdlib::client_api::WebApi;
 use futures::FutureExt;
 use tokio::{select, time::timeout};
@@ -73,7 +73,7 @@ async fn test_connection_timing() -> anyhow::Result<()> {
         let config = config_gw.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -84,7 +84,7 @@ async fn test_connection_timing() -> anyhow::Result<()> {
         let config = config_node1.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }

--- a/apps/freenet-ping/app/tests/test_limited_connectivity_get.rs
+++ b/apps/freenet-ping/app/tests/test_limited_connectivity_get.rs
@@ -43,7 +43,7 @@ use std::{
 
 use freenet::{
     local_node::NodeConfig,
-    server::serve_gateway,
+    server::serve_client_api,
     test_utils::{allocate_test_node_block, test_ip_for_node},
 };
 use freenet_stdlib::{
@@ -127,7 +127,7 @@ async fn test_limited_connectivity_get_nonexistent_contract() -> anyhow::Result<
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(5);
         let node = node_config
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -140,7 +140,7 @@ async fn test_limited_connectivity_get_nonexistent_contract() -> anyhow::Result<
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(5);
         let node = node_config
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }

--- a/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
+++ b/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use freenet::{local_node::NodeConfig, server::serve_gateway, test_utils::test_ip_for_node};
+use freenet::{local_node::NodeConfig, server::serve_client_api, test_utils::test_ip_for_node};
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
     client_api::{ClientRequest, ContractRequest, ContractResponse, HostResponse, WebApi},
@@ -102,7 +102,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(10);
         let node = node_config
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -115,7 +115,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(10);
         let node = node_config
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -128,7 +128,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(10);
         let node = node_config
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }

--- a/crates/core/architecture.md
+++ b/crates/core/architecture.md
@@ -133,7 +133,7 @@ graph LR
 
 **Key Components & Communication:**
 
-- **[Server](src/server/mod.rs):** Handles HTTP and WebSocket endpoints for client connections. The `ClientConnection` enum in [http_gateway.rs](src/server/http_gateway.rs) defines the interface between the server and client events system. The server manages the WebSocket API and passes client requests to the ClientEvents subsystem.
+- **[Server](src/server/mod.rs):** Handles HTTP and WebSocket endpoints for client connections. The `ClientConnection` enum in [client_api.rs](src/server/client_api.rs) defines the interface between the server and client events system. The server manages the WebSocket API and passes client requests to the ClientEvents subsystem.
 
 - **[Node](src/node.rs):** Central coordinator with the main event loop implemented in `run_event_loop()`. This function contains the core `tokio::select!` loop that dispatches events to appropriate handlers like `handle_network_message()`, `handle_node_event()`, and `handle_client_request()`. 
 

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -8,7 +8,7 @@ use freenet::{
     config::{Config, ConfigArgs, GlobalExecutor},
     local_node::{Executor, NodeConfig, OperationMode},
     run_local_node, run_network_node,
-    server::serve_gateway,
+    server::serve_client_api,
 };
 use std::sync::Arc;
 
@@ -85,9 +85,9 @@ async fn run_local(config: Config) -> anyhow::Result<()> {
 async fn run_network(config: Config) -> anyhow::Result<()> {
     tracing::info!("Starting freenet node in network mode");
 
-    let clients = serve_gateway(config.ws_api)
+    let clients = serve_client_api(config.ws_api)
         .await
-        .with_context(|| "failed to start HTTP/WebSocket gateway")?;
+        .with_context(|| "failed to start HTTP/WebSocket client API")?;
     tracing::info!("Initializing node configuration");
 
     let node_config = NodeConfig::new(config)

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -53,7 +53,7 @@ use crate::{
 };
 
 use super::{ClientError, ClientEventsProxy, ClientId, HostResult, OpenRequest};
-use crate::server::http_gateway::AttestedContractMap;
+use crate::server::client_api::AttestedContractMap;
 
 /// Checks if a WebSocket Origin header value refers to localhost.
 ///

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -128,7 +128,7 @@ impl Default for ConfigArgs {
             },
             ws_api: WebsocketApiArgs {
                 address: Some(default_listening_address()),
-                ws_api_port: Some(default_http_gateway_port()),
+                ws_api_port: Some(default_ws_api_port()),
                 token_ttl_seconds: None,
                 token_cleanup_interval_seconds: None,
             },
@@ -546,10 +546,7 @@ impl ConfigArgs {
                         _ => addr,
                     }
                 },
-                port: self
-                    .ws_api
-                    .ws_api_port
-                    .unwrap_or(default_http_gateway_port()),
+                port: self.ws_api.ws_api_port.unwrap_or(default_ws_api_port()),
                 token_ttl_seconds: self
                     .ws_api
                     .token_ttl_seconds
@@ -1232,7 +1229,7 @@ pub struct WebsocketApiConfig {
     pub address: IpAddr,
 
     /// Port to expose api on
-    #[serde(default = "default_http_gateway_port", rename = "ws-api-port")]
+    #[serde(default = "default_ws_api_port", rename = "ws-api-port")]
     pub port: u16,
 
     /// Token time-to-live in seconds
@@ -1273,7 +1270,7 @@ impl Default for WebsocketApiConfig {
     fn default() -> Self {
         Self {
             address: default_listening_address(),
-            port: default_http_gateway_port(),
+            port: default_ws_api_port(),
             token_ttl_seconds: default_token_ttl_seconds(),
             token_cleanup_interval_seconds: default_token_cleanup_interval_seconds(),
         }
@@ -1291,7 +1288,7 @@ const fn default_local_address() -> IpAddr {
 }
 
 #[inline]
-const fn default_http_gateway_port() -> u16 {
+const fn default_ws_api_port() -> u16 {
     7509
 }
 

--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -1811,7 +1811,7 @@ pub async fn run_local_node(
         _ => {}
     }
 
-    let (mut gw, mut ws_proxy) = crate::server::serve_gateway_in(socket).await?;
+    let (mut gw, mut ws_proxy) = crate::server::serve_client_api_in(socket).await?;
 
     // TODO: use combinator instead
     // let mut all_clients =
@@ -1849,7 +1849,7 @@ pub async fn run_local_node(
                     .await
             }
             ClientRequest::DelegateOp(op) => {
-                // Use the attested_contract already resolved by WebSocket/HttpGateway
+                // Use the attested_contract already resolved by the WebSocket/HTTP client API
                 // instead of re-looking up from gw.attested_contracts (which could fail
                 // if the token expired between WebSocket connect and this request)
                 let op_name = match op {

--- a/crates/core/src/server/app_packaging.rs
+++ b/crates/core/src/server/app_packaging.rs
@@ -1,4 +1,4 @@
-//! Helper functions and types for dealing with HTTP gateway compatible contracts.
+//! Helper functions and types for dealing with HTTP client API compatible contracts.
 use std::{
     io::{Cursor, Read},
     path::Path,

--- a/crates/core/src/server/client_api/v1.rs
+++ b/crates/core/src/server/client_api/v1.rs
@@ -2,7 +2,7 @@ use axum::{extract::Path, routing::get, Extension, Router};
 
 use super::*;
 
-/// Registers V1-specific HTTP gateway routes.
+/// Registers V1-specific HTTP client API routes.
 pub(super) fn routes(config: Config) -> Router {
     Router::new()
         .route("/v1", get(home))
@@ -13,7 +13,7 @@ pub(super) fn routes(config: Config) -> Router {
 
 async fn web_home_v1(
     key: Path<String>,
-    rs: Extension<HttpGatewayRequest>,
+    rs: Extension<HttpClientApiRequest>,
     config: axum::extract::State<Config>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     web_home(key, rs, config, ApiVersion::V1).await

--- a/crates/core/src/server/client_api/v2.rs
+++ b/crates/core/src/server/client_api/v2.rs
@@ -2,7 +2,7 @@ use axum::{extract::Path, routing::get, Extension, Router};
 
 use super::*;
 
-/// Registers V2-specific HTTP gateway routes.
+/// Registers V2-specific HTTP client API routes.
 ///
 /// Currently identical in behavior to V1; exists as a routing seam for
 /// future V2-specific protocol changes.
@@ -16,7 +16,7 @@ pub(super) fn routes(config: Config) -> Router {
 
 async fn web_home_v2(
     key: Path<String>,
-    rs: Extension<HttpGatewayRequest>,
+    rs: Extension<HttpClientApiRequest>,
     config: axum::extract::State<Config>,
 ) -> Result<axum::response::Response, WebSocketApiError> {
     web_home(key, rs, config, ApiVersion::V2).await

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -13,8 +13,8 @@ use crate::client_events::AuthToken;
 
 use super::{
     app_packaging::{WebApp, WebContractError},
+    client_api::HttpClientApiRequest,
     errors::WebSocketApiError,
-    http_gateway::HttpGatewayRequest,
     ApiVersion, ClientConnection, HostCallbackResult,
 };
 use tracing::{debug, instrument};
@@ -22,7 +22,7 @@ use tracing::{debug, instrument};
 #[instrument(level = "debug", skip(request_sender))]
 pub(super) async fn contract_home(
     key: String,
-    request_sender: HttpGatewayRequest,
+    request_sender: HttpClientApiRequest,
     assigned_token: AuthToken,
     api_version: ApiVersion,
 ) -> Result<impl IntoResponse, WebSocketApiError> {

--- a/crates/core/tests/error_notification.rs
+++ b/crates/core/tests/error_notification.rs
@@ -9,7 +9,7 @@
 
 use freenet::{
     local_node::NodeConfig,
-    server::serve_gateway,
+    server::serve_client_api,
     test_utils::{load_contract, make_get, make_subscribe, TestContext},
 };
 use freenet_macros::freenet_test;
@@ -445,7 +445,7 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
         let config = gateway_config.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
         node.run().await
     }
@@ -457,7 +457,7 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
         let config = peer_config.build().await?;
         let node = NodeConfig::new(config.clone())
             .await?
-            .build(serve_gateway(config.ws_api).await?)
+            .build(serve_client_api(config.ws_api).await?)
             .await?;
 
         // Run node until we receive shutdown signal

--- a/crates/core/tests/operations_before_join.rs
+++ b/crates/core/tests/operations_before_join.rs
@@ -5,7 +5,7 @@
 
 use freenet::{
     local_node::NodeConfig,
-    server::serve_gateway,
+    server::serve_client_api,
     test_utils::{load_contract, make_get, make_put, make_subscribe},
 };
 use freenet_stdlib::{client_api::WebApi, prelude::*};
@@ -193,7 +193,7 @@ async fn test_operations_blocked_before_join() -> anyhow::Result<()> {
     let (start_gateway_tx, start_gateway_rx) = tokio::sync::oneshot::channel::<()>();
 
     let peer_cfg = peer_config.build().await?;
-    let peer_ws_server = serve_gateway(peer_cfg.ws_api).await?;
+    let peer_ws_server = serve_client_api(peer_cfg.ws_api).await?;
     let peer_node = NodeConfig::new(peer_cfg.clone())
         .await?
         .build(peer_ws_server)
@@ -208,7 +208,7 @@ async fn test_operations_blocked_before_join() -> anyhow::Result<()> {
 
         let node = NodeConfig::new(gw_config.clone())
             .await?
-            .build(serve_gateway(gw_config.ws_api).await?)
+            .build(serve_client_api(gw_config.ws_api).await?)
             .await?;
         node.run().await
     }

--- a/crates/core/tests/token_expiration.rs
+++ b/crates/core/tests/token_expiration.rs
@@ -181,7 +181,7 @@ async fn test_token_cleanup_removes_expired_tokens() -> TestResult {
     use freenet::{
         config::WebsocketApiConfig,
         dev_tool::{AuthToken, ClientId},
-        server::{serve_gateway_for_test, AttestedContract},
+        server::{serve_client_api_for_test, AttestedContract},
         test_utils,
     };
     use std::time::Duration;
@@ -194,13 +194,13 @@ async fn test_token_cleanup_removes_expired_tokens() -> TestResult {
         const CLEANUP_INTERVAL_SECS: u64 = 1;
 
         info!(
-            "Starting gateway with short token TTL ({} seconds) and cleanup interval ({} seconds)",
+            "Starting client API with short token TTL ({} seconds) and cleanup interval ({} seconds)",
             TOKEN_TTL_SECS, CLEANUP_INTERVAL_SECS
         );
 
         let ws_socket = TcpListener::bind("127.0.0.1:0")?;
         let ws_port = ws_socket.local_addr()?.port();
-        // Drop the socket to release the port before the gateway binds to it
+        // Drop the socket to release the port before the client API binds to it
         drop(ws_socket);
 
         let config = WebsocketApiConfig {
@@ -210,8 +210,8 @@ async fn test_token_cleanup_removes_expired_tokens() -> TestResult {
             token_cleanup_interval_seconds: CLEANUP_INTERVAL_SECS,
         };
 
-        // Start the gateway server (which spawns the cleanup task)
-        let (gw, _ws_proxy) = serve_gateway_for_test(config).await?;
+        // Start the client API server (which spawns the cleanup task)
+        let (gw, _ws_proxy) = serve_client_api_for_test(config).await?;
 
         // Access the attested_contracts map via the test-only method
         let attested_contracts = gw.attested_contracts();

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -491,7 +491,7 @@ fn generate_node_builds(args: &FreenetTestArgs) -> TokenStream {
             let mut node_config = freenet::local_node::NodeConfig::new(built_config.clone()).await?;
             #connection_tuning
             let (#node_var, #flush_handle_var) = node_config
-                .build_with_flush_handle(freenet::server::serve_gateway(built_config.ws_api).await?)
+                .build_with_flush_handle(freenet::server::serve_client_api(built_config.ws_api).await?)
                 .await?;
         });
     }


### PR DESCRIPTION
## Problem

The term "gateway" was overloaded in the codebase. It correctly refers to **gateway peers** (network nodes that accept inbound connections), but was also used for the **HTTP/WebSocket client interface** — the API that clients use to interact with a Freenet node. This made the code confusing since `HttpGateway` in `server/` means something completely different from "gateway" in `transport/connection_handler.rs`.

## Approach

Pure rename refactor — no behavioral changes. Renamed all HTTP client interface types, functions, and module names to use `client_api` instead of `gateway`:

| Before | After |
|--------|-------|
| `http_gateway` module | `client_api` |
| `HttpGateway` | `HttpClientApi` |
| `HttpGatewayRequest` | `HttpClientApiRequest` |
| `serve_gateway()` | `serve_client_api()` |
| `serve_gateway_for_test()` | `serve_client_api_for_test()` |
| `default_http_gateway_port()` | `default_ws_api_port()` |

Also fixed misleading log/error messages and doc comments (e.g. `"HTTP gateway listening on"` → `"HTTP client API listening on"`).

Correct usages of "gateway" (meaning gateway peer) in `config/`, `transport/`, and `operations/` are left unchanged.

## Testing

- `cargo fmt` — clean
- `cargo clippy --all-targets` — clean (no warnings)
- CI will validate full test suite

[AI-assisted - Claude]