### PR TITLE
fix: monitor UDP listen task to detect transport layer death

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -640,6 +640,8 @@ impl P2pConnManager {
                     // connections will time out, and the node becomes unresponsive.
                     match listen_result {
                         Ok(Ok(())) => {
+                            // Currently unreachable: all listen() exit paths return Err.
+                            // Kept as defensive code in case listen() is modified later.
                             tracing::error!(
                                 "CRITICAL: UDP listen task exited cleanly — \
                                  this should never happen during normal operation"

--- a/crates/core/src/transport/connection_handler.rs
+++ b/crates/core/src/transport/connection_handler.rs
@@ -1277,6 +1277,7 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                             let kind = e.kind();
                             if matches!(kind, std::io::ErrorKind::ConnectionReset
                                 | std::io::ErrorKind::ConnectionRefused
+                                | std::io::ErrorKind::ConnectionAborted
                                 | std::io::ErrorKind::Interrupted
                                 | std::io::ErrorKind::WouldBlock
                                 | std::io::ErrorKind::TimedOut)
@@ -1421,10 +1422,13 @@ impl<S: Socket, T: TimeSource> UdpPacketsListener<S, T> {
                 // Handle new connection requests
                 connection_event = self.connection_handler.recv() => {
                     let Some((remote_addr, event)) = connection_event else {
-                        tracing::error!(
+                        // This fires both during graceful shutdown (event loop exits,
+                        // drops senders) and unexpected sender drops. Use warn! since
+                        // graceful shutdown is the common case.
+                        tracing::warn!(
                             bind_addr = %self.this_addr,
                             "Connection handler channel closed — listen task exiting. \
-                             This means all OutboundConnectionHandler senders were dropped."
+                             This is expected during graceful shutdown."
                         );
                         return Err(TransportError::ConnectionClosed(self.this_addr));
                     };


### PR DESCRIPTION
## Problem

Both production gateways (nova and vega) were found completely stalled for 5+ hours. Investigation revealed:

- UDP socket recv buffers 100% full (`r213248/rb212992`)
- **42.5 million** dropped packets on nova, **52.3 million** on vega
- All tokio worker threads parked in `futex_wait` — process alive but doing absolutely nothing
- Only ~4,000 context switches in 5.5 hours (a healthy node does thousands per second)

**Identified vulnerability:** The UDP `listen()` task's `JoinHandle` was dropped immediately after spawning (fire-and-forget at `connection_handler.rs:257`). If `listen()` exited for ANY reason — error, panic, or channel closure — nobody noticed. Without the listener reading the socket, UDP packets would pile up in the kernel buffer, all `PeerConnection`s would time out (120s idle timeout), and the node would enter a quiescent dead state.

**Note on root cause certainty:** We did not find log evidence that the listen task actually exited (no error logs after startup). The symptoms are consistent with either (a) the listen task exiting silently, or (b) the listen task being alive but stuck. This PR fixes vulnerability (a) and adds defense-in-depth against transient errors that could trigger it. If the stall recurs after this fix, the root cause is likely (b) and further investigation is needed.

## Approach

Rather than trying to prevent `listen()` from ever exiting (which would mask bugs), the fix **monitors the listen task and treats its exit as fatal**:

1. **Return the JoinHandle** from `config_listener()` and `create_connection_handler()` instead of dropping it
2. **Monitor it in the event loop** using `tokio::select!` alongside the `PrioritySelectStream` — if the listen task completes, propagate as a fatal error that triggers node shutdown (and systemd restart via `Restart=always`)
3. **Make transient `recv_from` errors non-fatal** — `ECONNREFUSED`, `ECONNRESET`, `ECONNABORTED`, `Interrupted`, `WouldBlock`, and `TimedOut` now log a warning and continue instead of killing the listener
4. **Upgrade connection handler channel closure** to return an error instead of `Ok(())`

The `biased` select ensures the listen task death is detected immediately (checked first each iteration), rather than potentially being delayed by event processing.

## Testing

- All 1,426 unit tests pass
- `cargo fmt` — clean
- `cargo clippy --all-targets --all-features` — clean (no warnings)
- 4-agent code review (code-first, testing, skeptical, big-picture) — all feedback addressed

**Error propagation verified end-to-end:** listen() → JoinHandle resolves → run_event_listener returns Err → run_node receives via deterministic_select → process exits → systemd `Restart=always` restarts the service.

**Why didn't CI catch this?** The listen task exit is a runtime failure that depends on specific conditions. Unit tests use mock sockets that don't produce transient errors. Follow-up issue #3121 tracks adding targeted regression tests.

## Fixes

Closes #3119
Follow-up: #3121 (audit other fire-and-forget tasks, add regression tests)

[AI-assisted - Claude]