### PR TITLE
fix: add --id flag to Docker startup scripts to disable telemetry

### DIFF
--- a/docker/freenet-gateway/freenet-gateway-startup.sh
+++ b/docker/freenet-gateway/freenet-gateway-startup.sh
@@ -15,6 +15,7 @@ echo "  Public Network Port: $PUBLIC_NETWORK_PORT"
 echo "  Network Port: $NETWORK_PORT"
 
 freenet network \
+    --id "test-gateway-${HOSTNAME}" \
     --skip-load-from-network \
     --is-gateway \
     --transport-keypair "$TRANSPORT_KEYPAIR" \

--- a/docker/freenet-node/freenet-node-startup.sh
+++ b/docker/freenet-node/freenet-node-startup.sh
@@ -7,6 +7,7 @@ BASE_DIR="/root/.cache/freenet"
 NODE_DIR="${BASE_DIR}/node"
 
 freenet network \
+  --id "test-node-${HOSTNAME}" \
   --config-dir "$BASE_DIR" \
   --data-dir "$NODE_DIR" \
   --ws-api-port "${WS_API_PORT:-7509}"


### PR DESCRIPTION
## Problem

The Docker-based six-peer regression tests were sending telemetry to the production collector (nova.locut.us), polluting it with thousands of `peer_startup` events from 172.x.x.x Docker IPs. PR #2471 added logic to disable telemetry when `--id` is passed (detecting test environments), but the Docker startup scripts never passed `--id`.

## Approach

Add `--id "test-gateway-${HOSTNAME}"` / `--id "test-node-${HOSTNAME}"` to the Docker startup scripts. This triggers the existing `is_test_environment` check in `config/mod.rs:578` which disables telemetry via `tracing/telemetry.rs:107-109`.

This is the minimal fix — no Rust code changes needed since the detection mechanism already exists, it just wasn't being activated by the Docker scripts.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features` — clean
- Verified the `--id` → `is_test_environment` → telemetry disabled path in `crates/core/src/config/mod.rs` and `crates/core/src/tracing/telemetry.rs`

## Files Changed

- `docker/freenet-gateway/freenet-gateway-startup.sh` — added `--id "test-gateway-${HOSTNAME}"`
- `docker/freenet-node/freenet-node-startup.sh` — added `--id "test-node-${HOSTNAME}"`

Closes #2511

[AI-assisted - Claude]