### PR TITLE
fix: local-network.mk nodes fail to start due to config/key issues

### DIFF
--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -573,7 +573,12 @@ impl ConfigArgs {
         };
 
         fs::create_dir_all(this.config_dir())?;
-        gateways.save_to_file(&gateways_file)?;
+        // Only persist gateways when they were fetched from the remote index.
+        // When skip_load_from_network is set (local test networks), the gateways.toml
+        // is managed externally and should not be overwritten.
+        if !self.network_api.skip_load_from_network {
+            gateways.save_to_file(&gateways_file)?;
+        }
 
         if should_persist {
             let path = this.config_dir().join("config.toml");

--- a/crates/core/src/config/secret.rs
+++ b/crates/core/src/config/secret.rs
@@ -217,10 +217,14 @@ fn read_transport_keypair(path_to_key: impl AsRef<Path>) -> std::io::Result<Tran
                     let keypair = TransportKeypair::new();
                     keypair.save(path)?;
 
-                    // Also update the public key file if it exists in the same directory
-                    // (freenet-test-network generates keypair.pem and public_key.pem together)
+                    // Also update the companion public key file if it exists.
+                    // Derive the public key path from the private key filename:
+                    //   "gw1_private_key.pem" → "gw1_public_key.pem"
+                    //   "private_key.pem" → "public_key.pem"
                     if let Some(parent) = path.parent() {
-                        let public_key_path = parent.join("public_key.pem");
+                        let filename = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+                        let public_filename = filename.replace("private", "public");
+                        let public_key_path = parent.join(&public_filename);
                         if public_key_path.exists() {
                             if let Err(e) = keypair.public().save(&public_key_path) {
                                 tracing::warn!(

--- a/scripts/local-network.mk
+++ b/scripts/local-network.mk
@@ -121,10 +121,13 @@ start-nodes:
 		network_port=$$(( $(BASE_PORT) + $(N_GATEWAYS) + $$i )); \
 		ws_port=$$(( $(WS_BASE_PORT) + $(N_GATEWAYS) + $$i )); \
 		public_port=$$(( $(WS_BASE_PORT) + $(N_NODES) + $$i )); \
+		node_config_dir="$(BASE_DIR)/n$$i/config"; \
+		mkdir -p "$$node_config_dir"; \
+		cp "$(GW_CONFIG)" "$$node_config_dir/gateways.toml"; \
 		if [ -f "$(LOGS_DIR)/n$$i.log" ]; then : > $(LOGS_DIR)/n$$i.log; fi; \
 		($(ENV_VARS) freenet network \
 			--skip-load-from-network \
-			--config-dir $(BASE_DIR) \
+			--config-dir $$node_config_dir \
 			--ws-api-port $$ws_port \
 			--public-network-port $$public_port \
 			--data-dir $(BASE_DIR)/n$$i \


### PR DESCRIPTION
## Summary

Fixes three bugs that prevent non-gateway nodes from starting when using `local-network.mk` to set up a local test network.

- **Gateway overwrites `gateways.toml`**: `Config::new()` unconditionally saves gateways to file, clobbering the correct config written by `generate-gw-config`. Fixed by skipping save when `skip_load_from_network` is set.
- **RSA→X25519 public key conversion uses wrong path**: `read_transport_keypair()` converts the private key but writes the companion public key to hardcoded `public_key.pem` instead of deriving the filename from the private key path (e.g. `gw1_private_key.pem` → `gw1_public_key.pem`). Fixed by deriving the public key filename.
- **Shared `config-dir` causes config poisoning**: All nodes share `--config-dir`, so non-gateway nodes inherit the gateway's persisted `transport_keypair` and `is_gateway=true`. Fixed by giving each node its own config-dir with a copy of `gateways.toml`.

## Test plan

- [ ] `make -f local-network.mk setup start N_GATEWAYS=1 N_NODES=2` starts all 3 processes successfully
- [ ] Non-gateway nodes can accept WebSocket connections on their assigned ports
- [ ] Contracts PUT on the gateway propagate to non-gateway nodes via GET
- [ ] Subscriptions on non-gateway nodes receive UpdateNotifications from the gateway

Fixes #3181

🤖 Generated with [Claude Code](https://claude.com/claude-code)