### PR TITLE
fix: wire up router feedback for subscribe, put, and update operations

### DIFF
--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -560,51 +560,49 @@ async fn report_result(
             // check operations.rs:handle_op_result to see what's the meaning of each state
             // in case more cases want to be handled when feeding information to the OpManager
 
-            match op_res.outcome() {
+            let route_event = match op_res.outcome() {
                 OpOutcome::ContractOpSuccess {
                     target_peer,
                     contract_location,
                     first_response_time,
                     payload_size,
                     payload_transfer_time,
-                } => {
-                    let event = RouteEvent {
-                        peer: target_peer.clone(),
-                        contract_location,
-                        outcome: RouteOutcome::Success {
-                            time_to_response_start: first_response_time,
-                            payload_size,
-                            payload_transfer_time,
-                        },
-                    };
-                    if let Some(log_event) =
-                        NetEventLog::route_event(op_res.id(), &op_manager.ring, &event)
-                    {
-                        event_listener
-                            .register_events(Either::Left(log_event))
-                            .await;
-                    }
-                    op_manager.ring.routing_finished(event);
-                }
+                } => Some(RouteEvent {
+                    peer: target_peer.clone(),
+                    contract_location,
+                    outcome: RouteOutcome::Success {
+                        time_to_response_start: first_response_time,
+                        payload_size,
+                        payload_transfer_time,
+                    },
+                }),
+                OpOutcome::ContractOpSuccessUntimed {
+                    target_peer,
+                    contract_location,
+                } => Some(RouteEvent {
+                    peer: target_peer.clone(),
+                    contract_location,
+                    outcome: RouteOutcome::SuccessUntimed,
+                }),
                 OpOutcome::ContractOpFailure {
                     target_peer,
                     contract_location,
-                } => {
-                    let event = RouteEvent {
-                        peer: target_peer.clone(),
-                        contract_location,
-                        outcome: RouteOutcome::Failure,
-                    };
-                    if let Some(log_event) =
-                        NetEventLog::route_event(op_res.id(), &op_manager.ring, &event)
-                    {
-                        event_listener
-                            .register_events(Either::Left(log_event))
-                            .await;
-                    }
-                    op_manager.ring.routing_finished(event);
+                } => Some(RouteEvent {
+                    peer: target_peer.clone(),
+                    contract_location,
+                    outcome: RouteOutcome::Failure,
+                }),
+                OpOutcome::Incomplete | OpOutcome::Irrelevant => None,
+            };
+            if let Some(event) = route_event {
+                if let Some(log_event) =
+                    NetEventLog::route_event(op_res.id(), &op_manager.ring, &event)
+                {
+                    event_listener
+                        .register_events(Either::Left(log_event))
+                        .await;
                 }
-                OpOutcome::Incomplete | OpOutcome::Irrelevant => {}
+                op_manager.ring.routing_finished(event);
             }
             if let Some(mut cb) = executor_callback {
                 cb.response(op_res).await;

--- a/crates/core/src/operations/mod.rs
+++ b/crates/core/src/operations/mod.rs
@@ -378,6 +378,12 @@ pub(crate) enum OpOutcome<'a> {
         /// Transfer time of the payload.
         payload_transfer_time: Duration,
     },
+    /// An op which involves a contract completed successfully but has no timing data
+    /// (subscribe, put, update). Feeds only the failure estimator.
+    ContractOpSuccessUntimed {
+        target_peer: &'a PeerKeyLocation,
+        contract_location: Location,
+    },
     /// An op which involves a contract completed unsuccessfully.
     ContractOpFailure {
         target_peer: &'a PeerKeyLocation,

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -421,9 +421,14 @@ impl SubscribeOp {
     }
 
     pub(super) fn outcome(&self) -> OpOutcome<'_> {
-        // If finalized successfully, routing succeeded (but we don't have timing
-        // stats for subscribe, so report as Irrelevant for the success path).
         if self.finalized() {
+            // Subscribe succeeded — report as untimed success if we have stats
+            if let Some(ref stats) = self.stats {
+                return OpOutcome::ContractOpSuccessUntimed {
+                    target_peer: &stats.target_peer,
+                    contract_location: stats.contract_location,
+                };
+            }
             return OpOutcome::Irrelevant;
         }
         // Not completed — if we have stats, report as failure

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -819,10 +819,16 @@ fn test_subscribe_failure_outcome() {
             contract_location,
         }),
     };
