### PR TITLE
fix: prevent WASM instance exhaustion on long-running gateways

### DIFF
--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -372,61 +372,6 @@ fn parse_listening_inode(contents: &str, port_hex: &str) -> Option<String> {
     None
 }
 
-#[cfg(test)]
-mod tests {
-    #[cfg(target_os = "linux")]
-    use super::parse_listening_inode;
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_parse_listening_inode_ipv4() {
-        // Real /proc/net/tcp format with a LISTEN socket on port 7509 (0x1D55)
-        let content = "\
-  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
-   0: 00000000:1D55 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 54321 1 0000000000000000 100 0 0 10 0
-   1: 0100007F:0035 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 11111 1 0000000000000000 100 0 0 10 0
-   2: 00000000:1D55 0100007F:E234 01 00000000:00000000 00:00000000 00000000  1000        0 99999 1 0000000000000000 100 0 0 10 0";
-
-        // Should find the LISTEN (0A) socket on port 7509, not the ESTABLISHED (01) one
-        assert_eq!(
-            parse_listening_inode(content, "1D55"),
-            Some("54321".to_string())
-        );
-        // Port 53 (0x0035) is also listening
-        assert_eq!(
-            parse_listening_inode(content, "0035"),
-            Some("11111".to_string())
-        );
-        // Port 8080 (0x1F90) is not present
-        assert_eq!(parse_listening_inode(content, "1F90"), None);
-    }
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_parse_listening_inode_ipv6() {
-        // /proc/net/tcp6 format — IPv6 addresses are 32 hex chars
-        let content = "\
-  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
-   0: 00000000000000000000000000000000:1D55 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 67890 1 0000000000000000 100 0 0 10 0";
-
-        assert_eq!(
-            parse_listening_inode(content, "1D55"),
-            Some("67890".to_string())
-        );
-    }
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_parse_listening_inode_short_line() {
-        // Lines with fewer than 10 fields should be skipped
-        let content = "\
-  sl  local_address rem_address   st
-   0: 00000000:1D55 00000000:0000 0A";
-
-        assert_eq!(parse_listening_inode(content, "1D55"), None);
-    }
-}
-
 fn run_node(config_args: ConfigArgs) -> anyhow::Result<()> {
     if config_args.version {
         println!(
@@ -520,5 +465,60 @@ fn main() {
             eprintln!("Error: {e:?}");
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "linux")]
+    use super::parse_listening_inode;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_parse_listening_inode_ipv4() {
+        // Real /proc/net/tcp format with a LISTEN socket on port 7509 (0x1D55)
+        let content = "\
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000:1D55 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 54321 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:0035 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 11111 1 0000000000000000 100 0 0 10 0
+   2: 00000000:1D55 0100007F:E234 01 00000000:00000000 00:00000000 00000000  1000        0 99999 1 0000000000000000 100 0 0 10 0";
+
+        // Should find the LISTEN (0A) socket on port 7509, not the ESTABLISHED (01) one
+        assert_eq!(
+            parse_listening_inode(content, "1D55"),
+            Some("54321".to_string())
+        );
+        // Port 53 (0x0035) is also listening
+        assert_eq!(
+            parse_listening_inode(content, "0035"),
+            Some("11111".to_string())
+        );
+        // Port 8080 (0x1F90) is not present
+        assert_eq!(parse_listening_inode(content, "1F90"), None);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_parse_listening_inode_ipv6() {
+        // /proc/net/tcp6 format — IPv6 addresses are 32 hex chars
+        let content = "\
+  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000000000000:1D55 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 67890 1 0000000000000000 100 0 0 10 0";
+
+        assert_eq!(
+            parse_listening_inode(content, "1D55"),
+            Some("67890".to_string())
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_parse_listening_inode_short_line() {
+        // Lines with fewer than 10 fields should be skipped
+        let content = "\
+  sl  local_address rem_address   st
+   0: 00000000:1D55 00000000:0000 0A";
+
+        assert_eq!(parse_listening_inode(content, "1D55"), None);
     }
 }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -5,6 +5,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -22,6 +23,7 @@ use freenet_stdlib::client_api::{
     RequestError,
 };
 use freenet_stdlib::prelude::*;
+use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 
@@ -772,6 +774,16 @@ pub struct Executor<R = Runtime, S: StateStorage = Storage> {
     /// Shared guard for corrupted-state recovery, preventing infinite recovery loops.
     /// See [`CorruptedStateRecoveryGuard`] for details.
     pub(crate) recovery_guard: CorruptedStateRecoveryGuard,
+
+    /// Cache of contract summaries keyed by ContractKey, storing (state_hash, summary).
+    /// Avoids redundant WASM instantiations during the 5-minute interest heartbeat
+    /// which calls summarize_state() for every matching contract.
+    /// LRU-bounded to prevent unbounded growth on gateways that see many contracts over time.
+    summary_cache: LruCache<ContractKey, (u64, StateSummary<'static>)>,
+
+    /// Cache of delta results keyed by (ContractKey, state_hash, their_summary_hash).
+    /// Avoids redundant WASM instantiations for get_state_delta() calls.
+    delta_cache: LruCache<(ContractKey, u64, u64), StateDelta<'static>>,
 }
 
 impl<R, S> Executor<R, S>
@@ -804,6 +816,8 @@ where
             shared_notifications: None,
             shared_summaries: None,
             recovery_guard: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            summary_cache: LruCache::new(NonZeroUsize::new(1024).unwrap()),
+            delta_cache: LruCache::new(NonZeroUsize::new(1024).unwrap()),
         })
     }
 

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1231,6 +1231,20 @@ where
             })
         })?;
 
