### PR TITLE
feat: add periodic interest heartbeat to prevent entry expiration

### DIFF
--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -1217,6 +1217,10 @@ async fn handle_interest_sync_message(
                     hashes.iter().copied().collect();
                 let current_contracts = op_manager.interest_manager.get_contracts_for_peer(pk);
 
+                // Hash collisions (FNV-1a u32) can cause a stale entry to
+                // survive if its hash collides with a live one. This is the
+                // safe direction — false negatives on removal, not false
+                // positives — and extremely rare in practice.
                 let mut removed = 0usize;
                 for contract in &current_contracts {
                     let h = contract_hash(contract);
@@ -1247,12 +1251,26 @@ async fn handle_interest_sync_message(
                 entries.push(SummaryEntry::from_summary(hash, summary.as_ref()));
 
                 if let Some(ref pk) = peer_key {
-                    op_manager.interest_manager.register_peer_interest(
-                        &contract,
-                        pk.clone(),
-                        None, // We'll get their summary in their Summaries response
-                        false,
-                    );
+                    // Refresh TTL for existing entries (preserves cached summary).
+                    // Only register new interest if this is a genuinely new entry;
+                    // otherwise register_peer_interest would overwrite the cached
+                    // summary with None, defeating delta optimization.
+                    if op_manager
+                        .interest_manager
+                        .get_peer_interest(&contract, pk)
+                        .is_some()
+                    {
+                        op_manager
+                            .interest_manager
+                            .refresh_peer_interest(&contract, pk);
+                    } else {
+                        op_manager.interest_manager.register_peer_interest(
+                            &contract,
+                            pk.clone(),
+                            None, // New entry; summary arrives in their Summaries response
+                            false,
+                        );
+                    }
                 }
             }
 

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -3981,7 +3981,7 @@ impl P2pConnManager {
                 // Issue #3046: Refresh the peer's interest TTL on every successful
                 // broadcast send. Without this, interest entries for peers who only
                 // receive full-state broadcasts (no delta → no update_peer_summary
-                // call) expire after INTEREST_TTL (5 min), even though broadcasts
+                // call) expire after INTEREST_TTL, even though broadcasts
                 // are being successfully delivered. This caused ~49% of River room
                 // subscribers to miss updates.
                 op_manager

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -1727,23 +1727,26 @@ mod tests {
         let current_contracts = manager.get_contracts_for_peer(&peer);
         assert_eq!(current_contracts.len(), 2);
 
-        // Step 2: Find matching contracts from incoming hashes
-        let incoming_contracts: HashSet<ContractKey> = incoming_hashes
-            .iter()
-            .flat_map(|h| manager.lookup_by_hash(*h))
-            .filter(|c| manager.has_local_interest(c))
-            .collect();
-
-        // Step 3: Remove entries not in incoming set
+        // Step 2: Remove entries whose hash is NOT in incoming set
+        // (mirrors the handler's hash-domain comparison, not resolved keys)
         for contract in &current_contracts {
-            if !incoming_contracts.contains(contract) {
+            let h = contract_hash(contract);
+            if !incoming_hashes.contains(&h) {
                 manager.remove_peer_interest(contract, &peer);
             }
         }
 
-        // Step 4: Register/refresh entries in incoming set
-        for contract in &incoming_contracts {
-            manager.register_peer_interest(contract, peer.clone(), None, false);
+        // Step 3: Find matching contracts and register/refresh
+        let matching =
+            manager.get_matching_contracts(&incoming_hashes.iter().copied().collect::<Vec<_>>());
+        for contract in &matching {
+            if manager.get_peer_interest(contract, &peer).is_some() {
+                // Existing entry: refresh TTL (preserves cached summary)
+                manager.refresh_peer_interest(contract, &peer);
+            } else {
+                // New entry
+                manager.register_peer_interest(contract, peer.clone(), None, false);
+            }
         }
 
         // Verify: contract1 removed, contract2 refreshed, contract3 added
@@ -1766,5 +1769,65 @@ mod tests {
             !interest2.is_expired_at(time.now()),
             "contract2 interest should not be expired after refresh"
         );
+    }
+
+    #[test]
+    fn test_refresh_preserves_summary() {
+        // Verify that refresh_peer_interest preserves the cached summary,
+        // unlike register_peer_interest which overwrites it.
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+        let summary = StateSummary::from(vec![1, 2, 3]);
+
+        // Register with a summary
+        manager.register_peer_interest(&contract, peer.clone(), Some(summary.clone()), false);
+
+        // Advance time
+        time.advance_time(Duration::from_secs(60));
+
+        // Refresh TTL (should preserve summary)
+        manager.refresh_peer_interest(&contract, &peer);
+
+        // Verify summary is still there
+        let cached = manager.get_peer_summary(&contract, &peer);
+        assert!(
+            cached.is_some(),
+            "summary should be preserved after refresh"
+        );
+        assert_eq!(cached.unwrap().as_ref(), summary.as_ref());
+
+        // Verify TTL was reset
+        let interest = manager.get_peer_interest(&contract, &peer).unwrap();
+        assert!(
+            !interest.is_expired_at(time.now()),
+            "interest should not be expired after refresh"
+        );
+    }
+
+    #[test]
+    fn test_register_peer_interest_resets_ttl() {
+        // Verify that register_peer_interest resets TTL for existing entries.
+        // The heartbeat relies on this for new-entry registration.
+        let (manager, time) = make_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(1);
+
+        // Register interest
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+
+        // Advance time to nearly expired
+        time.advance_time(INTEREST_TTL - Duration::from_secs(10));
+
+        // Re-register (as heartbeat would for a new entry)
+        manager.register_peer_interest(&contract, peer.clone(), None, false);
+
+        // Advance time past original registration but not past re-registration
+        time.advance_time(Duration::from_secs(20));
+
+        // Should not be expired
+        let expired = manager.sweep_expired_interests();
+        assert!(expired.is_empty(), "re-registration should have reset TTL");
+        assert!(manager.get_peer_interest(&contract, &peer).is_some());
     }
 }

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -560,13 +560,17 @@ impl Ring {
                 continue;
             }
 
-            // Get all connected peer addresses
+            // Get all connected peer addresses (deduplicated)
             let connections = ring.connection_manager.get_connections_by_location();
-            let peer_addrs: Vec<std::net::SocketAddr> = connections
-                .values()
-                .flat_map(|conns| conns.iter())
-                .filter_map(|conn| conn.location.socket_addr())
-                .collect();
+            let peer_addrs: Vec<std::net::SocketAddr> = {
+                let mut seen = HashSet::new();
+                connections
+                    .values()
+                    .flat_map(|conns| conns.iter())
+                    .filter_map(|conn| conn.location.socket_addr())
+                    .filter(|addr| seen.insert(*addr))
+                    .collect()
+            };
 
             if peer_addrs.is_empty() {
                 continue;
@@ -597,6 +601,8 @@ impl Ring {
                     ))
                     .await
                 {
+                    // Channel send failure means the receiver is dropped (node
+                    // shutting down). No point sending to remaining peers.
                     tracing::debug!(
                         peer = %peer_addr,
                         error = %e,

--- a/docs/architecture/ring/README.md
+++ b/docs/architecture/ring/README.md
@@ -282,7 +282,7 @@ flowchart LR
 **Features:**
 - Hash-based contract discovery
 - Delta sent only if < 50% of full state
-- TTL-based interest expiry (5 minutes)
+- TTL-based interest expiry (20 min) with periodic heartbeat refresh (5 min)
 
 **Code reference:** `crates/core/src/ring/interest.rs`
 


### PR DESCRIPTION
## Problem

Interest entries are how peers tell neighbors "forward updates for contract X to me." They have a TTL but are only refreshed by subscription acceptance and broadcast sends. This creates a death spiral: when broadcasts stop flowing through a link, interest entries expire, which guarantees broadcasts never flow again.

Telemetry from v0.1.140 confirmed this: technic had an active subscription to the River UI contract but received zero broadcasts because interest entries on its upstream relay expired.

## Approach

Add a background heartbeat that periodically re-sends the full interest set to each connected peer. The key design decisions:

1. **Full-replace semantics**: Each `Interests { hashes }` message represents the sender's complete interest set. The handler diffs against the peer's current entries, removing stale ones and refreshing active ones. This makes both connection-time exchange and heartbeat idempotent — the first message initializes (nothing to remove), subsequent messages replace.

2. **TTL = 4× heartbeat interval**: With a 5-minute heartbeat, the 20-minute TTL tolerates up to 3 consecutive missed heartbeats before expiry. Previously TTL was 30 minutes with no heartbeat, meaning entries expired silently.

3. **Spread sends across interval**: To avoid bursts, the heartbeat sleeps `interval / num_peers` between each send.

## Changes

| File | What |
|------|------|
| `crates/core/src/ring/interest.rs` | `INTEREST_HEARTBEAT_INTERVAL` (5 min), `INTEREST_TTL` (20 min = 4× heartbeat), `get_contracts_for_peer()` method, 2 new tests |
| `crates/core/src/node/mod.rs` | Full-replace semantics in `Interests` handler — diff incoming hashes against current entries |
| `crates/core/src/ring/mod.rs` | `interest_heartbeat()` background task + spawn from `Ring::new()` |

## Testing

- `test_get_contracts_for_peer`: verifies the new reverse-index lookup method
- `test_full_replace_interest_sync`: verifies full-replace logic — old entries removed, new entries added, shared entries refreshed with TTL reset
- All existing interest tests pass with the new TTL value (they use `INTEREST_TTL` symbolically)
- `cargo fmt && cargo clippy --all-targets` clean (no new warnings)

## Verification Plan

After deploy, monitor telemetry:
- `interest_expired` events should drop dramatically
- `interest_heartbeat_cycle` events should appear every ~5 minutes per peer
- River UI broadcast delivery to technic should resume

[AI-assisted - Claude]