-    assert!(
-        matches!(op_completed.outcome(), OpOutcome::Irrelevant),
-        "Completed subscribe should return Irrelevant"
-    );
+    match op_completed.outcome() {
+        OpOutcome::ContractOpSuccessUntimed {
+            target_peer: peer,
+            contract_location: loc,
+        } => {
+            assert_eq!(*peer, target_peer);
+            assert_eq!(loc, contract_location);
+        }
+        _ => panic!("Expected ContractOpSuccessUntimed for completed subscribe with stats"),
+    }
 
     // Non-finalized op without stats → should return Incomplete
     let op_no_stats = SubscribeOp {

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -50,7 +50,7 @@ use crate::transport::TransportPublicKey;
 use crate::util::time_source::TimeSource;
 
 /// TTL for peer interests. After this duration without refresh, entries are expired.
-pub const INTEREST_TTL: Duration = Duration::from_secs(300); // 5 minutes
+pub const INTEREST_TTL: Duration = Duration::from_secs(1800); // 30 minutes
 
 /// Interval for background sweep to clean up expired interests.
 pub const INTEREST_SWEEP_INTERVAL: Duration = Duration::from_secs(60); // 1 minute

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -526,6 +526,7 @@ fn event_kind_to_string(kind: &EventKind) -> String {
             use crate::router::RouteOutcome;
             match &route_event.outcome {
                 RouteOutcome::Success { .. } => "route_success".to_string(),
+                RouteOutcome::SuccessUntimed => "route_success_untimed".to_string(),
                 RouteOutcome::Failure => "route_failure".to_string(),
             }
         }
@@ -1276,9 +1277,13 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         "payload_transfer_time_ms": payload_transfer_time.as_millis() as u64,
                     })
                 }
-                RouteOutcome::Failure => {
+                RouteOutcome::SuccessUntimed | RouteOutcome::Failure => {
+                    let type_str = match &route_event.outcome {
+                        RouteOutcome::SuccessUntimed => "route_success_untimed",
+                        _ => "route_failure",
+                    };
                     serde_json::json!({
-                        "type": "route_failure",
+                        "type": type_str,
                         "peer_location": route_event.peer.location().map(|l| l.as_f64()),
                         "contract_location": route_event.contract_location.as_f64(),
                         "distance": distance,


### PR DESCRIPTION
## Problem

The Router's failure estimator only received data from GET operations. Subscribe, put, and update all returned `OpOutcome::Irrelevant` on success, starving the Router of success signals. PUT and UPDATE also didn't report timeout failures. This meant the Router couldn't distinguish good peers from bad for 3 out of 4 operation types — the core "Router never learns" bug.

Additionally, `INTEREST_TTL` at 5 minutes was too aggressive, causing interest entries to expire before renewals could succeed during congestion.

## Approach

Add a `RouteOutcome::SuccessUntimed` variant for operations that succeed but don't have timing data (subscribe, put, update). This feeds only the `failure_estimator` (0.0 = success), not the timing estimators. Wire up all operation types to report outcomes, including timeout failures.

Key design decisions:
- **SuccessUntimed vs reusing Success**: A separate variant avoids polluting the timing estimators with fake data. When the router has insufficient timing data, it correctly falls back to distance-based peer selection (existing tested behavior).
- **Stats tracking**: Each operation type (put, update, subscribe) now tracks `target_peer` and `contract_location` at the forwarding decision point, enabling both success reporting via `outcome()` and timeout failure reporting via `op_state_manager` helpers.
- **INTEREST_TTL 5min → 30min**: Prevents interest entries from expiring before renewals succeed during congestion. Memory impact is mitigated by `remove_all_peer_interests` cleanup on disconnect.

## Changes

- **router/mod.rs**: Add `SuccessUntimed` variant to `RouteOutcome`, handle in `new()` and `add_event()`
- **operations/mod.rs**: Add `ContractOpSuccessUntimed` to `OpOutcome`
- **node/mod.rs**: Add match arm for `ContractOpSuccessUntimed` in `report_result()`, deduplicate route event handling
- **operations/subscribe.rs**: Return `ContractOpSuccessUntimed` on success with stats
- **operations/put.rs**: Add `PutStats` struct, wire up all construction sites, implement `outcome()` and `failure_routing_info()`
- **operations/update.rs**: Add `contract_location` to `UpdateStats`, implement `outcome()` and `failure_routing_info()`
- **node/op_state_manager.rs**: Add `remove_put_and_report_failure()` and `remove_update_and_report_failure()` timeout helpers
- **ring/interest.rs**: Increase `INTEREST_TTL` from 300s to 1800s
- **tracing/telemetry.rs**: Handle `SuccessUntimed` in telemetry event matching

## Testing

New unit tests added:
- `test_success_untimed_feeds_failure_only` — verifies SuccessUntimed feeds only failure_estimator, not timing estimators
- `test_success_untimed_in_history` — verifies Router::new() handles mixed history correctly
- Updated `test_subscribe_failure_outcome` — asserts ContractOpSuccessUntimed instead of Irrelevant
- 6 tests for `PutOp::outcome()` — all four branches (success/irrelevant/failure/incomplete) + failure_routing_info
- 8 tests for `UpdateOp::outcome()` — all branches including partial stats edge case + failure_routing_info

All 1447 unit tests pass. `cargo fmt` and `cargo clippy --all-targets --all-features` clean.

## Fixes

Closes #3127

[AI-assisted - Claude]