### PR TITLE
test: migrate nightly simulation tests to nextest and disable unstable tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,3 +8,11 @@ retries = 2
 fail-fast = false
 # Terminate tests that hang (2 periods of 120s = 4 min max per test).
 slow-timeout = { period = "120s", terminate-after = 2 }
+
+[profile.nightly]
+# Nightly tests run longer by design; no retries since failures need investigation.
+retries = 0
+fail-fast = false
+# Long-running simulation takes ~2.5 min wall clock (1h virtual @ 25x Turmoil
+# acceleration). Allow 10 min per period with 2 periods = 20 min hard cap.
+slow-timeout = { period = "600s", terminate-after = 2 }

--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -154,39 +154,49 @@ jobs:
         run: |
           echo "Running long-running deterministic simulation test (3600s virtual time)"
           echo "This tests for time-dependent bugs (connection timeouts, state drift, etc.)"
-          cargo test -p freenet --features "simulation_tests,testing,nightly_tests" --test simulation_integration \
-            test_long_running_deterministic -- \
-            --test-threads=1 --nocapture
+          cargo nextest run -p freenet \
+            --features "simulation_tests,testing,nightly_tests" \
+            --test simulation_integration \
+            -E 'test(test_long_running_deterministic)' \
+            --test-threads 1 \
+            --no-capture \
+            --profile nightly
 
-      # Large scale test (500 nodes) - stress test for scaling issues
-      - name: Large scale test (500 nodes)
-        run: |
-          echo "Running large scale simulation (500 nodes, 10000 events)"
-          target/release/fdev test \
-            --name "nightly-large-500" \
-            --seed 0x500BEEF \
-            --gateways 10 \
-            --nodes 490 \
-            --events 10000 \
-            --ring-max-htl 15 \
-            --max-connections 30 \
-            --min-connections 10 \
-            --latency-min 10 \
-            --latency-max 50 \
-            --min-success-rate 1.0 \
-            --print-summary \
-            --print-network-stats \
-            single-process
+      # Large scale test (500 nodes) - disabled until scaling issues are resolved
+      # TODO: Re-enable once the 500-node configuration runs reliably
+      # - name: Large scale test (500 nodes)
+      #   run: |
+      #     echo "Running large scale simulation (500 nodes, 10000 events)"
+      #     target/release/fdev test \
+      #       --name "nightly-large-500" \
+      #       --seed 0x500BEEF \
+      #       --gateways 10 \
+      #       --nodes 490 \
+      #       --events 10000 \
+      #       --ring-max-htl 15 \
+      #       --max-connections 30 \
+      #       --min-connections 10 \
+      #       --latency-min 10 \
+      #       --latency-max 50 \
+      #       --min-success-rate 1.0 \
+      #       --print-summary \
+      #       --print-network-stats \
+      #       single-process
 
-      # Real-process soak test - runs last (requires riverctl, skipped if not available)
-      - name: Run large network soak test (50+ real nodes)
-        run: |
-          echo "Running large network soak test with seed: $SIMULATION_SEED"
-          if command -v riverctl &> /dev/null; then
-            cargo test -p freenet --test large_network -- --ignored --nocapture --test-threads=1
-          else
-            echo "Skipping large_network test - riverctl not installed"
-          fi
+      # Real-process soak test - disabled until the test runs properly
+      # TODO: Re-enable once large_network test is stable
+      # - name: Run large network soak test (50+ real nodes)
+      #   run: |
+      #     echo "Running large network soak test with seed: $SIMULATION_SEED"
+      #     if command -v riverctl &> /dev/null; then
+      #       cargo nextest run -p freenet --test large_network \
+      #         -E 'test(large_network_soak)' \
+      #         --test-threads 1 \
+      #         --no-capture \
+      #         --profile nightly
+      #     else
+      #       echo "Skipping large_network test - riverctl not installed"
+      #     fi
 
   # Notify Matrix channel on failure
   # Uses curl directly because the matrix-message action doesn't URL-encode room IDs


### PR DESCRIPTION
## Summary
This PR updates the nightly simulation test workflow to use `cargo nextest` for better test execution and reporting, while temporarily disabling two large-scale tests that have reliability issues.

## Key Changes
- **Migrated long-running deterministic test** from `cargo test` to `cargo nextest run` with the new `nightly` profile for better handling of long-running tests
- **Disabled large scale test (500 nodes)** with TODO comment to re-enable once scaling issues are resolved
- **Disabled real-process soak test** with TODO comment to re-enable once the test is stable
- **Added new `nightly` profile** to `.config/nextest.toml` with:
  - No retries (failures need investigation in nightly tests)
  - Extended slow-timeout of 600s per period with 2 periods (20 min hard cap) to accommodate long-running simulation tests (~2.5 min wall clock for 1h virtual time at 25x acceleration)
  - `fail-fast = false` to run all tests even if some fail

## Notable Implementation Details
- The nightly profile's extended timeout is specifically tuned for the long-running deterministic simulation which runs 3600s of virtual time
- Both disabled tests are preserved in comments with TODO markers for future re-enablement rather than complete removal
- The migration to nextest uses the `-E 'test(...)'` filter syntax for more precise test selection

https://claude.ai/code/session_01NeyH4k6DnrcbJpN57hwQT3