### PR TITLE
fix: re-enable ignored simulation convergence tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     hooks:
       - id: todo-must-fix
         name: Check for TODO-MUST-FIX markers
-        entry: bash -c 'if git diff --cached -- "*.rs" "*.ts" "*.js" "*.py" | grep -i "TODO-MUST-FIX"; then echo "❌ Found TODO-MUST-FIX in staged changes. Please fix before committing."; exit 1; fi'
+        entry: bash -c 'if git diff --cached -- "*.rs" "*.ts" "*.js" "*.py" | grep "^+" | grep -iv "^+++" | grep -i "TODO-MUST-FIX"; then echo "❌ Found TODO-MUST-FIX in staged changes. Please fix before committing."; exit 1; fi'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2638,11 +2638,7 @@ fn test_concurrent_updates_from_n_sources() {
 /// 2. Each node has a "stale" view of other nodes' summaries
 /// 3. ResyncRequest mechanism recovers divergent state
 ///
-/// Currently fails with 4 nodes - only 4 of 5 peers converge, 2 unique states remain.
-/// The 6-node variant (test_concurrent_updates_from_n_sources) passes.
-// TODO-MUST-FIX: Known-failing convergence with 4 nodes. #3085
 #[test_log::test]
-#[ignore]
 fn test_stale_summary_cache_multiple_branches() {
     const SEED: u64 = 0x57A1_E001_0001;
     const NETWORK_NAME: &str = "stale-summaries";
@@ -2845,9 +2841,7 @@ fn test_max_downstream_limit_reached() {
 /// Originally tested subscription tree topology (Issue #2787).
 /// Now tests that nodes subscribing one-by-one still achieve CRDT convergence
 /// when updates are issued after all have subscribed.
-// Known-failing: convergence failure with this seed/topology. Tracked in #3030.
 #[test_log::test]
-#[ignore]
 fn test_chain_topology_formation() {
     const SEED: u64 = 0xC4A1_0001_0001;
     const NETWORK_NAME: &str = "chain-topology";


### PR DESCRIPTION
## Problem

Two simulation tests were `#[ignore]`d due to CRDT convergence failures:
- `test_chain_topology_formation` (#3030)
- `test_stale_summary_cache_multiple_branches` (#3085)

## Solution

Recent fixes (mock_runtime BSC emission, thread-local RNG/ID counters) resolved the underlying convergence issues. Both tests now pass consistently (verified across 5 consecutive runs, plus the full 70-test simulation suite).

Removed `#[ignore]` and `TODO-MUST-FIX` markers. Also fixed the pre-commit `todo-must-fix` hook which was incorrectly flagging *removals* of TODO-MUST-FIX markers (it checked `git diff` lines without filtering for additions only).

## Testing

- Both tests pass 5/5 runs
- Full simulation suite: 70 passed, 0 failed, 0 ignored

Closes #3030
