### PR TITLE
feat: add broadcast delivery diagnostics telemetry

### DIFF
--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -509,6 +509,9 @@ fn event_kind_to_string(kind: &EventKind) -> String {
                 UpdateEvent::BroadcastComplete { .. } => "update_broadcast_complete".to_string(),
                 UpdateEvent::BroadcastReceived { .. } => "update_broadcast_received".to_string(),
                 UpdateEvent::BroadcastApplied { .. } => "update_broadcast_applied".to_string(),
+                UpdateEvent::BroadcastDeliverySummary { .. } => {
+                    "update_broadcast_delivery_summary".to_string()
+                }
             }
         }
         EventKind::Transfer(transfer_event) => {
@@ -1135,6 +1138,34 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         json["state_hash_after"] = serde_json::Value::String(hash.clone());
                     }
                     json
+                }
+                UpdateEvent::BroadcastDeliverySummary {
+                    key,
+                    proximity_found,
+                    proximity_resolve_failed,
+                    interest_found,
+                    interest_resolve_failed,
+                    skipped_self,
+                    skipped_sender,
+                    skipped_summary_match,
+                    targets_sent,
+                    send_failed,
+                    timestamp,
+                } => {
+                    serde_json::json!({
+                        "type": "broadcast_delivery_summary",
+                        "key": key.to_string(),
+                        "proximity_found": proximity_found,
+                        "proximity_resolve_failed": proximity_resolve_failed,
+                        "interest_found": interest_found,
+                        "interest_resolve_failed": interest_resolve_failed,
+                        "skipped_self": skipped_self,
+                        "skipped_sender": skipped_sender,
+                        "skipped_summary_match": skipped_summary_match,
+                        "targets_sent": targets_sent,
+                        "send_failed": send_failed,
+                        "timestamp": timestamp,
+                    })
                 }
             }
         }


### PR DESCRIPTION
## Problem

Funnel analysis of River telemetry shows 77/158 (49%) of peers who subscribed to the official room contract missed update broadcasts while they were online. Current telemetry shows "broadcast emitted to N peers" and "peer X received broadcast", but **cannot explain why a specific peer was NOT in the target list**. The broadcasting node makes several filtering decisions that are invisible to telemetry.

Three distinct failure populations exist:
- 30 peers: last activity >5min before update (Interest TTL expiry plausible)
- 25 peers: last activity <5min before update (TTL does NOT explain)
- 22 peers: inconclusive (no timestamp data)

## Solution

Add a single new telemetry event (`BroadcastDeliverySummary`) emitted after each broadcast cycle that provides the full breakdown of every filtering decision:

| Counter | What it tracks |
|---------|---------------|
| `proximity_found` | Peers found in proximity cache |
| `proximity_resolve_failed` | Proximity peers whose address couldn't be resolved |
| `interest_found` | Peers found via interest manager |
| `interest_resolve_failed` | Interest peers whose address couldn't be resolved |
| `skipped_self` | Skipped because target is us |
| `skipped_sender` | Skipped because target is the sender |
| `skipped_summary_match` | Skipped because peer already has our state |
| `targets_sent` | Successfully sent broadcast |
| `send_failed` | Send attempt failed |

Changes across 4 files:
- `operations/update.rs`: `get_broadcast_targets_update()` returns `BroadcastTargetResult` struct with counters
- `node/network_bridge/p2p_protoc.rs`: `handle_broadcast_state_change()` tracks per-target loop counters and emits the event
- `tracing/mod.rs`: `BroadcastDeliverySummary` variant on `UpdateEvent` + constructor
- `tracing/telemetry.rs`: Event type string mapping + JSON serialization

This is purely observational — no behavioral changes.

## Testing

- `cargo build` — compiles
- `cargo clippy --all-targets` — no warnings
- `cargo test -p freenet` — all tests pass
- Dashboard compatibility: `getEventClass()` uses `.includes('update')` matching — the new `update_broadcast_delivery_summary` type matches

## Fixes

Provides diagnostic telemetry for #3046. Also relevant to #3043 (six-peer test subscription propagation failures).

[AI-assisted - Claude]