### PR TITLE
fix: include non-timestamped error logs in diagnostic reports

### DIFF
--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -85,7 +85,17 @@ impl HttpClientApi {
         // (network mode) allow HTTP cookies — most home users lack TLS.
         let localhost = socket.ip().is_loopback() || socket.ip().is_unspecified();
         let contract_web_path = std::env::temp_dir().join("freenet").join("webs");
-        std::fs::create_dir_all(contract_web_path).unwrap();
+        std::fs::create_dir_all(&contract_web_path).unwrap_or_else(|e| {
+            panic!(
+                "Failed to create contract web directory at {}: {}. \
+                 This may happen if {} was created by another user. \
+                 Try: sudo rm -rf {}",
+                contract_web_path.display(),
+                e,
+                std::env::temp_dir().join("freenet").display(),
+                std::env::temp_dir().join("freenet").display(),
+            )
+        });
 
         let (proxy_request_sender, request_to_server) = mpsc::channel(1);
 


### PR DESCRIPTION
## Problem

The `freenet service report` command silently discards error log content when it contains no parseable timestamps. Panic backtraces, the most critical debugging data for crash-looping nodes, have no timestamps — so the entire error log is dropped from the report.

Discovered via user report BDN2PU: a node crash-looping with `PermissionDenied` at `client_api.rs:88` had a 182KB error log full of panic traces, but the diagnostic report showed `error_log: null`. The exact data needed to diagnose the crash was thrown away.

Additionally, the panic message when `/tmp/freenet/webs` can't be created (the root cause of the user's crash loop) was an opaque `.unwrap()` with no context about cause or fix.

## Approach

In `read_log_file()`: track whether any timestamp was successfully parsed. If the file has content but no parseable timestamps, include all lines instead of returning `None`. This preserves panic backtraces and other non-timestamped stderr output while still filtering timestamped logs to the 30-minute window.

In `client_api.rs`: replace `.unwrap()` with `.unwrap_or_else()` that explains the permission issue and suggests `sudo rm -rf /tmp/freenet` as a fix. This happens when `/tmp/freenet/` was created by a different user (e.g., root).

## Testing

- `test_read_log_file_no_timestamps_includes_all_content` — verifies panic backtrace content (no timestamps) is preserved in full
- `test_read_log_file_old_timestamps_excluded` — verifies that timestamped logs older than 30 minutes are still correctly filtered out (existing behavior unchanged)
- All 11 report tests pass, clippy clean

[AI-assisted - Claude]