### PR TITLE
docs: document lock ordering requirements in ConnectionManager

### DIFF
--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -1,3 +1,17 @@
+//! # Lock Ordering
+//!
+//! To prevent deadlocks, all `RwLock`-protected fields in [`ConnectionManager`] **must** be
+//! acquired in the following order whenever multiple locks are held simultaneously:
+//!
+//! 1. `location_for_peer`
+//! 2. `connections_by_location`
+//! 3. `pending_reservations`
+//!
+//! Acquiring locks in any other order risks an ABBA deadlock. This ordering was established
+//! after a deadlock introduced in PR #3091 (fixed in PR #3095), where
+//! `cleanup_stale_reservations` acquired `pending_reservations` before `connections_by_location`,
+//! while `prune_connection` acquired them in the opposite order.
+
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use std::collections::{btree_map::Entry, BTreeMap};


### PR DESCRIPTION
## Summary
Added comprehensive documentation to `ConnectionManager` specifying the required lock acquisition order for all `RwLock`-protected fields to prevent deadlocks.

## Key Changes
- Added a "Lock Ordering" documentation section at the top of `connection_manager.rs` that establishes a strict ordering requirement for acquiring multiple locks:
  1. `location_for_peer`
  2. `connections_by_location`
  3. `pending_reservations`
- Documented the historical context: a previous deadlock (PR #3091, fixed in PR #3095) occurred when `cleanup_stale_reservations` and `prune_connection` acquired locks in opposite orders

## Notable Details
- This is a preventative documentation change to help developers avoid future deadlock issues
- The lock ordering requirement applies whenever multiple locks are held simultaneously
- The documentation explicitly warns that acquiring locks in any other order risks an ABBA deadlock

https://claude.ai/code/session_015MFH5spSv149t8xugk5Q8E

Closes #3103 