### PR TITLE
fix: accelerate topology formation for peers below min_connections

### DIFF
--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -1272,6 +1272,8 @@ impl Ring {
                         target_location = %ideal_location,
                         "Skipping connection attempt - target in backoff"
                     );
+                    // Intentionally not re-queued: adjust_topology will re-request
+                    // this location on the next cycle if still below min_connections.
                     continue;
                 }
                 if active_count >= MAX_CONCURRENT_CONNECTIONS {
@@ -1451,6 +1453,10 @@ impl Ring {
                 || !pending_conn_adds.is_empty();
 
             if needs_fast_tick {
+                // Uses sleep() instead of an interval so we don't need a second
+                // Interval object. check_interval accumulates missed ticks during
+                // this phase; with MissedTickBehavior::Skip the first steady-state
+                // tick fires immediately on transition (which is desirable).
                 crate::deterministic_select! {
                   _ = refresh_density_map.tick() => {
                     self.refresh_density_request_cache();

--- a/crates/core/src/topology/mod.rs
+++ b/crates/core/src/topology/mod.rs
@@ -1274,8 +1274,7 @@ mod tests {
                 );
 
                 // Remaining targets should be spread across the ring at evenly
-                // spaced offsets from own location. Verify they are distinct and
-                // cover the ring.
+                // spaced offsets from own location.
                 for (i, loc) in locations.iter().enumerate().skip(1) {
                     let expected_offset = i as f64 / 24.0;
                     let expected = Location::new_rounded(my_location.as_f64() + expected_offset);
@@ -1284,6 +1283,16 @@ mod tests {
                         "Connection {i} should be at offset {expected_offset} from own location"
                     );
                 }
+
+                // All locations must be distinct so they survive BTreeSet
+                // deduplication in the caller's pending connection queue.
+                let as_set: std::collections::BTreeSet<Location> =
+                    locations.iter().copied().collect();
+                assert_eq!(
+                    as_set.len(),
+                    locations.len(),
+                    "All target locations must be distinct"
+                );
             }
             _ => panic!("Expected AddConnections, got {adjustment:?}"),
         }


### PR DESCRIPTION
## Problem

The topology maintenance loop has three compounding issues that make initial mesh formation extremely slow in production mode, causing the six-peer Docker NAT regression test to fail its mesh topology assertion (river#106):

1. **60-second tick rate**: `CHECK_TICK_DURATION = 60s` in non-test mode. The loop processes pending connections once per tick, so reaching `min_connections=4` from 1 (gateway only) requires ~180 seconds of wall time — far exceeding the 90-second mesh assertion timeout.

2. **BTreeSet deduplication**: `pending_conn_adds` is a `BTreeSet<Location>`. When below `DENSITY_SELECTION_THRESHOLD` (5 connections), `adjust_topology` returns `below_threshold` copies of the peer's own location via `locations.resize(below_threshold, *location)`. BTreeSet collapses these to 1 entry, so only 1 connection target survives instead of 3.

3. **Single drain per iteration**: The loop calls `pending_conn_adds.pop_first()` once per tick, processing just 1 pending target per 60-second cycle — even though `MAX_CONCURRENT_CONNECTIONS = 3`.

**Combined effect**: Each topology cycle queues 1 connection target (dedup), processed every 60 seconds. Getting 2+ P2P connections takes 120+ seconds.

## Approach

Three targeted fixes, each addressing one of the bugs above:

- **Fast tick when below min_connections**: Added `FAST_CHECK_TICK_DURATION` (5s prod / 1s test) used when `current_connections < min_connections` or pending connections exist. Steady-state still uses the 60s interval — this only affects the initial ramp-up phase.

- **Diverse target locations**: Instead of filling the target vector with N copies of own location, spread targets across the ring: first target is own location (for local clustering), additional targets are evenly spaced offsets (`own_loc + i/N`). These are distinct values so BTreeSet preserves all of them, and they cause CONNECT operations to discover different peers across the ring rather than repeatedly finding the same nearest peer.

- **Drain all pending per iteration**: Changed `pop_first()` (one per tick) to a `while` loop that drains up to `MAX_CONCURRENT_CONNECTIONS` pending targets per iteration.

**Result**: A peer starting with 1 connection (gateway) now queues 3 diverse targets immediately, initiates all 3 within the first 5-second tick, and retries every 5 seconds. Timeline drops from ~180s to ~15-20s.

## Testing

- All 1411 tests pass (1378 unit + 33 integration), 0 failures
- Updated `test_early_connections_target_own_location` to validate the new diverse-location strategy
- `cargo fmt` and `cargo clippy --all-targets` clean

The real validation is the six-peer Docker NAT regression test in CI, which this PR unblocks. A companion river PR will restore the mesh assertion to `min_p2p_per_peer=2, max_wait=90s` (reverting the weakening from river#105).

## Fixes

Addresses the root cause identified in https://github.com/freenet/river/issues/106

[AI-assisted - Claude]