### PR TITLE
refactor: replace string-based EmptyRing detection with type-safe error variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30978c799400ba3b3df505192895e2ba6a5069fc6391d87d7db94626bafc1e88"
+checksum = "3fbae5bb920e2c5f24f7fed46905ea33adaa9fe949c1718d20a316c143145158"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ wmi = "0.18.1"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet
-freenet-stdlib = "0.1.37"
+freenet-stdlib = "0.1.38"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/crates/core/src/client_events/mod.rs
+++ b/crates/core/src/client_events/mod.rs
@@ -414,9 +414,14 @@ where
                                 client_id = %cli_id,
                                 "Operation rejected: peer has not joined network yet - client should retry after join"
                             );
-                            (cli_id, Err(ErrorKind::OperationError {
-                                cause: "PEER_NOT_JOINED: peer has not joined the network yet - retry after node joins".into()
-                            }.into()))
+                            (cli_id, Err(ErrorKind::PeerNotJoined.into()))
+                        }
+                        Err(Error::EmptyRing) => {
+                            tracing::warn!(
+                                client_id = %cli_id,
+                                "Operation rejected: no ring connections found - client should retry after connections are established"
+                            );
+                            (cli_id, Err(ErrorKind::EmptyRing.into()))
                         }
                         Err(err) => {
                             tracing::error!(
@@ -542,6 +547,8 @@ enum Error {
     Disconnected,
     #[error("Peer has not joined the network yet (no ring location established)")]
     PeerNotJoined,
+    #[error("No ring connections found")]
+    EmptyRing,
     #[error("Node error: {0}")]
     Node(String),
     #[error(transparent)]
@@ -558,8 +565,8 @@ impl From<crate::ring::RingError> for Error {
     fn from(err: crate::ring::RingError) -> Self {
         match err {
             crate::ring::RingError::PeerNotJoined => Error::PeerNotJoined,
+            crate::ring::RingError::EmptyRing => Error::EmptyRing,
             other @ crate::ring::RingError::ConnError(_)
-            | other @ crate::ring::RingError::EmptyRing
             | other @ crate::ring::RingError::NoCachingPeers(_) => Error::Node(other.to_string()),
         }
     }

--- a/crates/core/src/server/errors.rs
+++ b/crates/core/src/server/errors.rs
@@ -4,11 +4,6 @@ use freenet_stdlib::client_api::ErrorKind;
 use freenet_stdlib::prelude::ContractInstanceId;
 use std::fmt::{Display, Formatter};
 
-/// Marker string used to identify EmptyRing errors without needing to modify freenet-stdlib.
-/// If this string changes in ring/mod.rs, update it here too.
-const EMPTY_RING_ERROR: &str = "No ring connections found";
-const PEER_NOT_JOINED_ERROR: &str = "PEER_NOT_JOINED";
-
 #[derive(Debug)]
 pub(super) enum WebSocketApiError {
     /// Something went wrong when calling the user repo.
@@ -67,8 +62,7 @@ impl IntoResponse for WebSocketApiError {
     fn into_response(self) -> Response {
         // Check for errors that indicate the peer is still connecting to the network
         if let WebSocketApiError::AxumError { ref error } = self {
-            let error_str = format!("{error}");
-            if error_str.contains(EMPTY_RING_ERROR) || error_str.contains(PEER_NOT_JOINED_ERROR) {
+            if matches!(error, ErrorKind::EmptyRing | ErrorKind::PeerNotJoined) {
                 return (StatusCode::SERVICE_UNAVAILABLE, Html(connecting_page())).into_response();
             }
         }

--- a/crates/core/tests/operations_before_join.rs
+++ b/crates/core/tests/operations_before_join.rs
@@ -42,12 +42,12 @@ async fn expect_peer_not_joined(client: &mut WebApi, op_name: &str) -> anyhow::R
     };
 
     assert!(
-        error_msg.contains("PEER_NOT_JOINED"),
-        "{}: expected PEER_NOT_JOINED, got: {}",
+        error_msg.contains("PeerNotJoined"),
+        "{}: expected PeerNotJoined, got: {}",
         op_name,
         error_msg
     );
-    info!("{}: got PEER_NOT_JOINED as expected", op_name);
+    info!("{}: got PeerNotJoined as expected", op_name);
     Ok(())
 }
 
@@ -267,9 +267,9 @@ async fn test_operations_blocked_before_join() -> anyhow::Result<()> {
                 }
                 Ok(Err(e)) => {
                     let err_str = format!("{:?}", e);
-                    if err_str.contains("PEER_NOT_JOINED") {
+                    if err_str.contains("PeerNotJoined") {
                         info!(
-                            "Still PEER_NOT_JOINED after {:?}, retrying...",
+                            "Still PeerNotJoined after {:?}, retrying...",
                             join_start.elapsed()
                         );
                         continue;


### PR DESCRIPTION
## Problem

The HTTP server detects "peer still connecting" errors via brittle string matching against error messages (`"No ring connections found"`, `"PEER_NOT_JOINED"`). If the error message text changes in `ring/mod.rs`, the detection silently breaks — no compiler warning, just a degraded UX where users see raw error messages instead of the friendly "Connecting to Freenet..." page.

## Approach

Uses the new `ErrorKind::EmptyRing` and `ErrorKind::PeerNotJoined` variants added in freenet-stdlib 0.1.38 (freenet/freenet-stdlib#54) to replace string matching with type-safe pattern matching. This way, if someone changes an error message the behavior is unaffected, and if someone removes or renames a variant the compiler catches it.

Changes:

1. **`client_events/mod.rs`**: Added `Error::EmptyRing` variant and maps `RingError::EmptyRing` to `ErrorKind::EmptyRing` (instead of `ErrorKind::OperationError` with a string). Same for `PeerNotJoined`.
2. **`server/errors.rs`**: Replaced `format!("{error}").contains(...)` with `matches!(error, ErrorKind::EmptyRing | ErrorKind::PeerNotJoined)`. Removed the `EMPTY_RING_ERROR` and `PEER_NOT_JOINED_ERROR` string constants.
3. **`tests/operations_before_join.rs`**: Updated assertions to match the new `PeerNotJoined` variant name (was checking for the old `PEER_NOT_JOINED` string embedded in `OperationError`).

## Testing

- `test_operations_blocked_before_join` updated and passing — this test validates that PUT/GET/SUBSCRIBE operations are rejected with `PeerNotJoined` before the peer joins the network
- `cargo clippy --all-targets` clean (only pre-existing warnings)
- `cargo fmt --check` clean

## Fixes

Closes #2351

[AI-assisted - Claude]