+        // Check summary cache: if state hash matches, return cached summary
+        let state_hash = {
+            use std::hash::{Hash, Hasher};
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            state.as_ref().hash(&mut hasher);
+            hasher.finish()
+        };
+
+        if let Some((cached_hash, cached_summary)) = self.summary_cache.get(&key) {
+            if *cached_hash == state_hash {
+                return Ok(cached_summary.clone());
+            }
+        }
+
         let params = self
             .state_store
             .get_params(&key)
@@ -1243,9 +1257,13 @@ where
                 })
             })?;
 
-        self.runtime
+        let summary = self
+            .runtime
             .summarize_state(&key, &params, &state)
-            .map_err(|e| ExecutorError::execution(e, None))
+            .map_err(|e| ExecutorError::execution(e, None))?;
+
+        self.summary_cache.put(key, (state_hash, summary.clone()));
+        Ok(summary)
     }
 
     pub(super) async fn bridged_get_contract_state_delta(
@@ -1262,6 +1280,21 @@ where
             })
         })?;
 
+        // Check delta cache: if (state_hash, their_summary_hash) matches, return cached delta
+        let (state_hash, summary_hash) = {
+            use std::hash::{Hash, Hasher};
+            let mut h1 = std::collections::hash_map::DefaultHasher::new();
+            state.as_ref().hash(&mut h1);
+            let mut h2 = std::collections::hash_map::DefaultHasher::new();
+            their_summary.as_ref().hash(&mut h2);
+            (h1.finish(), h2.finish())
+        };
+
+        let cache_key = (key, state_hash, summary_hash);
+        if let Some(cached_delta) = self.delta_cache.get(&cache_key) {
+            return Ok(cached_delta.clone());
+        }
+
         let params = self
             .state_store
             .get_params(&key)
@@ -1274,9 +1307,13 @@ where
                 })
             })?;
 
-        self.runtime
+        let delta = self
+            .runtime
             .get_state_delta(&key, &params, &state, &their_summary)
