### PR TITLE
test: resource invariant simulation tests (Stage 2, #3150)

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -2043,6 +2043,11 @@ std::thread_local! {
     static GLOBAL_RESYNC_REQUESTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_DELTA_SENDS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     static GLOBAL_FULL_STATE_SENDS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_PENDING_OP_INSERTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_PENDING_OP_REMOVES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_PENDING_OP_HWM: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_NEIGHBOR_CACHE_UPDATES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static GLOBAL_ANTI_STARVATION_TRIGGERS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Global test metrics for tracking events across the simulation network.
@@ -2072,6 +2077,11 @@ impl GlobalTestMetrics {
         GLOBAL_RESYNC_REQUESTS.with(|c| c.set(0));
         GLOBAL_DELTA_SENDS.with(|c| c.set(0));
         GLOBAL_FULL_STATE_SENDS.with(|c| c.set(0));
+        GLOBAL_PENDING_OP_INSERTS.with(|c| c.set(0));
+        GLOBAL_PENDING_OP_REMOVES.with(|c| c.set(0));
+        GLOBAL_PENDING_OP_HWM.with(|c| c.set(0));
+        GLOBAL_NEIGHBOR_CACHE_UPDATES.with(|c| c.set(0));
+        GLOBAL_ANTI_STARVATION_TRIGGERS.with(|c| c.set(0));
     }
 
     /// Records that a ResyncRequest was received.
@@ -2105,6 +2115,47 @@ impl GlobalTestMetrics {
     /// Returns the total number of full state sends since last reset.
     pub fn full_state_sends() -> u64 {
         GLOBAL_FULL_STATE_SENDS.with(|c| c.get())
+    }
+
+    pub fn record_pending_op_insert() {
+        GLOBAL_PENDING_OP_INSERTS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn pending_op_inserts() -> u64 {
+        GLOBAL_PENDING_OP_INSERTS.with(|c| c.get())
+    }
+
+    pub fn record_pending_op_remove() {
+        GLOBAL_PENDING_OP_REMOVES.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn pending_op_removes() -> u64 {
+        GLOBAL_PENDING_OP_REMOVES.with(|c| c.get())
+    }
+
+    /// Track high-water mark for pending_op_results size.
+    pub fn record_pending_op_size(len: u64) {
+        GLOBAL_PENDING_OP_HWM.with(|c| c.set(c.get().max(len)));
+    }
+
+    pub fn pending_op_high_water_mark() -> u64 {
+        GLOBAL_PENDING_OP_HWM.with(|c| c.get())
+    }
+
+    pub fn record_neighbor_cache_update() {
+        GLOBAL_NEIGHBOR_CACHE_UPDATES.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn neighbor_cache_updates() -> u64 {
+        GLOBAL_NEIGHBOR_CACHE_UPDATES.with(|c| c.get())
+    }
+
+    pub fn record_anti_starvation_trigger() {
+        GLOBAL_ANTI_STARVATION_TRIGGERS.with(|c| c.set(c.get() + 1));
+    }
+
+    pub fn anti_starvation_triggers() -> u64 {
+        GLOBAL_ANTI_STARVATION_TRIGGERS.with(|c| c.get())
     }
 }
 

--- a/crates/core/src/node/network_bridge/priority_select.rs
+++ b/crates/core/src/node/network_bridge/priority_select.rs
@@ -166,6 +166,7 @@ where
                 "Anti-starvation: forcing poll of Tier-2 channels"
             );
             tier2_polled_in_phase1 = true;
+            crate::config::GlobalTestMetrics::record_anti_starvation_trigger();
 
             // Force-poll P7: Client transaction handler
             if !this.client_transaction_closed {

--- a/crates/core/src/node/proximity_cache.rs
+++ b/crates/core/src/node/proximity_cache.rs
@@ -155,6 +155,7 @@ impl ProximityCacheManager {
                     self.neighbor_caches
                         .insert(from.clone(), added.iter().copied().collect());
                 }
+                crate::config::GlobalTestMetrics::record_neighbor_cache_update();
 
                 let neighbor_contracts: usize = self
                     .neighbor_caches
@@ -238,6 +239,7 @@ impl ProximityCacheManager {
 
                 self.neighbor_caches
                     .insert(from.clone(), contracts.into_iter().collect());
+                crate::config::GlobalTestMetrics::record_neighbor_cache_update();
 
                 info!(
                     peer = %from,


### PR DESCRIPTION
## Problem

Issue #3141 identified that resource leaks and channel starvation bugs (#3100, #3094) were caught by users, not CI. Stage 1 (PR #3160, merged) fixed wiring/error propagation. Stage 2 adds simulation tests that assert bounded resource usage, catching regressions of these fixes.

## Solution

Extend the existing `GlobalTestMetrics` pattern (thread-local `Cell<u64>` counters incremented by production code, read by tests) with 5 new resource metrics. Add ~15 lines of instrumentation across 3 production files. Write 3 simulation tests in the existing `simulation_integration.rs`.

All three tests also run `verify_state_report()` to assert zero hard correctness violations (`FinalDivergence`, `MissingBroadcast`, `ZombieTransaction`) per [Nacho's feedback](https://github.com/freenet/freenet-core/issues/3141#issuecomment-3937579077).

### Changes

| Category | Files | Lines |
|----------|-------|-------|
| GlobalTestMetrics extension | `config/mod.rs` | +51 |
| Production instrumentation | `p2p_protoc.rs`, `proximity_cache.rs`, `priority_select.rs` | +15 |
| Simulation tests | `simulation_integration.rs` | +91 |
| **Total** | **5 files** | **+157** |

### New metrics

- `pending_op_inserts` / `pending_op_removes` / `pending_op_high_water_mark` — track `pending_op_results` HashMap lifecycle
- `neighbor_cache_updates` — track proximity cache churn
- `anti_starvation_triggers` — track PrioritySelectStream anti-starvation activations

### New tests

| Test | What it catches | Assertions |
|------|----------------|------------|
| `test_pending_op_results_bounded` | #3100 (unbounded HashMap growth) | HWM <= 100, leak <= 10 at shutdown, zero hard anomalies |
| `test_neighbor_cache_bounded` | Excessive cache churn | updates > 0, updates <= 500, zero hard anomalies |
| `test_anti_starvation_exercised` | #3094 (starvation) | Convergence under load, zero hard anomalies |

### Note on pending_op_results

The `op_execution` channel's sender (`notify_op_execution`) is currently dead code, so `pending_op_results` is not populated during simulation. The test serves as a regression guard — if the path is re-enabled (see #3159), it will catch unbounded growth. The test explicitly logs when inserts = 0 for visibility.

### Addressing review feedback

- `record_pending_op_remove()` is now conditional on `remove()` returning `Some` (avoids phantom remove counting)
- Shutdown `drain()` path now counts removes for accurate leak detection
- All three tests run `verify_state_report()` for StateVerifier zero-tolerance assertions
- Fixed "6-node" to "8-peer" in assertion messages (2 gateways + 6 nodes)

## Testing

All 3 new tests pass:
```
cargo test -p freenet --features "simulation_tests,testing" --test simulation_integration \
  -- test_pending_op_results_bounded test_neighbor_cache_bounded test_anti_starvation_exercised
```

Full test suite passes. Clippy clean (only pre-existing unused import warning).

## Fixes

Closes #3150

[AI-assisted - Claude]