### PR TITLE
refactor: simplify UDP listener error handling by removing Result wrapper

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -639,15 +639,7 @@ impl P2pConnManager {
                     // Without the listener, no UDP packets are read from the socket,
                     // connections will time out, and the node becomes unresponsive.
                     match listen_result {
-                        Ok(Ok(())) => {
-                            // Currently unreachable: all listen() exit paths return Err.
-                            // Kept as defensive code in case listen() is modified later.
-                            tracing::error!(
-                                "CRITICAL: UDP listen task exited cleanly — \
-                                 this should never happen during normal operation"
-                            );
-                        }
-                        Ok(Err(e)) => {
+                        Ok(e) => {
                             tracing::error!(
                                 error = %e,
                                 "CRITICAL: UDP listen task exited with transport error"


### PR DESCRIPTION
## Summary
This PR simplifies the error handling in the UDP packet listener by removing the `Result` wrapper from the `listen()` function's return type. The function now returns `TransportError` directly instead of `Result<(), TransportError>`, eliminating unnecessary error wrapping and simplifying the call site.

## Key Changes
- Changed `UdpPacketsListener::listen()` return type from `Result<(), TransportError>` to `TransportError`
- Updated all return statements in the `listen()` function to return `TransportError` directly instead of `Err(TransportError)`
- Updated type signatures for `JoinHandle` in `create_connection_handler()` and `ListenerSetup` to reflect the new return type
- Simplified error handling in `P2pConnManager` by removing the nested `Ok(Ok(...))` and `Ok(Err(...))` pattern matching, now just matching on `Ok(e)`
- Removed defensive code comment about unreachable `Ok(Ok(()))` case since it's no longer possible

## Implementation Details
The `listen()` function is spawned as a tokio task that is expected to run indefinitely. When it exits, it always indicates an error condition (connection closed, fatal error, etc.). By removing the `Result` wrapper, the code more accurately reflects this semantic: the function either never returns (success case) or returns a `TransportError` (failure case). This eliminates the awkward `Result<(), TransportError>` pattern where the `Ok(())` case was unreachable in practice.

https://claude.ai/code/session_01RLxDoL2NFts28FoAqNkN4R