### PR TITLE
fix: raise ClientTransaction priority from P7 to P3

### DIFF
--- a/crates/core/src/node/network_bridge/priority_select.rs
+++ b/crates/core/src/node/network_bridge/priority_select.rs
@@ -175,7 +175,28 @@ where
             }
         }
 
-        // Priority 3: Peer connection events
+        // Priority 3: Client transaction handler (implements Stream directly)
+        // Registering client transactions is a lightweight operation (HashMap insert),
+        // so it should be high priority to avoid starvation under sustained network load.
+        // See: https://github.com/freenet/freenet-core/issues/3074
+        if !this.client_transaction_closed {
+            match Pin::new(&mut this.client_transaction_handler).poll_next(cx) {
+                Poll::Ready(Some(result)) => {
+                    return Poll::Ready(Some(SelectResult::ClientTransaction(Ok(result))))
+                }
+                Poll::Ready(None) => {
+                    this.client_transaction_closed = true;
+                    if first_closed_channel.is_none() {
+                        first_closed_channel = Some(SelectResult::ClientTransaction(Err(
+                            anyhow::anyhow!("channel closed"),
+                        )));
+                    }
+                }
+                Poll::Pending => {}
+            }
+        }
+
+        // Priority 4: Peer connection events
         if !this.conn_events_closed {
             match Pin::new(&mut this.conn_events).poll_next(cx) {
                 Poll::Ready(Some(event)) => {
@@ -191,7 +212,7 @@ where
             }
         }
 
-        // Priority 4: Connection bridge
+        // Priority 5: Connection bridge
         if !this.conn_bridge_closed {
             match Pin::new(&mut this.conn_bridge).poll_next(cx) {
                 Poll::Ready(Some(msg)) => {
@@ -208,7 +229,7 @@ where
             }
         }
 
-        // Priority 5: Handshake handler (implements Stream directly)
+        // Priority 6: Handshake handler (implements Stream directly)
         if !this.handshake_closed {
             match Pin::new(&mut this.handshake_handler).poll_next(cx) {
                 Poll::Ready(Some(event)) => {
@@ -224,7 +245,7 @@ where
             }
         }
 
-        // Priority 6: Node controller
+        // Priority 7: Node controller
         if !this.node_controller_closed {
             match Pin::new(&mut this.node_controller).poll_next(cx) {
                 Poll::Ready(Some(msg)) => {
@@ -235,24 +256,6 @@ where
                     this.node_controller_closed = true;
                     if first_closed_channel.is_none() {
                         first_closed_channel = Some(SelectResult::NodeController(None));
-                    }
-                }
-                Poll::Pending => {}
-            }
-        }
-
-        // Priority 7: Client transaction handler (implements Stream directly)
-        if !this.client_transaction_closed {
-            match Pin::new(&mut this.client_transaction_handler).poll_next(cx) {
-                Poll::Ready(Some(result)) => {
-                    return Poll::Ready(Some(SelectResult::ClientTransaction(Ok(result))))
-                }
-                Poll::Ready(None) => {
-                    this.client_transaction_closed = true;
-                    if first_closed_channel.is_none() {
-                        first_closed_channel = Some(SelectResult::ClientTransaction(Err(
-                            anyhow::anyhow!("channel closed"),
-                        )));
                     }
                 }
                 Poll::Pending => {}


### PR DESCRIPTION
## Problem

Client transaction registration (a microsecond HashMap insert) was at Priority 7 in `PrioritySelectStream`, meaning it could be indefinitely starved by sustained traffic on any of the 6 higher-priority channels (notifications, op execution, peer connections, connection bridge, handshakes, node controller).

Under sustained network load, this caused PUT/GET operations initiated by clients to silently hang — the transaction never got registered in the event loop because higher-priority channels always had pending work.

## Solution

Move `ClientTransaction` polling from Priority 7 to Priority 3 (after `OpExecution`, before `PeerConnection`). This is safe because:

1. **The operation is trivially fast** — it's just a HashMap insert, completing in microseconds
2. **It can't cause backpressure** — unlike network message processing, transaction registration has no I/O
3. **It directly unblocks client operations** — without registration, PUT/GET/SUBSCRIBE operations can't even start

New priority order:
| Priority | Channel | Rationale |
|----------|---------|-----------|
| P1 | Notification | Incoming network messages (highest) |
| P2 | OpExecution | Operation results |
| **P3** | **ClientTransaction** | **Client request registration (microsecond HashMap insert)** |
| P4 | PeerConnection | Peer connection events |
| P5 | ConnBridge | Connection bridge events |
| P6 | Handshake | Handshake protocol |
| P7 | NodeController | Node control events |
| P8 | ExecutorTransaction | Executor transactions (lowest) |

## Testing

- All 16 existing `priority_select` tests pass, including the concurrent stress test with 1700 messages across 6 channels
- `cargo clippy` clean
- `cargo fmt` clean

## Note

The related `pending_op_results` HashMap leak (entries inserted but never removed) was investigated but is a separate issue — it has a pre-existing FIXME comment and requires understanding operation completion semantics to fix safely.

Fixes #3074

[AI-assisted - Claude]