### PR TITLE
fix: increase min relay ready connections from 2 to 3

### DIFF
--- a/apps/freenet-ping/app/tests/common/mod.rs
+++ b/apps/freenet-ping/app/tests/common/mod.rs
@@ -332,6 +332,16 @@ pub fn ws_config() -> WebSocketConfig {
         .max_frame_size(Some(16 * 1024 * 1024)) // 16MB frames
 }
 
+/// Creates a NodeConfig with test-appropriate defaults.
+/// Disables relay readiness gating (which requires a minimum number of ring connections
+/// before a node will route non-CONNECT operations). Small test topologies can never
+/// reach the production threshold, so this must be disabled.
+pub async fn test_node_config(config: freenet::config::Config) -> Result<NodeConfig> {
+    let mut nc = NodeConfig::new(config).await?;
+    nc.relay_ready_connections(Some(0));
+    Ok(nc)
+}
+
 pub async fn connect_ws_client(ws_port: u16) -> Result<WebApi> {
     let uri = format!("ws://127.0.0.1:{ws_port}/v1/contract/command?encodingProtocol=native");
     let (stream, _) = connect_async_with_config(&uri, Some(ws_config()), false).await?;

--- a/apps/freenet-ping/app/tests/run_app.rs
+++ b/apps/freenet-ping/app/tests/run_app.rs
@@ -3,7 +3,7 @@ mod common;
 use std::{net::TcpListener, path::PathBuf, time::Duration};
 
 use anyhow::anyhow;
-use freenet::{local_node::NodeConfig, server::serve_client_api};
+use freenet::server::serve_client_api;
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
     client_api::{
@@ -19,8 +19,8 @@ use tracing::{span, Instrument, Level};
 
 use common::{
     allocate_test_node_block, base_node_test_config_with_rng, connect_ws_with_retry,
-    gw_config_from_path_with_rng, test_ip_for_node, wait_for_node_connected, APP_TAG, PACKAGE_DIR,
-    PATH_TO_CONTRACT,
+    gw_config_from_path_with_rng, test_ip_for_node, test_node_config, wait_for_node_connected,
+    APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
 };
 use freenet_ping_app::ping_client::{
     run_ping_client, wait_for_get_response, wait_for_put_response, wait_for_subscribe_response,
@@ -262,7 +262,7 @@ async fn test_node_diagnostics_query() -> anyhow::Result<()> {
     // Start gateway node
     let gateway_node = async {
         let config = config_gw.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -273,7 +273,7 @@ async fn test_node_diagnostics_query() -> anyhow::Result<()> {
     // Start client node
     let client_node = async move {
         let config = config_node.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -640,7 +640,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
     // Start gateway node first
     let gateway_node = async {
         let config = config_gw.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -657,7 +657,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
         tracing::info!("Node1 starting after gateway delay");
 
         let config = config_node1.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -672,7 +672,7 @@ async fn test_ping_multi_node() -> anyhow::Result<()> {
         tracing::info!("Node2 starting after gateway delay");
 
         let config = config_node2.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -1375,7 +1375,7 @@ async fn test_ping_application_loop() -> anyhow::Result<()> {
     // Start gateway node first
     let gateway_node = async {
         let config = config_gw.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -1390,7 +1390,7 @@ async fn test_ping_application_loop() -> anyhow::Result<()> {
         tracing::info!("Node1 starting after gateway delay");
 
         let config = config_node1.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -1405,7 +1405,7 @@ async fn test_ping_application_loop() -> anyhow::Result<()> {
         tracing::info!("Node2 starting after gateway delay");
 
         let config = config_node2.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;

--- a/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
+++ b/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
@@ -18,10 +18,9 @@ use std::{
 use anyhow::anyhow;
 use common::{
     base_node_test_config_with_ip, get_all_ping_states, gw_config_from_path_with_ip,
-    wait_for_node_connected, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
+    test_node_config, wait_for_node_connected, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
 };
 use freenet::{
-    local_node::NodeConfig,
     server::serve_client_api,
     test_utils::{allocate_test_node_block, test_ip_for_node},
 };
@@ -180,7 +179,7 @@ async fn run_blocked_peers_test(attempt: usize) -> anyhow::Result<()> {
     // Start nodes
     let gateway_node = async {
         let config = config_gw.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -190,7 +189,7 @@ async fn run_blocked_peers_test(attempt: usize) -> anyhow::Result<()> {
 
     let node1 = async {
         let config = config_node1.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -200,7 +199,7 @@ async fn run_blocked_peers_test(attempt: usize) -> anyhow::Result<()> {
 
     let node2 = async {
         let config = config_node2.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;

--- a/apps/freenet-ping/app/tests/run_app_delegate_wasmtime.rs
+++ b/apps/freenet-ping/app/tests/run_app_delegate_wasmtime.rs
@@ -3,7 +3,7 @@ mod common;
 use std::{net::TcpListener, time::Duration};
 
 use anyhow::anyhow;
-use freenet::{local_node::NodeConfig, server::serve_client_api};
+use freenet::server::serve_client_api;
 use freenet_stdlib::{
     client_api::{ClientRequest, HostResponse},
     prelude::*,
@@ -15,7 +15,7 @@ use tokio::select;
 
 use common::{
     allocate_test_node_block, base_node_test_config_with_rng, connect_ws_with_retry,
-    test_ip_for_node,
+    test_ip_for_node, test_node_config,
 };
 
 /// Message types matching test-delegate-integration's InboundAppMessage
@@ -79,7 +79,7 @@ async fn test_delegate_e2e_wasmtime() -> anyhow::Result<()> {
     // Start gateway node
     let gateway_node = async {
         let config = config_gw.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;

--- a/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
+++ b/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use anyhow::anyhow;
-use freenet::{local_node::NodeConfig, server::serve_client_api, test_utils::test_ip_for_node};
+use freenet::{server::serve_client_api, test_utils::test_ip_for_node};
 use freenet_ping_app::ping_client::wait_for_put_response;
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
@@ -34,7 +34,7 @@ use tracing::{span, Instrument, Level};
 
 use common::{
     base_node_test_config_with_ip, connect_ws_with_retry, gw_config_from_path_with_ip,
-    wait_for_node_connected, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
+    test_node_config, wait_for_node_connected, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
 };
 
 /// Test for subscription propagation in a partially connected network.
@@ -232,7 +232,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
         let config = gateway_configs.remove(0);
         let gateway_future = async move {
             let config = config.build().await?;
-            let node = NodeConfig::new(config.clone()).await?;
+            let node = test_node_config(config.clone()).await?;
             let gateway_service = serve_client_api(config.ws_api).await?;
             let node = node.build(gateway_service).await?;
             node.run().await
@@ -252,7 +252,7 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
         let config = node_configs.remove(0);
         let regular_node_future = async move {
             let config = config.build().await?;
-            let node = NodeConfig::new(config.clone()).await?;
+            let node = test_node_config(config.clone()).await?;
             let gateway_service = serve_client_api(config.ws_api).await?;
             let node = node.build(gateway_service).await?;
             node.run().await

--- a/apps/freenet-ping/app/tests/test_50_node_operations.rs
+++ b/apps/freenet-ping/app/tests/test_50_node_operations.rs
@@ -8,7 +8,7 @@
 mod common;
 
 use anyhow::anyhow;
-use freenet::{local_node::NodeConfig, server::serve_client_api, test_utils::test_ip_for_node};
+use freenet::{server::serve_client_api, test_utils::test_ip_for_node};
 use freenet_ping_app::ping_client::wait_for_put_response;
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
@@ -25,7 +25,7 @@ use tokio::{select, time::timeout};
 
 use common::{
     base_node_test_config_with_ip, connect_async_with_config, gw_config_from_path_with_ip,
-    ws_config, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
+    test_node_config, ws_config, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
 };
 
 const NUM_GATEWAYS: usize = 3; // Multiple gateways to distribute load
@@ -175,7 +175,7 @@ async fn setup_50_node_network(
         let config = gateway_configs.remove(0);
         let gateway_future = async {
             let config = config.build().await?;
-            let node = NodeConfig::new(config.clone())
+            let node = test_node_config(config.clone())
                 .await?
                 .build(serve_client_api(config.ws_api).await?)
                 .await?;
@@ -205,7 +205,7 @@ async fn setup_50_node_network(
             let config = node_configs.remove(0);
             let regular_node_future = async {
                 let config = config.build().await?;
-                let node = NodeConfig::new(config.clone())
+                let node = test_node_config(config.clone())
                     .await?
                     .build(serve_client_api(config.ws_api).await?)
                     .await?;

--- a/apps/freenet-ping/app/tests/test_connection_timing.rs
+++ b/apps/freenet-ping/app/tests/test_connection_timing.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use freenet::{local_node::NodeConfig, server::serve_client_api, test_utils::test_ip_for_node};
+use freenet::{server::serve_client_api, test_utils::test_ip_for_node};
 use freenet_stdlib::client_api::WebApi;
 use futures::FutureExt;
 use tokio::{select, time::timeout};
@@ -15,7 +15,7 @@ use tracing::{span, Instrument, Level};
 
 use common::{
     base_node_test_config_with_ip, connect_async_with_config, gw_config_from_path_with_ip,
-    ws_config,
+    test_node_config, ws_config,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
@@ -71,7 +71,7 @@ async fn test_connection_timing() -> anyhow::Result<()> {
     // Start nodes
     let gateway_future = async {
         let config = config_gw.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;
@@ -82,7 +82,7 @@ async fn test_connection_timing() -> anyhow::Result<()> {
 
     let node1_future = async {
         let config = config_node1.build().await?;
-        let node = NodeConfig::new(config.clone())
+        let node = test_node_config(config.clone())
             .await?
             .build(serve_client_api(config.ws_api).await?)
             .await?;

--- a/apps/freenet-ping/app/tests/test_limited_connectivity_get.rs
+++ b/apps/freenet-ping/app/tests/test_limited_connectivity_get.rs
@@ -42,7 +42,6 @@ use std::{
 };
 
 use freenet::{
-    local_node::NodeConfig,
     server::serve_client_api,
     test_utils::{allocate_test_node_block, test_ip_for_node},
 };
@@ -56,7 +55,7 @@ use tracing::{span, Instrument, Level};
 
 use common::{
     base_node_test_config_with_ip, connect_async_with_config, gw_config_from_path_with_ip,
-    wait_for_node_connected, ws_config,
+    test_node_config, wait_for_node_connected, ws_config,
 };
 
 /// Test that GET requests for non-existent contracts terminate gracefully
@@ -123,7 +122,7 @@ async fn test_limited_connectivity_get_nonexistent_contract() -> anyhow::Result<
 
     let gateway_future = async {
         let config = config_gw.build().await?;
-        let mut node_config = NodeConfig::new(config.clone()).await?;
+        let mut node_config = test_node_config(config.clone()).await?;
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(5);
         let node = node_config
@@ -136,7 +135,7 @@ async fn test_limited_connectivity_get_nonexistent_contract() -> anyhow::Result<
 
     let peer_future = async {
         let config = config_peer.build().await?;
-        let mut node_config = NodeConfig::new(config.clone()).await?;
+        let mut node_config = test_node_config(config.clone()).await?;
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(5);
         let node = node_config

--- a/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
+++ b/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use freenet::{local_node::NodeConfig, server::serve_client_api, test_utils::test_ip_for_node};
+use freenet::{server::serve_client_api, test_utils::test_ip_for_node};
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
     client_api::{ClientRequest, ContractRequest, ContractResponse, HostResponse, WebApi},
@@ -18,7 +18,7 @@ use tracing::{span, Instrument, Level};
 
 use common::{
     base_node_test_config_with_ip, connect_async_with_config, gw_config_from_path_with_ip,
-    wait_for_node_connected, ws_config, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
+    test_node_config, wait_for_node_connected, ws_config, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
@@ -98,7 +98,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
 
     let gateway_future = async {
         let config = config_gw.build().await?;
-        let mut node_config = NodeConfig::new(config.clone()).await?;
+        let mut node_config = test_node_config(config.clone()).await?;
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(10);
         let node = node_config
@@ -111,7 +111,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
 
     let node1_future = async {
         let config = config_node1.build().await?;
-        let mut node_config = NodeConfig::new(config.clone()).await?;
+        let mut node_config = test_node_config(config.clone()).await?;
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(10);
         let node = node_config
@@ -124,7 +124,7 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
 
     let node2_future = async {
         let config = config_node2.build().await?;
-        let mut node_config = NodeConfig::new(config.clone()).await?;
+        let mut node_config = test_node_config(config.clone()).await?;
         node_config.min_number_of_connections(1);
         node_config.max_number_of_connections(10);
         let node = node_config

--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -178,7 +178,7 @@ pub struct NodeConfig {
     pub(crate) transient_ttl: Duration,
     /// Minimum ring connections before this peer advertises readiness
     /// to accept non-CONNECT operations. `None` or `Some(0)` disables the gate.
-    /// Default: `Some(2)` in production.
+    /// Default: `Some(3)` in production.
     #[serde(default)]
     pub(crate) relay_ready_connections: Option<usize>,
 }


### PR DESCRIPTION
## Problem

The relay readiness threshold of 2 connections (from #3169) is too low. A peer behind symmetric NAT could establish connections to 2 gateways but still be unable to accept connections from peers behind other NATs. This means it would advertise readiness prematurely, becoming a dead-end for routed operations.

## Solution

Increase `relay_ready_connections` default from `Some(2)` to `Some(3)`. This ensures at least one non-gateway peer connection exists before a node advertises readiness to its neighbors.

## Testing

One-line change to default value. All tests use `relay_ready_connections = Some(0)` (disabled) so no test impact.

[AI-assisted - Claude]