### PR TITLE
fix: prevent service restart loop when port 7509 is already in use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,6 +1846,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
+ "socket2 0.5.10",
  "sqlx",
  "statrs",
  "stretto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ zeroize = { version = "1.8", features = ["derive"] }
 # Async/networking
 axum = { version = "0.8", default-features = false }
 futures = "0.3"
+socket2 = "0.5"
 headers = "0.4"
 hickory-resolver = { version = "0.24", features = ["dns-over-rustls"] }
 http = "1.4"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -57,6 +57,7 @@ rand = { features = ["small_rng"], workspace = true }
 redb = { workspace = true, optional = true }
 serde = { features = ["derive", "rc"], workspace = true }
 serde_json = { workspace = true }
+socket2 = { workspace = true }
 toml = { workspace = true }
 serde_with = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"], optional = true }

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -368,6 +368,11 @@ ExecStart={binary} network
 Restart=always
 # Wait 10 seconds before restart to avoid rapid restart loops
 RestartSec=10
+# Stop restart loop after 5 failures in 2 minutes (e.g., port conflict with
+# a stale process). Without this, systemd restarts indefinitely. The counter
+# resets after a successful start, so auto-update (exit 42) is unaffected.
+StartLimitBurst=5
+StartLimitIntervalSec=120
 # Allow 15 seconds for graceful shutdown before SIGKILL
 # The node handles SIGTERM to properly close peer connections
 TimeoutStopSec=15
@@ -421,6 +426,11 @@ ExecStart={binary} network
 Restart=always
 # Wait 10 seconds before restart to avoid rapid restart loops
 RestartSec=10
+# Stop restart loop after 5 failures in 2 minutes (e.g., port conflict with
+# a stale process). Without this, systemd restarts indefinitely. The counter
+# resets after a successful start, so auto-update (exit 42) is unaffected.
+StartLimitBurst=5
+StartLimitIntervalSec=120
 # Allow 15 seconds for graceful shutdown before SIGKILL
 # The node handles SIGTERM to properly close peer connections
 TimeoutStopSec=15
