### PR TITLE
feat: add subscription tree telemetry and enrich timeout events

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1256,7 +1256,8 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                 for tx in old_missing.drain(..) {
                     if let Some(tx) = ops.completed.remove(&tx) {
                         if cfg!(feature = "trace-ot") {
-                            event_register.notify_of_time_out(tx).await;
+                            let op_type = tx.transaction_type().description();
+                            event_register.notify_of_time_out(tx, op_type, None).await;
                         } else {
                             _ = tx;
                         }
@@ -1339,7 +1340,8 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                     if let Some(tx) = ops.completed.remove(&tx) {
                         tracing::debug!("Clean up timed out: {tx}");
                         if cfg!(feature = "trace-ot") {
-                            event_register.notify_of_time_out(tx).await;
+                            let op_type = tx.transaction_type().description();
+                            event_register.notify_of_time_out(tx, op_type, None).await;
                         } else {
                             _ = tx;
                         }


### PR DESCRIPTION
## Summary

- **Enrich timeout telemetry**: `EventKind::Timeout` now includes `op_type` (connect/put/get/subscribe/update) and `target_peer` (when available from routing info), fixing the 85% of GET failure timeouts that produced unactionable generic events
- **Global telemetry sender**: `send_standalone_event()` via `OnceLock` allows background tasks (renewal loop, sweep task) to emit OTLP events without needing a `NetEventRegister` reference
- **Subscription renewal outcome telemetry**: Emits `subscription_renewal_outcome` events with contract, outcome (success/dropped_channel_full/failed), and error detail
- **Interest expiration telemetry**: Emits `interest_expired` per swept entry and `subscription_health_snapshot` every 60s with contracts_with_interests, total_interest_entries, and expired_this_sweep counts

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo test -p freenet --lib` — 1458 passed, 0 failed
- [x] New unit test: `test_event_kind_to_json_timeout_enriched` verifies enriched Timeout JSON
- [x] New unit test: `test_send_standalone_event_no_panic_without_init` verifies graceful no-op when telemetry disabled
- [ ] After deployment: verify new event types in OTLP collector (`interest_expired`, `subscription_renewal_outcome`, `subscription_health_snapshot`, enriched `timeout`)

Fixes #3127

[AI-assisted - Claude]