### PR TITLE
feat: add router telemetry and bump consider_n_closest_peers to 5

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -359,6 +359,15 @@ impl ConnectForwardEstimator {
             .ok()
             .map(|p| p.clamp(0.0, 1.0))
     }
+
+    /// Return the PAV curve points, event count, and peer adjustment count for telemetry.
+    pub(crate) fn snapshot(&self) -> (Vec<(f64, f64)>, usize, usize) {
+        (
+            self.estimator.curve_points(),
+            self.estimator.len(),
+            self.estimator.peer_adjustments.len(),
+        )
+    }
 }
 impl RelayState {
     /// Helper to prepare and execute forwarding to a peer.

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -156,6 +156,15 @@ impl IsotonicEstimator {
     pub(crate) fn len(&self) -> usize {
         self.global_regression.len()
     }
+
+    /// Extract the global regression curve as `(x, y)` pairs, sorted by x.
+    pub(crate) fn curve_points(&self) -> Vec<(f64, f64)> {
+        self.global_regression
+            .get_points_sorted()
+            .into_iter()
+            .map(|p| (*p.x(), *p.y()))
+            .collect()
+    }
 }
 
 pub(crate) enum EstimatorType {

--- a/crates/core/src/router/util.rs
+++ b/crates/core/src/router/util.rs
@@ -33,6 +33,6 @@ impl Default for Mean {
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
-pub(super) struct TransferSpeed {
+pub(crate) struct TransferSpeed {
     pub bytes_per_second: f64,
 }

--- a/crates/core/src/test_utils.rs
+++ b/crates/core/src/test_utils.rs
@@ -1587,6 +1587,8 @@ impl TestContext {
                     crate::tracing::EventKind::Ignored => ("⏭️", "Ignored"),
                     crate::tracing::EventKind::TransportSnapshot(..) => ("📊", "TransportSnapshot"),
                     crate::tracing::EventKind::InterestSync(..) => ("🔃", "InterestSync"),
+                    crate::tracing::EventKind::RoutingDecision(..) => ("🎯", "RoutingDecision"),
+                    crate::tracing::EventKind::RouterSnapshot(..) => ("📸", "RouterSnapshot"),
                 };
 
                 writeln!(
@@ -1632,6 +1634,8 @@ impl TestContext {
                 crate::tracing::EventKind::Ignored => ("⏭️", "Ignored"),
                 crate::tracing::EventKind::TransportSnapshot(..) => ("📊", "TransportSnapshot"),
                 crate::tracing::EventKind::InterestSync(..) => ("🔃", "InterestSync"),
+                crate::tracing::EventKind::RoutingDecision(..) => ("🎯", "RoutingDecision"),
+                crate::tracing::EventKind::RouterSnapshot(..) => ("📸", "RouterSnapshot"),
             };
 
             writeln!(
@@ -1698,6 +1702,8 @@ impl TestContext {
                             crate::tracing::EventKind::TransportSnapshot(..) => "TransportSnapshot",
                             crate::tracing::EventKind::InterestSync(..) => "InterestSync",
                             crate::tracing::EventKind::Ignored => "Ignored",
+                            crate::tracing::EventKind::RoutingDecision(..) => "RoutingDecision",
+                            crate::tracing::EventKind::RouterSnapshot(..) => "RouterSnapshot",
                         };
                         *by_type.entry(type_name.to_string()).or_default() += 1;
                     }
@@ -1756,6 +1762,12 @@ impl TestContext {
                                 ("📈", "TransportSnapshot")
                             }
                             crate::tracing::EventKind::InterestSync(..) => ("🔃", "InterestSync"),
+                            crate::tracing::EventKind::RoutingDecision(..) => {
+                                ("🎯", "RoutingDecision")
+                            }
+                            crate::tracing::EventKind::RouterSnapshot(..) => {
+                                ("📸", "RouterSnapshot")
+                            }
                             crate::tracing::EventKind::Ignored => ("⏭️", "Ignored"),
                         };
 


### PR DESCRIPTION
## Problem

The router's routing decisions are a complete black box — we can see events going in and outcomes coming out, but not *why* a particular peer was chosen. The Route event in OTLP is serialized as `{:?}` debug format, making it useless for dashboards. Additionally, `consider_n_closest_peers` is set to 2, which doesn't give the failure estimator enough room to route around bad peers.

## Solution

**N=5 bump:** Increases `consider_n_closest_peers` from 2 to 5 so the isotonic regression model has a meaningful candidate set to optimize over.

**Per-decision telemetry:** Adds `tracing::debug!` logging at both routing call sites (`closest_potentially_caching` and `k_closest_potentially_caching`), showing the full candidate set with distances, predictions, strategy used, and which peer was selected.

**Periodic router snapshots:** Every 5 minutes, emits a `RouterSnapshot` via `EventKind::RouterSnapshot` containing:
- Isotonic regression curves (failure rate, response time, transfer rate)
- ConnectForwardEstimator curves
- Model state (event counts, prediction active status, peer adjustment counts)

**Structured Route events:** Replaces `format!("{:?}", route_event)` in OTLP with structured JSON, split into `route_success`/`route_failure` event types with distance, timing, and payload fields.

**Unified routing:** `select_k_best_peers` now delegates to `select_k_best_peers_with_telemetry` to ensure consistent behavior across all paths.

## Testing

- All 36 router tests pass including `test_failure_avoidance` (updated for 5 peers)
- Full `cargo test -p freenet` passes (1426 tests)
- `cargo clippy --all-targets --all-features` clean (0 warnings)
- Code simplified via code-simplifier agent
- Four parallel review agents (code-first, testing, skeptical, big-picture) — all findings addressed

## Files Changed

| File | Change |
|------|--------|
| `router/mod.rs` | Telemetry types, `select_k_best_peers_with_telemetry`, `snapshot()`, N bump |
| `ring/mod.rs` | Log decisions at both call sites, periodic snapshot task |
| `ring/connection_manager.rs` | `routing_with_telemetry` method |
| `operations/connect.rs` | `ConnectForwardEstimator::snapshot()` |
| `router/isotonic_estimator.rs` | `curve_points()` helper |
| `router/util.rs` | `TransferSpeed` visibility fix |
| `tracing/mod.rs` | `RoutingDecision` + `RouterSnapshot` EventKind variants |
| `tracing/telemetry.rs` | Structured JSON for Route/RoutingDecision/RouterSnapshot |
| `test_utils.rs` | New EventKind arms in exhaustive matches |

[AI-assisted - Claude]