### PR TITLE
ci: adopt cargo-nextest and enable health_check_readiness on all tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+[profile.ci]
+# Retry individual failed tests instead of re-running entire workspace.
+# Real-network tests are timing-sensitive and occasionally fail under CI
+# resource pressure — per-test retries avoid the 10-15 min penalty of
+# re-running all tests.
+retries = 2
+# Don't stop on first failure — run all tests to surface multiple issues.
+fail-fast = false
+# Terminate tests that hang (2 periods of 120s = 4 min max per test).
+slow-timeout = { period = "120s", terminate-after = 2 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - name: Install nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
       - name: Build
         env:
           # Use mold linker to avoid rust-lld crashes (see issue #2519)
@@ -194,15 +197,13 @@ jobs:
         # Exclude freenet-ping-app: its 3 blocked-peers tests each spin up 3 real
         # nodes (9 total). Running them in parallel with core tests causes CI
         # timeouts. They run sequentially in their own step below.
-        # Retry once on failure — real-network tests are timing-sensitive
-        # and occasionally fail under CI resource pressure.
+        # nextest retries only failed tests (via .config/nextest.toml [profile.ci]),
+        # avoiding the 10-15 min penalty of re-running the entire workspace.
         run: |
-          cargo test --workspace --exclude freenet-ping-app --exclude freenet-ping-types --no-default-features \
+          cargo nextest run --workspace --exclude freenet-ping-app --exclude freenet-ping-types \
+            --no-default-features \
             --features trace,websocket,redb,wasmtime-backend,simulation_tests,testing \
-            -- --skip determinism \
-          || cargo test --workspace --exclude freenet-ping-app --exclude freenet-ping-types --no-default-features \
-            --features trace,websocket,redb,wasmtime-backend,simulation_tests,testing \
-            -- --skip determinism
+            --profile ci -E 'not test(determinism)'
 
       - name: Test ping app (serial)
         if: ${{ !cancelled() }}
@@ -215,10 +216,8 @@ jobs:
         # Also includes freenet-ping-types (excluded from main step because
         # --no-default-features disables its std feature, breaking test code).
         run: |
-          cargo test -p freenet-ping-app -p freenet-ping-types --features testing \
-            -- --test-threads=1 \
-          || cargo test -p freenet-ping-app -p freenet-ping-types --features testing \
-            -- --test-threads=1
+          cargo nextest run -p freenet-ping-app -p freenet-ping-types \
+            --features testing --profile ci -j 1
 
       - name: Test determinism (serial)
         if: ${{ !cancelled() }}
@@ -228,7 +227,10 @@ jobs:
         # Determinism comparison tests compare exact event sequences across sequential runs.
         # Shared atomic counters must not be advanced by concurrent tests between runs.
         # The "determinism" filter matches: test_strict_determinism_*, test_turmoil_determinism_*, test_deterministic_replay_*
-        run: cargo test -p freenet --no-default-features --features trace,websocket,redb,wasmtime-backend,simulation_tests,testing --test simulation_integration determinism -- --test-threads=1
+        run: |
+          cargo nextest run -p freenet --no-default-features \
+            --features trace,websocket,redb,wasmtime-backend,simulation_tests,testing \
+            --profile ci -E 'test(determinism)' -j 1
 
   six_peer_regression:
     name: six-peer-regression

--- a/crates/core/tests/connectivity.rs
+++ b/crates/core/tests/connectivity.rs
@@ -82,6 +82,7 @@ async fn query_connected_peers(
 /// so auto_connect_peers ensures they can form a full mesh rather than only
 /// connecting to the gateway.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -257,6 +258,7 @@ async fn test_gateway_reconnection(ctx: &mut TestContext) -> TestResult {
 
 /// Simplified test to verify basic gateway connectivity
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 60,
@@ -335,6 +337,7 @@ async fn test_basic_gateway_connectivity(ctx: &mut TestContext) -> TestResult {
 /// 8. Router forwards to peer's internal 192.168.1.100:8080 ✅
 ///
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer1", "peer2"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -777,6 +780,7 @@ async fn perform_put_with_retries(
 /// The fix ensures handle_connect_peer updates the transport entry's pub_key
 /// when promoting transients.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 120,

--- a/crates/core/tests/edge_case_state_sizes.rs
+++ b/crates/core/tests/edge_case_state_sizes.rs
@@ -25,6 +25,7 @@ use tokio_tungstenite::connect_async;
 /// Verifies the lower bound of contract state size handling.
 /// Uses the smallest valid TodoList: {"tasks":[],"version":1}
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 10,
@@ -80,6 +81,7 @@ async fn test_minimal_state_put_get(ctx: &mut TestContext) -> TestResult {
 ///
 /// Verifies handling of states near the practical size limit without exceeding it.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 90,
     startup_wait_secs = 10,
@@ -142,6 +144,7 @@ async fn test_large_state_put_get(ctx: &mut TestContext) -> TestResult {
 ///
 /// Verifies handling of zero-task todo lists (valid but empty contract state).
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 10,
@@ -210,6 +213,7 @@ async fn test_empty_state_put_get(ctx: &mut TestContext) -> TestResult {
 /// This test is designed to verify the system doesn't crash or hang
 /// when confronted with oversized data.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 120,
     startup_wait_secs = 10,
@@ -286,6 +290,7 @@ async fn test_oversized_state_handling(ctx: &mut TestContext) -> TestResult {
 /// Related to: Bug #1734 - UPDATE operations that result in no state change
 /// should still return a proper response, not timeout.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 90,
     startup_wait_secs = 10,
@@ -360,6 +365,7 @@ async fn test_update_no_state_change(ctx: &mut TestContext) -> TestResult {
 /// Creates a state close to practical size limits (950KB) to verify
 /// edge case handling around the boundary without hitting system limits.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 90,
     startup_wait_secs = 10,

--- a/crates/core/tests/error_notification.rs
+++ b/crates/core/tests/error_notification.rs
@@ -42,6 +42,7 @@ static RNG: LazyLock<Mutex<rand::rngs::StdRng>> = LazyLock::new(|| {
 ///
 /// Fixes: #1858
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 10,
@@ -104,6 +105,7 @@ async fn test_get_error_notification(ctx: &mut TestContext) -> TestResult {
 /// This test verifies that when a PUT operation fails (e.g., invalid contract),
 /// the client receives an error response rather than hanging indefinitely.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 10,
@@ -175,6 +177,7 @@ async fn test_put_error_notification(ctx: &mut TestContext) -> TestResult {
 /// This test verifies that when an UPDATE operation fails (e.g., contract doesn't exist),
 /// the client receives an error response rather than hanging indefinitely.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 10,
@@ -242,6 +245,7 @@ async fn test_update_error_notification(ctx: &mut TestContext) -> TestResult {
 ///
 /// Fixes: #2490
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "node-a"],
     timeout_secs = 180,
     startup_wait_secs = 30,

--- a/crates/core/tests/isolated_node_regression.rs
+++ b/crates/core/tests/isolated_node_regression.rs
@@ -27,6 +27,7 @@ use tracing::info;
 /// - GET operations retrieve from local cache without self-routing attempts (PR #1806)
 /// - Complete workflow functions properly without peer connections
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 10,
@@ -142,6 +143,7 @@ async fn test_isolated_node_put_get_workflow(ctx: &mut TestContext) -> TestResul
 /// 4. Client 2 sends identical GET request → Router tries to reuse removed TX
 /// 5. Bug: Client 2 never receives response
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 10,
@@ -284,6 +286,7 @@ async fn test_concurrent_get_deduplication_race(ctx: &mut TestContext) -> TestRe
 /// Tests the fix in PR #1844 where SubscribeResponse messages were not being
 /// delivered to WebSocket clients for local contracts.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 10,
@@ -423,6 +426,7 @@ async fn test_isolated_node_local_subscription(ctx: &mut TestContext) -> TestRes
 /// - UPDATE returns UpdateResponse without timeout (issue #1884)
 /// - GET operation retrieves updated state
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 10,

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -162,6 +162,7 @@ async fn send_put_with_retry(
 
 /// Test PUT operation across two peers (gateway and peer)
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-a"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -267,6 +268,7 @@ async fn test_put_contract(ctx: &mut TestContext) -> TestResult {
 }
 
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-a"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -461,6 +463,7 @@ async fn test_update_contract(ctx: &mut TestContext) -> TestResult {
 /// Test that a second PUT to an already cached contract persists the merged state.
 /// This is a regression test for issue #1995.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-a"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -615,6 +618,7 @@ async fn test_put_merge_persists_state(ctx: &mut TestContext) -> TestResult {
 // Re-enabled to verify if the flakiness (issue #1798, #2494) has been resolved.
 // The test expects multiple clients across different nodes to receive subscription updates.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "node-a", "node-b"],
     timeout_secs = 600,
     startup_wait_secs = 40,
@@ -1226,6 +1230,7 @@ async fn test_multiple_clients_subscription(ctx: &mut TestContext) -> TestResult
 }
 
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "node-a"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -1484,6 +1489,7 @@ async fn test_get_with_subscribe_flag(ctx: &mut TestContext) -> TestResult {
 
 // FIXME Update notification is not received
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "node-a"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -1950,6 +1956,7 @@ async fn test_put_with_subscribe_flag(ctx: &mut TestContext) -> TestResult {
 /// The PUT response should arrive only after the subscription is established.
 /// No SubscribeResponse should leak to the client (subscription is a sub-operation).
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "node-a"],
     timeout_secs = 300,
     startup_wait_secs = 30,
@@ -2051,6 +2058,7 @@ async fn test_put_with_blocking_subscribe(ctx: &mut TestContext) -> TestResult {
 /// Tests that GET with blocking_subscribe=true completes successfully.
 /// The GET response should arrive and no SubscribeResponse should leak.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "node-a"],
     timeout_secs = 300,
     startup_wait_secs = 30,
@@ -2166,6 +2174,7 @@ async fn test_get_with_blocking_subscribe(ctx: &mut TestContext) -> TestResult {
 }
 
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "client-node"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -2355,6 +2364,7 @@ fn expected_three_hop_locations() -> [f64; 3] {
 }
 
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-a", "peer-c"],
     gateways = ["gateway"],
     node_configs = {
@@ -2515,6 +2525,7 @@ async fn test_put_contract_three_hop_returns_response(ctx: &mut TestContext) -> 
 }
 
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-node"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -2585,6 +2596,7 @@ async fn test_subscription_introspection(ctx: &mut TestContext) -> TestResult {
 }
 
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-a"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -2705,6 +2717,7 @@ async fn test_update_no_change_notification(ctx: &mut TestContext) -> TestResult
 // - startup_wait_secs: 15s to allow nodes to fully start and establish connections
 // - tokio_worker_threads: 4 to provide adequate concurrency for multi-node test
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-a"],
     // Increased timeout for CI where 8 parallel tests compete for resources
     timeout_secs = 300,
@@ -2964,6 +2977,7 @@ async fn test_update_broadcast_propagation_issue_2301(ctx: &mut TestContext) -> 
 /// 2. Client immediately does Subscribe (before propagation to other peers)
 /// 3. Subscribe should succeed locally without network round-trip
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-a"],
     timeout_secs = 300,
     startup_wait_secs = 30,
@@ -3099,6 +3113,7 @@ async fn test_put_then_immediate_subscribe_succeeds_locally_regression_2326(
 /// 2. Gateway has no peers to forward to
 /// 3. Gateway should immediately return NotFound to the client
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 60,
     startup_wait_secs = 5,
@@ -3217,6 +3232,7 @@ async fn test_get_notfound_no_forwarding_targets(ctx: &mut TestContext) -> TestR
 ///
 /// The fix compares old stored state with new stored state instead.
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-a"],
     timeout_secs = 300,
     startup_wait_secs = 30,
@@ -3554,6 +3570,7 @@ enum DelegateCommandResponse {
 /// 5. The delegate issues an UpdateContractRequest with new state
 /// 6. A direct GET confirms the updated state
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 300,
     startup_wait_secs = 20,
@@ -3782,6 +3799,7 @@ async fn test_delegate_contract_put_and_update(ctx: &mut TestContext) -> TestRes
 /// 4. The runtime fetches the state and sends GetContractResponse back to the delegate
 /// 5. The delegate wraps the result as an ApplicationMessage
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     timeout_secs = 300,
     startup_wait_secs = 20,

--- a/crates/core/tests/test_macro_example.rs
+++ b/crates/core/tests/test_macro_example.rs
@@ -10,7 +10,7 @@ use freenet::test_utils::TestContext;
 use freenet_macros::freenet_test;
 
 /// Simple test with just a gateway node
-#[freenet_test(nodes = ["gateway"])]
+#[freenet_test(health_check_readiness = true, nodes = ["gateway"])]
 async fn test_single_node(ctx: &mut TestContext) -> TestResult {
     // The macro has already set up:
     // - TestLogger with JSON format
@@ -33,6 +33,7 @@ async fn test_single_node(ctx: &mut TestContext) -> TestResult {
 
 /// Test with multiple nodes
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-1", "peer-2"],
     timeout_secs = 120,
     startup_wait_secs = 10
@@ -67,6 +68,7 @@ async fn test_multi_node(ctx: &mut TestContext) -> TestResult {
 
 /// Test that demonstrates event aggregation on failure
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-1"],
     aggregate_events = "on_failure"
 )]
@@ -91,6 +93,7 @@ async fn test_with_event_aggregation(ctx: &mut TestContext) -> TestResult {
 
 /// Test that always shows event aggregation
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     aggregate_events = "always"
 )]
@@ -103,6 +106,7 @@ async fn test_always_aggregate(ctx: &mut TestContext) -> TestResult {
 
 /// Test with custom tokio configuration
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     tokio_flavor = "multi_thread",
     tokio_worker_threads = 8,
@@ -130,6 +134,7 @@ async fn test_custom_tokio_config(ctx: &mut TestContext) -> TestResult {
 
 /// Test with single-threaded runtime
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway"],
     tokio_flavor = "current_thread",
     timeout_secs = 60,
@@ -147,6 +152,7 @@ async fn test_current_thread_runtime(ctx: &mut TestContext) -> TestResult {
 
 /// Test with multiple gateways
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gw-1", "gw-2", "peer-1", "peer-2"],
     gateways = ["gw-1", "gw-2"],
     timeout_secs = 120,
@@ -211,6 +217,7 @@ async fn test_multiple_gateways(ctx: &mut TestContext) -> TestResult {
 
 /// Test with auto_connect_peers enabled (now the default)
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gateway", "peer-1", "peer-2"],
     timeout_secs = 120,
     startup_wait_secs = 30
@@ -239,6 +246,7 @@ async fn test_auto_connect_peers(ctx: &mut TestContext) -> TestResult {
 
 /// Test with multiple gateways and auto_connect_peers (now the default)
 #[freenet_test(
+    health_check_readiness = true,
     nodes = ["gw-1", "gw-2", "peer-1", "peer-2"],
     gateways = ["gw-1", "gw-2"],
     timeout_secs = 120,


### PR DESCRIPTION
## Problem

CI currently takes ~14-18 min on success and ~25-35 min with retries. The `|| retry` pattern re-runs the **entire workspace** when any single test fails, adding 10-15 min penalty. Additionally, all 45 `#[freenet_test]` tests use fixed sleep waits (10-40s each) instead of polling for actual node readiness.

## Solution

### 1. cargo-nextest with per-test retries

Replace `cargo test ... || retry` with `cargo nextest run --profile ci`. The `.config/nextest.toml` CI profile configures:
- **2 retries per failed test** (not the whole workspace)
- `fail-fast = false` to surface multiple issues
- `slow-timeout` at 120s with terminate-after to catch hangs

This reduces retry penalty from 10-15 min to 30-60s.

### 2. health_check_readiness on all tests

Enable `health_check_readiness = true` on all 45 `#[freenet_test]` invocations across 6 test files. This polls `wait_for_all_nodes_ready()` instead of sleeping fixed durations. Nodes typically become ready in 2-5s on localhost; current fixed waits are 10-40s per test.

**Files changed:**
- `operations.rs` — 18 tests
- `test_macro_example.rs` — 9 tests
- `edge_case_state_sizes.rs` — 6 tests
- `connectivity.rs` — 4 tests
- `error_notification.rs` — 4 tests
- `isolated_node_regression.rs` — 4 tests

## Testing

- [x] `cargo clippy --all-targets` passes
- [x] `cargo fmt` clean
- [ ] CI passes with nextest

## Fixes

Part of #3084.

[AI-assisted - Claude]