@@ -1088,6 +1098,10 @@ mod tests {
         assert!(service_content.contains("Restart=always"));
         assert!(service_content.contains("RestartSec=10"));
 
+        // Verify restart loop prevention (limits consecutive failures)
+        assert!(service_content.contains("StartLimitBurst=5"));
+        assert!(service_content.contains("StartLimitIntervalSec=120"));
+
         // Verify auto-update support via ExecStopPost
         assert!(service_content.contains("ExecStopPost="));
 
@@ -1126,6 +1140,8 @@ mod tests {
 
         // Verify it still has all the standard settings
         assert!(service_content.contains("Restart=always"));
+        assert!(service_content.contains("StartLimitBurst=5"));
+        assert!(service_content.contains("StartLimitIntervalSec=120"));
         assert!(service_content.contains("LimitNOFILE=65536"));
         assert!(service_content.contains("ExecStopPost="));
     }

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -85,6 +85,10 @@ async fn run_local(config: Config) -> anyhow::Result<()> {
 async fn run_network(config: Config) -> anyhow::Result<()> {
     tracing::info!("Starting freenet node in network mode");
 
+    // Check if another freenet process is already using the WS API port.
+    // This gives a clear error message instead of a generic "address in use".
+    check_for_existing_process(&config);
+
     let clients = serve_client_api(config.ws_api)
         .await
         .with_context(|| "failed to start HTTP/WebSocket client API")?;
@@ -253,6 +257,174 @@ async fn run_network_node_with_signals(
     }
 
     result
+}
+
+/// Log a warning if another freenet process is already listening on the WS API port.
+///
+/// This is a best-effort check — it tries to connect to the port before we bind it.
+/// If another process is there, we warn loudly so the user knows why startup will fail.
+/// The actual binding still happens in `serve_client_api` where `SO_REUSEADDR` handles
+/// TIME_WAIT sockets and the error message handles truly conflicting processes.
+fn check_for_existing_process(config: &Config) {
+    use std::net::{SocketAddr, TcpStream};
+    use std::time::Duration;
+
+    let addr = SocketAddr::from((config.ws_api.address, config.ws_api.port));
+    if TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok() {
+        let pid = find_process_on_port(config.ws_api.port);
+        // Log as warn, not error — this is advisory. The bind call in
+        // serve_client_api() is the authoritative check and will produce
+        // the actual error if the port is still occupied.
+        if let Some(pid) = pid {
+            tracing::warn!(
+                port = config.ws_api.port,
+                pid = pid,
+                "Another process (PID {pid}) is already listening on port {}. \
+                 If freenet is installed as a service, use 'freenet service stop' before \
+                 running manually. Otherwise use 'kill {pid}' to stop it.",
+                config.ws_api.port
+            );
+        } else {
+            tracing::warn!(
+                port = config.ws_api.port,
+                "Port {} is already in use by another process. \
+                 If freenet is installed as a service, use 'freenet service stop' before \
+                 running manually.",
+                config.ws_api.port
+            );
+        }
+    }
+}
+
+/// Try to find the PID of the process listening on the given port.
+/// Returns None if we can't determine it (non-Linux, no permissions, etc.).
+fn find_process_on_port(port: u16) -> Option<u32> {
+    #[cfg(target_os = "linux")]
+    {
+        // Parse /proc/net/tcp and /proc/net/tcp6 to find the listening socket,
+        // then find its inode owner. This avoids requiring external tools like lsof or ss.
+        let port_hex = format!("{:04X}", port);
+
+        // Search both IPv4 and IPv6 socket tables
+        let target_inode = find_listening_inode("/proc/net/tcp", &port_hex)
+            .or_else(|| find_listening_inode("/proc/net/tcp6", &port_hex))?;
+
+        // Scan /proc/*/fd/ to find which process owns this inode
+        let expected_link = format!("socket:[{target_inode}]");
+        let proc_dir = std::fs::read_dir("/proc").ok()?;
+        for entry in proc_dir.filter_map(|e| e.ok()) {
+            let pid_str = entry.file_name();
+            let pid_str = pid_str.to_string_lossy();
+            if !pid_str.chars().all(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            let fd_dir = format!("/proc/{pid_str}/fd");
+            if let Ok(fds) = std::fs::read_dir(&fd_dir) {
+                for fd in fds.filter_map(|e| e.ok()) {
+                    if let Ok(link) = std::fs::read_link(fd.path()) {
+                        if link.to_string_lossy() == expected_link {
+                            return pid_str.parse().ok();
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = port;
+        None
+    }
+}
+
+/// Search a /proc/net/tcp{,6} file for a LISTEN socket on the given port.
+/// Returns the inode number as a string if found.
+#[cfg(target_os = "linux")]
+fn find_listening_inode(proc_path: &str, port_hex: &str) -> Option<String> {
+    let contents = std::fs::read_to_string(proc_path).ok()?;
+    parse_listening_inode(&contents, port_hex)
+}
+
+/// Parse /proc/net/tcp{,6} content for a LISTEN socket on the given hex port.
+///
+/// The format has a header line followed by socket entries. Each entry has
+/// whitespace-separated fields:
+///   [0]=sl [1]=local_address [2]=rem_address [3]=st [4]=tx_queue:rx_queue
+///   [5]=tr:tm->when [6]=retrnsmt [7]=uid [8]=timeout [9]=inode ...
+///
+/// State 0A = TCP_LISTEN. The local_address format is hex_ip:hex_port.
+#[cfg(target_os = "linux")]
+fn parse_listening_inode(contents: &str, port_hex: &str) -> Option<String> {
+    for line in contents.lines().skip(1) {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() < 10 {
+            continue;
+        }
+        if fields[3] == "0A" {
+            if let Some(addr_port) = fields[1].rsplit_once(':') {
+                if addr_port.1 == port_hex {
+                    return Some(fields[9].to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "linux")]
+    use super::parse_listening_inode;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_parse_listening_inode_ipv4() {
+        // Real /proc/net/tcp format with a LISTEN socket on port 7509 (0x1D55)
+        let content = "\
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000:1D55 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 54321 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:0035 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 11111 1 0000000000000000 100 0 0 10 0
+   2: 00000000:1D55 0100007F:E234 01 00000000:00000000 00:00000000 00000000  1000        0 99999 1 0000000000000000 100 0 0 10 0";
+
+        // Should find the LISTEN (0A) socket on port 7509, not the ESTABLISHED (01) one
+        assert_eq!(
+            parse_listening_inode(content, "1D55"),
+            Some("54321".to_string())
+        );
+        // Port 53 (0x0035) is also listening
+        assert_eq!(
+            parse_listening_inode(content, "0035"),
+            Some("11111".to_string())
+        );
+        // Port 8080 (0x1F90) is not present
+        assert_eq!(parse_listening_inode(content, "1F90"), None);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_parse_listening_inode_ipv6() {
+        // /proc/net/tcp6 format — IPv6 addresses are 32 hex chars
+        let content = "\
+  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000000000000:1D55 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 67890 1 0000000000000000 100 0 0 10 0";
+
+        assert_eq!(
+            parse_listening_inode(content, "1D55"),
+            Some("67890".to_string())
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_parse_listening_inode_short_line() {
+        // Lines with fewer than 10 fields should be skipped
+        let content = "\
+  sl  local_address rem_address   st
+   0: 00000000:1D55 00000000:0000 0A";
+
+        assert_eq!(parse_listening_inode(content, "1D55"), None);
+    }
 }
 
 fn run_node(config_args: ConfigArgs) -> anyhow::Result<()> {

--- a/crates/core/src/server/mod.rs
+++ b/crates/core/src/server/mod.rs
@@ -114,20 +114,43 @@ async fn serve_with_listener(
             std_listener.set_nonblocking(true)?;
             tokio::net::TcpListener::from_std(std_listener)?
         }
-        None => tokio::net::TcpListener::bind(socket).await.map_err(|e| {
-            if e.kind() == std::io::ErrorKind::AddrInUse {
-                std::io::Error::new(
-                    std::io::ErrorKind::AddrInUse,
-                    format!(
-                        "Port {} is already in use. Another freenet process may be running. \
-                         Use 'pkill freenet' to stop it, or specify a different port with --ws-api-port.",
-                        socket.port()
-                    ),
+        None => {
+            // Use SO_REUSEADDR so we can rebind immediately if the previous
+            // process exited but the socket is still in TIME_WAIT.
+            let std_listener = {
+                let sock = socket2::Socket::new(
+                    if socket.is_ipv4() {
+                        socket2::Domain::IPV4
+                    } else {
+                        socket2::Domain::IPV6
+                    },
+                    socket2::Type::STREAM,
+                    Some(socket2::Protocol::TCP),
                 )
-            } else {
-                e
-            }
-        })?,
+                .map_err(|e| {
+                    std::io::Error::new(e.kind(), format!("Failed to create socket: {e}"))
+                })?;
+                sock.set_reuse_address(true)?;
+                sock.set_nonblocking(true)?;
+                sock.bind(&socket.into()).map_err(|e| {
+                    if e.kind() == std::io::ErrorKind::AddrInUse {
+                        std::io::Error::new(
+                            std::io::ErrorKind::AddrInUse,
+                            format!(
+                                "Port {} is already in use. Another freenet process may be running. \
+                                 Use 'pkill freenet' to stop it, or specify a different port with --ws-api-port.",
+                                socket.port()
+                            ),
+                        )
+                    } else {
+                        e
+                    }
+                })?;
+                sock.listen(128)?;
+                std::net::TcpListener::from(sock)
+            };
+            tokio::net::TcpListener::from_std(std_listener)?
+        }
     };
     tracing::info!("HTTP client API listening on {}", socket);
     GlobalExecutor::spawn(async move {


### PR DESCRIPTION
## Problem

Users who have freenet installed as a systemd service AND also run it manually (`freenet network`) get stuck in an infinite restart loop. The old process holds port 7509, every new instance fails to bind, exits with code 1, and systemd restarts it 10 seconds later — indefinitely. The node never connects to the network.

Discovered via diagnostic report MDW2MV from a user whose node restarted **174 times** in 30 minutes.

## Approach

Three complementary mitigations:

1. **`StartLimitBurst` / `StartLimitIntervalSec` in systemd unit templates** — Limits restarts to 5 attempts in 2 minutes. After that, systemd puts the unit into failed state instead of looping forever. The counter resets after a successful start, so auto-update (exit code 42) is unaffected. This replaces a previous approach using `ExecStartPre=-/usr/bin/pkill -x freenet` which review correctly identified as dangerous on multi-instance hosts.

2. **`SO_REUSEADDR` on the WebSocket API TCP listener** — Uses `socket2` to set `SO_REUSEADDR` so the socket can rebind immediately if the previous process exited but the port is still in TIME_WAIT state. The UDP transport layer already had retry logic for this; the WebSocket binding did not.

3. **Detect existing process at startup** — Before binding, probe the port with a TCP connect. If something is already listening, identify the conflicting PID (on Linux via `/proc/net/tcp` and `/proc/net/tcp6`) and log a warning telling the user to run `freenet service stop`. Advisory only — does not abort startup.

## Testing

- Existing `test_systemd_user_service_file_generation` and `test_systemd_system_service_file_generation` tests updated with assertions for `StartLimitBurst` and `StartLimitIntervalSec`
- `cargo fmt && cargo clippy --all-targets` clean
- All lib + bin tests pass (16/16)

[AI-assisted - Claude]