### PR TITLE
feat: show actionable connection diagnostics on the connecting page

### DIFF
--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -72,6 +72,7 @@ mod network_bridge;
 // No cfg gate: underlying items are unconditionally compiled and integration
 // tests compile the lib without cfg(test).
 pub use network_bridge::in_memory::{get_fault_injector, set_fault_injector, FaultInjectorState};
+pub(crate) mod network_status;
 mod op_state_manager;
 mod p2p_impl;
 pub(crate) mod proximity_cache;

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -122,6 +122,9 @@ impl NodeP2P {
         // Record the start time for uptime tracking in shutdown event
         let start_time = tokio::time::Instant::now();
 
+        // Initialize network status tracking for the connecting page diagnostics
+        super::network_status::init(self.conn_manager.listening_port());
+
         // Emit peer startup event
         if let Some(event) = crate::tracing::NetEventLog::peer_startup(
             &self.op_manager.ring,


### PR DESCRIPTION
## Problem

When a Freenet node can't connect to the network, users see a generic "Connecting to Freenet..." page with a spinner and no diagnostic info. The actual failure reasons (version mismatch, firewall blocking UDP, NAT traversal failure) are buried in log files, leading users to file bug reports for issues they could self-diagnose.

Triggered by diagnostic report BKXJAK where a user spent time debugging what turned out to be a firewall blocking UDP — information the node already had internally but didn't surface.

## Solution

Wire up the `network_status` module (added in 0.1.137 but never connected) to the connection event handlers and the connecting page:

- **Classify failures**: Parse `TransportError` strings in the `OutboundFailed` handler to identify version mismatches, NAT traversal failures, timeouts, and other errors
- **Track state**: Record failures and successes in the global `NetworkStatus` singleton
- **Show diagnostics**: The connecting page now renders a yellow warning box with specific issues and remediation steps when failures have been recorded

### What users see

- **Version mismatch**: "Your version: 0.1.133 — Gateway requires: 0.1.135. Run: `cargo install --force freenet --version 0.1.135`"
- **NAT traversal failed**: "Can't reach gateway. Check that UDP port {port} is open in your firewall."
- **Timeout**: "Gateway did not respond."
- **No failures yet**: The original generic "Connecting to Freenet..." message (first few seconds of startup)

The page auto-refreshes every 3 seconds via existing `<meta http-equiv="refresh">`.

## Testing

- `cargo build` — compiles cleanly
- `cargo clippy --all-targets` — no warnings
- `cargo test -p freenet --lib` — all 1439 tests pass
- 6 new unit tests for error classification, HTML escaping, and snapshot rendering

## Files changed

| File | Change |
|------|--------|
| `crates/core/src/node/mod.rs` | Add `mod network_status` declaration |
| `crates/core/src/node/p2p_impl.rs` | Initialize NetworkStatus on node startup |
| `crates/core/src/node/network_bridge/p2p_protoc.rs` | Record failures in OutboundFailed, record success on connection; add `listening_port()` getter |
| `crates/core/src/server/errors.rs` | Dynamic connecting page with diagnostic info |

[AI-assisted - Claude]