### PR TITLE
fix: prevent deadlock in cleanup_stale_reservations lock ordering

### DIFF
--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -1229,7 +1229,10 @@ impl Ring {
             // when CONNECT operations fail to complete cleanly.
             let stale_removed = self.connection_manager.cleanup_stale_reservations();
             if stale_removed > 0 {
-                tracing::warn!(stale_removed, "Cleaned up stale pending reservations");
+                tracing::warn!(
+                    stale_removed,
+                    "Cleaned up stale reservations and orphaned location entries"
+                );
             }
 
             // Expire old NAT traversal failure entries


### PR DESCRIPTION
## Problem

PR #3091 introduced a lock ordering inconsistency in `cleanup_stale_reservations` that creates a potential deadlock with `prune_connection`:

- `cleanup_stale_reservations`: `pending_reservations(W)` → `connections_by_location(R)` → `location_for_peer(W)`
- `prune_connection`: `location_for_peer(W)` → `connections_by_location(W)` → `pending_reservations(W)`

If these two functions execute concurrently on different threads, classic ABBA deadlock can occur.

## Approach

Split `cleanup_stale_reservations` into two phases:
1. **Phase 1**: Acquire `pending_reservations(W)`, clean expired entries, snapshot surviving addresses into a `Vec`, then release the lock.
2. **Phase 2**: Acquire locks in `prune_connection`'s order (`location_for_peer(W)` → `connections_by_location(R)`), use the snapshot to check pending status without holding `pending_reservations`.

The TOCTOU race between phases is benign: if a new `should_accept` fires between phases, `has_connection_or_pending` still checks `pending_reservations` as a fallback.

Additional review fixes:
- Fix incorrect test comment: `prune_in_transit_connection` also removes the `pending_reservations` entry, so `has_connection_or_pending` returns false immediately. Added assertion.
- Tighten test assertion from `>= 2` to `== 2`.
- Update `location_for_peer` field comment to reflect it tracks both established and in-progress connections.
- Update log message to mention orphaned location cleanup.

## Testing

All 53 connection_manager tests pass, including the 3 regression tests from #3091.

[AI-assisted - Claude]