### PR TITLE
test: add nextest installation to simulation nightly workflow

### DIFF
--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -60,6 +60,9 @@ jobs:
           prefix-key: simulation-large
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - name: Install nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
       - name: Clean test directories
         run: |
           rm -rf /tmp/freenet /tmp/freenet-* 2>/dev/null || true


### PR DESCRIPTION
## Summary
This change adds the installation of nextest (a next-generation test runner for Rust) to the simulation nightly CI workflow.

## Key Changes
- Added a new workflow step that installs nextest from the official distribution using curl and tar
- The installation downloads the latest Linux binary and extracts it to the Cargo bin directory
- This step is positioned after cache restoration and before test directory cleanup

## Implementation Details
- Uses the official nextest installation script (`https://get.nexte.st/latest/linux`)
- Respects the standard `CARGO_HOME` environment variable with a fallback to `~/.cargo/bin`
- The installation occurs as part of the nightly simulation test job, enabling the use of nextest for test execution in subsequent workflow steps

https://claude.ai/code/session_019EEmcZXLU29oHo34ZPsYSx