-            .map_err(|e| ExecutorError::execution(e, None))
+            .map_err(|e| ExecutorError::execution(e, None))?;
+
+        self.delta_cache.put(cache_key, delta.clone());
+        Ok(delta)
     }
 
     // --- Helper methods ---

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -1064,12 +1064,14 @@ pub(super) mod in_memory {
     /// Contract handler using MockWasmRuntime — exercises the production ContractExecutor
     /// code path (init_tracker, validation, notification pipeline, corrupted state recovery)
     /// without requiring real WASM binaries.
+    #[allow(dead_code)]
     pub(crate) struct MockWasmContractHandler {
         channel: ContractHandlerChannel<ContractHandlerHalve>,
         runtime: Executor<MockWasmRuntime, MockStateStorage>,
     }
 
     /// Builder for MockWasmContractHandler.
+    #[allow(dead_code)]
     pub struct MockWasmHandlerBuilder {
         pub identifier: String,
         pub shared_storage: MockStateStorage,

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -333,6 +333,7 @@ impl<ER> Builder<ER> {
     ///
     /// Same as `run_node_with_shared_storage` but uses `MockWasmContractHandler` instead of
     /// `SimulationContractHandler`.
+    #[allow(dead_code)]
     pub async fn run_node_with_mock_wasm<UsrEv>(
         self,
         user_events: UsrEv,

--- a/crates/core/src/router/mod.rs
+++ b/crates/core/src/router/mod.rs
@@ -1258,8 +1258,6 @@ mod tests {
     /// feeds router's failure_estimator.
     #[test]
     fn test_get_partial_timing_feeds_router() {
-        use crate::operations::OpOutcome;
-
         let target_peer = PeerKeyLocation::random();
         let contract_location = Location::random();
 

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -213,6 +213,27 @@ impl ResourceLimiter for HostState {
         const MAX_TABLE_ELEMENTS: usize = 10_000;
         Ok(desired <= MAX_TABLE_ELEMENTS)
     }
+
+    /// Disable wasmtime's per-Store instance limit.
+    ///
+    /// Wasmtime's `Store` has a monotonic instance counter (only incremented in
+    /// `Store::check_new_instance`, never decremented) with a default limit of 10,000.
+    /// Since freenet properly cleans up instances (drops them from the HashMap and frees
+    /// their memory), we hit this artificial limit during long-running gateway sessions
+    /// where the 5-minute interest heartbeat calls `summarize_state()` for every contract,
+    /// each creating a WASM instance. With hundreds of contracts the store exhausts
+    /// within ~100 minutes.
+    fn instances(&self) -> usize {
+        usize::MAX
+    }
+
+    fn tables(&self) -> usize {
+        usize::MAX
+    }
+
+    fn memories(&self) -> usize {
+        usize::MAX
+    }
 }
 
 impl WasmEngine for WasmtimeEngine {
@@ -1063,6 +1084,26 @@ mod tests {
 
         let result = Module::new(&engine, SIMPLE_WASM);
         assert!(result.is_ok(), "Failed to compile simple WASM module");
+    }
+
+    /// Regression test for Report 2RDXTD: wasmtime's per-Store instance counter is
+    /// monotonic (never decremented) with a default limit of 10,000. Our ResourceLimiter
+    /// override sets instances() to usize::MAX so long-running gateways don't exhaust.
+    /// This test creates and drops >10,000 instances on a single Store to verify.
+    #[test]
+    fn test_instance_limit_override_allows_many_instances() {
+        let config = RuntimeConfig::default();
+        let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+        let module = engine.compile(SIMPLE_WASM).unwrap();
+
+        // Create and drop 10,001 instances on the same store — exceeds wasmtime's
+        // default 10,000 limit. Without our ResourceLimiter override this would fail.
+        for i in 0..10_001 {
+            let handle = engine
+                .create_instance(&module, i, 1024)
+                .unwrap_or_else(|e| panic!("instance {i} should succeed: {e}"));
+            engine.drop_instance(&handle);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

User louisL reported River showing "Room state not available" — traced to wasmtime's per-Store instance counter exhausting the 10,000 default limit. The counter is **monotonic** (only incremented in `Store::check_new_instance`, never decremented), so after ~10,000 WASM calls the store is permanently broken until timeout/panic triggers `recover_store()`.

The hottest path is contract summarization during the 5-minute interest heartbeat, which calls `summarize_state()` for every matching contract — each creating a WASM instance. With hundreds of contracts, the store exhausts within ~20 cycles (~100 min).

## Solution

Three complementary fixes:

1. **Remove wasmtime instance limit** — Override `ResourceLimiter::instances()`, `tables()`, `memories()` to return `usize::MAX`. Since freenet properly cleans up instances (drops them from the HashMap and frees memory), the monotonic counter is the only problem.

2. **Cache contract summaries** — In `bridged_summarize_contract_state`, hash the state bytes with `DefaultHasher` and check a `HashMap<ContractKey, (u64, StateSummary)>` cache. On state change the hash differs, auto-invalidating. One entry per contract, no explicit invalidation needed.

3. **Cache delta results** — In `bridged_get_contract_state_delta`, cache with key `(ContractKey, state_hash, their_summary_hash)` in an `LruCache` (1024 entries). Same hash-based invalidation pattern.

Also fixes pre-existing clippy warnings (`dead_code`, `items_after_test_module`, unused import).

## Testing

- `cargo test -p freenet` — 1508 passed, 0 failed (1 pre-existing flaky test `test_realistic_mixed_traffic_routing` passes in isolation)
- `cargo clippy --all-targets` — zero warnings
- `cargo fmt --check` — clean

## Fixes

Report 2RDXTD

[AI-assisted - Claude]