### PR TITLE
fix: seed GlobalRng in test_realistic_mixed_traffic_routing for determinism

### DIFF
--- a/crates/core/src/router/mod.rs
+++ b/crates/core/src/router/mod.rs
@@ -1421,6 +1421,7 @@ mod tests {
     /// low-failure, low-latency peers.
     #[test]
     fn test_realistic_mixed_traffic_routing() {
+        let _guard = crate::config::GlobalRng::seed_guard(0xCAFE_BABE);
         let contract_location = Location::random();
         let close_peer = PeerKeyLocation::random();
         let mid_peer = PeerKeyLocation::random();


### PR DESCRIPTION
## Problem

`test_realistic_mixed_traffic_routing` fails ~25% of the time because it generates peers with truly random ring positions (no `GlobalRng` seeding). The isotonic regression failure estimator uses an ascending monotonicity constraint (failure probability expected to increase with ring distance). When random peer locations produce a distance ordering that contradicts the failure rate ordering, the model can't fit correctly and peer ranking assertions fail.

## Approach

Add `GlobalRng::seed_guard(0xCAFE_BABE)` at the test start to make all `Location::random()` and `PeerKeyLocation::random()` calls deterministic. This follows the pattern used in simulation tests, topology tests, and `deterministic_select` tests throughout the codebase.

The router module correctly routes all randomness through `GlobalRng` (no `rand::random()` or `Instant::now()` bypasses), so seeding is sufficient to make the test fully deterministic.

## Why didn't CI catch this?

The test was always flaky from its introduction in #3163 — it simply wasn't caught because the ~25% failure rate doesn't always trigger in a single CI run. None of the 27 router tests seed `GlobalRng`; this test was uniquely vulnerable because it uses 3 peers with intermediate failure rates where the isotonic regression is sensitive to distance ordering.

## Testing

- Verified the test passes 20/20 consecutive runs after the fix (previously ~15/20)
- All 50 router tests pass
- `cargo fmt` and `cargo clippy` clean

Closes #3188

[AI-assisted - Claude]