### PR TITLE
build: stop auto-regenerating flatbuffers on every build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Mark auto-generated files so GitHub collapses them in PRs
+crates/core/src/generated/* linguist-generated=true

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -4,26 +4,13 @@ fn main() {
     // Emit build metadata for startup logging
     emit_build_metadata();
 
-    // Skip flatbuffers generation for cross-compilation
-    if std::env::var("CARGO_BUILD_TARGET").is_ok() {
-        return;
-    }
-
-    // Only regenerate if the schema file changes
-    println!("cargo:rerun-if-changed=../../schemas/flatbuffers/topology.fbs");
-
-    let status = Command::new("flatc")
-        .arg("--rust")
-        .arg("-o")
-        .arg("src/generated")
-        .arg("../../schemas/flatbuffers/topology.fbs")
-        .status();
-    if let Err(err) = status {
-        println!("failed compiling flatbuffers schema: {err}");
-        println!("refer to https://github.com/google/flatbuffers to install the flatc compiler");
-    } else {
-        let _ = Command::new("cargo").arg("fmt").status();
-    }
+    // Flatbuffers codegen is intentionally NOT run automatically.
+    // The generated file (src/generated/topology_generated.rs) is checked in
+    // and only needs regeneration when schemas/flatbuffers/topology.fbs changes.
+    //
+    // To regenerate:
+    //   flatc --rust -o crates/core/src/generated ../../schemas/flatbuffers/topology.fbs
+    //   cargo fmt -p freenet
 }
 
 fn emit_build_metadata() {


### PR DESCRIPTION
## Problem

`build.rs` runs `flatc` + `cargo fmt` on every `cargo build`. Since different developers/CI environments have different `flatc` versions installed, the generated `topology_generated.rs` file keeps showing cosmetic diffs — different formatting, different deprecated-constant styles, different `unsafe` block patterns, etc. This creates noise in PRs and `git status`.

## Solution

Remove automatic `flatc` invocation from `build.rs`. The generated file is already checked into git and only needs regeneration when `schemas/flatbuffers/topology.fbs` actually changes (which is rare). Regeneration instructions are documented in the build.rs comment.

Also adds `.gitattributes` with `linguist-generated=true` so GitHub collapses generated files in PR diffs.

## Testing

- `cargo check -p freenet` passes
- Pre-commit hooks (fmt, clippy) pass
- No functional change — the generated file is unchanged