### PR TITLE
fix: monitor fire-and-forget spawned tasks (#3121)

### DIFF
--- a/crates/core/src/node/background_task_monitor.rs
+++ b/crates/core/src/node/background_task_monitor.rs
@@ -1,0 +1,213 @@
+//! Monitor for fire-and-forget background tasks.
+//!
+//! Background tasks spawned via `GlobalExecutor::spawn` that run for the entire
+//! lifetime of a node are critical infrastructure. If any such task silently
+//! exits (panic, cancellation, or unexpected return), the node runs in a
+//! degraded state with no logging or detection.
+//!
+//! `BackgroundTaskMonitor` collects the `JoinHandle`s of these long-lived tasks
+//! under human-readable names. The main event loop calls
+//! [`BackgroundTaskMonitor::wait_for_any_exit`] inside its `select!` to detect
+//! the first task that exits and propagate the failure.
+//!
+//! See issue #3121 and the incident described in #3120 for motivation.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::task::JoinHandle;
+
+/// A named background task whose JoinHandle is tracked for silent-death detection.
+struct TrackedTask {
+    name: &'static str,
+    handle: JoinHandle<()>,
+}
+
+/// Registry of critical background tasks.
+///
+/// Tasks are registered with [`register`](BackgroundTaskMonitor::register) during
+/// node construction. Once the node event loop starts, call
+/// [`wait_for_any_exit`](BackgroundTaskMonitor::wait_for_any_exit) which resolves
+/// with an error when the first tracked task exits.
+///
+/// Thread-safe: the inner state is behind `Arc<Mutex<_>>` so that subsystems
+/// (Ring, OpManager, etc.) can register tasks during construction without
+/// requiring mutable access to the monitor.
+#[derive(Clone)]
+pub(crate) struct BackgroundTaskMonitor {
+    inner: Arc<Mutex<Vec<TrackedTask>>>,
+}
+
+impl BackgroundTaskMonitor {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Register a named background task for monitoring.
+    ///
+    /// The `name` is used in error messages when the task exits. It should be
+    /// a short, human-readable identifier (e.g. "connection_maintenance",
+    /// "garbage_cleanup").
+    pub fn register(&self, name: &'static str, handle: JoinHandle<()>) {
+        self.inner.lock().push(TrackedTask { name, handle });
+    }
+
+    /// Consume the monitor and return a future that resolves with an error
+    /// when the first tracked task exits (for any reason).
+    ///
+    /// This method drains all registered tasks out of the monitor. After
+    /// calling this, the monitor is empty and should not be reused.
+    pub fn wait_for_any_exit(self) -> impl std::future::Future<Output = anyhow::Error> + Send {
+        let tasks: Vec<TrackedTask> = {
+            let mut inner = self.inner.lock();
+            std::mem::take(&mut *inner)
+        };
+
+        async move {
+            if tasks.is_empty() {
+                // No tasks registered; park forever so the select! arm never fires.
+                std::future::pending::<()>().await;
+                unreachable!();
+            }
+
+            // Use a JoinSet to wait for the first task to exit.
+            let mut join_set = tokio::task::JoinSet::new();
+            let names: Vec<&'static str> = tasks.iter().map(|t| t.name).collect();
+
+            for (idx, task) in tasks.into_iter().enumerate() {
+                // Each entry in the JoinSet wraps one tracked JoinHandle.
+                // When the underlying task exits, the wrapper completes.
+                join_set.spawn(async move {
+                    let result = task.handle.await;
+                    (idx, result)
+                });
+            }
+
+            // Wait for the first completion.
+            let (idx, result) = join_set
+                .join_next()
+                .await
+                .expect("JoinSet is non-empty")
+                .expect("wrapper task should not panic");
+
+            let name = names[idx];
+
+            // Abort remaining wrapper tasks so they don't leak.
+            join_set.abort_all();
+
+            match result {
+                Err(e) if e.is_panic() => {
+                    tracing::error!(task = name, "Background task panicked: {e}");
+                    anyhow::anyhow!("Background task '{name}' panicked: {e}")
+                }
+                Err(e) => {
+                    tracing::error!(task = name, "Background task failed: {e}");
+                    anyhow::anyhow!("Background task '{name}' failed: {e}")
+                }
+                Ok(()) => {
+                    tracing::error!(
+                        task = name,
+                        "Background task exited unexpectedly (clean return)"
+                    );
+                    anyhow::anyhow!("Background task '{name}' exited unexpectedly")
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// When a tracked task panics, wait_for_any_exit resolves with a panic error.
+    #[tokio::test]
+    async fn panicking_task_is_detected() {
+        let monitor = BackgroundTaskMonitor::new();
+
+        // One task that sleeps forever, one that panics.
+        let h1 = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        let h2 = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            panic!("background task panic");
+        });
+
+        monitor.register("sleeper", h1);
+        monitor.register("panicker", h2);
+
+        let err = monitor.wait_for_any_exit().await;
+        let msg = err.to_string();
+        assert!(
+            msg.contains("panicker") && msg.contains("panicked"),
+            "Expected panic error for 'panicker', got: {msg}"
+        );
+    }
+
+    /// When a tracked task returns cleanly (unexpected for long-lived tasks),
+    /// wait_for_any_exit resolves with an "exited unexpectedly" error.
+    #[tokio::test]
+    async fn clean_exit_is_detected() {
+        let monitor = BackgroundTaskMonitor::new();
+
+        let h1 = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        let h2 = tokio::spawn(async {
+            // Exits immediately
+        });
+
+        monitor.register("sleeper", h1);
+        monitor.register("quick_exit", h2);
+
+        let err = monitor.wait_for_any_exit().await;
+        let msg = err.to_string();
+        assert!(
+            msg.contains("quick_exit") && msg.contains("exited unexpectedly"),
+            "Expected 'exited unexpectedly' error for 'quick_exit', got: {msg}"
+        );
+    }
+
+    /// Registering zero tasks means wait_for_any_exit never resolves.
+    #[tokio::test]
+    async fn empty_monitor_never_resolves() {
+        let monitor = BackgroundTaskMonitor::new();
+
+        let result =
+            tokio::time::timeout(Duration::from_millis(50), monitor.wait_for_any_exit()).await;
+
+        assert!(result.is_err(), "Empty monitor should not resolve");
+    }
+
+    /// Multiple tasks: only the first to exit is reported.
+    #[tokio::test]
+    async fn first_exit_wins() {
+        let monitor = BackgroundTaskMonitor::new();
+
+        let h1 = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+        let h2 = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            // Returns early
+        });
+        let h3 = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+
+        monitor.register("slow_exit", h1);
+        monitor.register("fast_exit", h2);
+        monitor.register("sleeper", h3);
+
+        let err = monitor.wait_for_any_exit().await;
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fast_exit"),
+            "Expected 'fast_exit' to be detected first, got: {msg}"
+        );
+    }
+}

--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -72,6 +72,7 @@ mod network_bridge;
 // No cfg gate: underlying items are unconditionally compiled and integration
 // tests compile the lib without cfg(test).
 pub use network_bridge::in_memory::{get_fault_injector, set_fault_injector, FaultInjectorState};
+pub(crate) mod background_task_monitor;
 pub(crate) mod network_status;
 mod op_state_manager;
 mod p2p_impl;

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -303,6 +303,7 @@ impl OpManager {
         event_register: ER,
         connection_manager: ConnectionManager,
         result_router_tx: mpsc::Sender<(Transaction, HostResult)>,
+        task_monitor: &super::background_task_monitor::BackgroundTaskMonitor,
     ) -> anyhow::Result<Self> {
         let ring = Ring::new(
             config,
@@ -310,6 +311,7 @@ impl OpManager {
             event_register.clone(),
             config.is_gateway,
             connection_manager,
+            task_monitor,
         )?;
         let ops = Arc::new(Ops::default());
 
@@ -328,21 +330,24 @@ impl OpManager {
             Mutex<std::collections::HashMap<ContractInstanceId, Vec<oneshot::Sender<()>>>>,
         > = Arc::new(Mutex::new(std::collections::HashMap::new()));
 
-        GlobalExecutor::spawn(
-            garbage_cleanup_task(
-                rx,
-                ops.clone(),
-                ring.live_tx_tracker.clone(),
-                notification_channel.clone(),
-                event_register,
-                sub_op_tracker.clone(),
-                result_router_tx.clone(),
-                request_router.clone(),
-                ring.clone(),
-                ch_outbound.clone(),
-                contract_waiters.clone(),
-            )
-            .instrument(garbage_span),
+        task_monitor.register(
+            "garbage_cleanup",
+            GlobalExecutor::spawn(
+                garbage_cleanup_task(
+                    rx,
+                    ops.clone(),
+                    ring.live_tx_tracker.clone(),
+                    notification_channel.clone(),
+                    event_register,
+                    sub_op_tracker.clone(),
+                    result_router_tx.clone(),
+                    request_router.clone(),
+                    ring.clone(),
+                    ch_outbound.clone(),
+                    contract_waiters.clone(),
+                )
+                .instrument(garbage_span),
+            ),
         );
 
         // Gateways are ready immediately (peer_id set from config)

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -26,7 +26,7 @@ use crate::{
     operations::connect,
 };
 
-use super::OpManager;
+use super::{background_task_monitor::BackgroundTaskMonitor, OpManager};
 
 pub(crate) struct NodeP2P {
     pub(crate) op_manager: Arc<OpManager>,
@@ -46,6 +46,8 @@ pub(crate) struct NodeP2P {
     session_actor_task: JoinHandle<()>,
     result_router_task: JoinHandle<()>,
     op_mediator_task: JoinHandle<()>,
+    /// Monitor for background tasks spawned during node construction (Ring, OpManager, etc.)
+    background_task_monitor: BackgroundTaskMonitor,
 }
 
 impl NodeP2P {
@@ -215,6 +217,10 @@ impl NodeP2P {
             }
         };
 
+        // Monitor background tasks registered during node construction
+        // (Ring maintenance, garbage cleanup, etc.)
+        let background_monitor = self.background_task_monitor.wait_for_any_exit();
+
         let join_task = self.initial_join_task.take();
         let result = crate::deterministic_select! {
             r = f => {
@@ -236,6 +242,11 @@ impl NodeP2P {
             e = infra_monitor => {
                 eprintln!("CRITICAL: Infrastructure task exited: {e}");
                 tracing::error!("Infrastructure task exited: {:?}", e);
+                Err(e)
+            },
+            e = background_monitor => {
+                eprintln!("CRITICAL: Background task exited: {e}");
+                tracing::error!("Background task exited: {:?}", e);
                 Err(e)
             },
         };
@@ -324,6 +335,7 @@ impl NodeP2P {
 
         tracing::info!("Actor-based client management infrastructure installed with result router");
 
+        let background_task_monitor = BackgroundTaskMonitor::new();
         let connection_manager = ConnectionManager::new(&config);
         let op_manager = Arc::new(OpManager::new(
             notification_tx,
@@ -332,6 +344,7 @@ impl NodeP2P {
             event_register.clone(),
             connection_manager,
             result_router_tx,
+            &background_task_monitor,
         )?);
         op_manager.ring.attach_op_manager(&op_manager);
 
@@ -430,6 +443,7 @@ impl NodeP2P {
                 session_actor_task,
                 result_router_task,
                 op_mediator_task,
+                background_task_monitor,
             },
             shutdown_tx,
         ))

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -21,6 +21,7 @@ use crate::{
         SimulationContractHandler, SimulationHandlerBuilder,
     },
     node::{
+        background_task_monitor::BackgroundTaskMonitor,
         network_bridge::{event_loop_notification_channel, p2p_protoc::P2pConnManager},
         op_state_manager::OpManager,
         EventLoopExitReason, MessageProcessor, NetEventRegister,
@@ -83,6 +84,9 @@ impl<ER> Builder<ER> {
         // Create result router channel - needed for MessageProcessor
         let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
 
+        // In-memory nodes use a monitor for API compatibility; tasks are cleaned
+        // up when the monitor is dropped at the end of scope.
+        let task_monitor = BackgroundTaskMonitor::new();
         let op_manager = Arc::new(OpManager::new(
             notification_tx,
             ops_ch_channel,
@@ -90,6 +94,7 @@ impl<ER> Builder<ER> {
             self.event_register.clone(),
             connection_manager.clone(),
             result_router_tx.clone(),
+            &task_monitor,
         )?);
         op_manager.ring.attach_op_manager(&op_manager);
         std::mem::drop(_guard);
@@ -221,6 +226,7 @@ impl<ER> Builder<ER> {
         // Create result router channel
         let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
 
+        let task_monitor = BackgroundTaskMonitor::new();
         let op_manager = Arc::new(OpManager::new(
             notification_tx,
             ops_ch_channel,
@@ -228,6 +234,7 @@ impl<ER> Builder<ER> {
             self.event_register.clone(),
             connection_manager.clone(),
             result_router_tx.clone(),
+            &task_monitor,
         )?);
         op_manager.ring.attach_op_manager(&op_manager);
         std::mem::drop(_guard);
@@ -359,6 +366,7 @@ impl<ER> Builder<ER> {
         // Create result router channel
         let (result_router_tx, _result_router_rx) = tokio::sync::mpsc::channel(100);
 
+        let task_monitor = BackgroundTaskMonitor::new();
         let op_manager = Arc::new(OpManager::new(
             notification_tx,
             ops_ch_channel,
@@ -366,6 +374,7 @@ impl<ER> Builder<ER> {
             self.event_register.clone(),
             connection_manager.clone(),
             result_router_tx.clone(),
+            &task_monitor,
         )?);
         op_manager.ring.attach_op_manager(&op_manager);
         std::mem::drop(_guard);

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -168,6 +168,7 @@ impl Ring {
         event_register: ER,
         is_gateway: bool,
         connection_manager: ConnectionManager,
+        task_monitor: &crate::node::background_task_monitor::BackgroundTaskMonitor,
     ) -> anyhow::Result<Arc<Self>> {
         let live_tx_tracker = LiveTransactionTracker::new();
 
@@ -178,7 +179,10 @@ impl Ring {
         };
 
         let router = Arc::new(RwLock::new(Router::new(&[])));
-        GlobalExecutor::spawn(Self::refresh_router(router.clone(), event_register.clone()));
+        task_monitor.register(
+            "refresh_router",
+            GlobalExecutor::spawn(Self::refresh_router(router.clone(), event_register.clone())),
+        );
 
         // Interval for periodic subscription state telemetry snapshots (1 minute)
         const SUBSCRIPTION_STATE_INTERVAL: Duration = Duration::from_secs(60);
@@ -226,61 +230,91 @@ impl Ring {
             tracing::info_span!(parent: current_span, "connection_maintenance")
         };
 
-        GlobalExecutor::spawn(
-            ring.clone()
-                .connection_maintenance(event_loop_notifier, live_tx_tracker)
-                .instrument(span),
+        task_monitor.register(
+            "connection_maintenance",
+            GlobalExecutor::spawn({
+                let fut = ring
+                    .clone()
+                    .connection_maintenance(event_loop_notifier, live_tx_tracker)
+                    .instrument(span);
+                async move {
+                    if let Err(e) = fut.await {
+                        tracing::error!(error = %e, "connection_maintenance exited with error");
+                    }
+                }
+            }),
         );
 
         // Spawn periodic subscription state telemetry task
-        GlobalExecutor::spawn(Self::emit_subscription_state_telemetry(
-            ring.clone(),
-            SUBSCRIPTION_STATE_INTERVAL,
-        ));
+        task_monitor.register(
+            "emit_subscription_state_telemetry",
+            GlobalExecutor::spawn(Self::emit_subscription_state_telemetry(
+                ring.clone(),
+                SUBSCRIPTION_STATE_INTERVAL,
+            )),
+        );
 
         // Spawn periodic subscription recovery task to fix "orphaned seeders"
         // (peers that have contracts cached but aren't in the subscription tree)
-        GlobalExecutor::spawn(Self::recover_orphaned_subscriptions(
-            ring.clone(),
-            SUBSCRIPTION_RECOVERY_INTERVAL,
-        ));
+        task_monitor.register(
+            "recover_orphaned_subscriptions",
+            GlobalExecutor::spawn(Self::recover_orphaned_subscriptions(
+                ring.clone(),
+                SUBSCRIPTION_RECOVERY_INTERVAL,
+            )),
+        );
 
         // Spawn periodic GET subscription cache sweep task
         // Cleans up expired GET-triggered subscriptions to maintain bounded memory
-        GlobalExecutor::spawn(Self::sweep_get_subscription_cache(
-            ring.clone(),
-            GET_SUBSCRIPTION_SWEEP_INTERVAL,
-        ));
+        task_monitor.register(
+            "sweep_get_subscription_cache",
+            GlobalExecutor::spawn(Self::sweep_get_subscription_cache(
+                ring.clone(),
+                GET_SUBSCRIPTION_SWEEP_INTERVAL,
+            )),
+        );
 
         // Spawn periodic topology snapshot registration task (test mode only)
         // This allows SimNetwork to validate subscription topology during tests
         #[cfg(any(test, feature = "testing"))]
-        GlobalExecutor::spawn(Self::register_topology_snapshots_periodically(
-            ring.clone(),
-            TOPOLOGY_SNAPSHOT_INTERVAL,
-        ));
+        task_monitor.register(
+            "register_topology_snapshots",
+            GlobalExecutor::spawn(Self::register_topology_snapshots_periodically(
+                ring.clone(),
+                TOPOLOGY_SNAPSHOT_INTERVAL,
+            )),
+        );
 
         // Spawn periodic router model snapshot telemetry (every 5 minutes)
-        GlobalExecutor::spawn(Self::emit_router_snapshot_telemetry(
-            ring.clone(),
-            Duration::from_secs(60 * 5),
-        ));
+        task_monitor.register(
+            "emit_router_snapshot_telemetry",
+            GlobalExecutor::spawn(Self::emit_router_snapshot_telemetry(
+                ring.clone(),
+                Duration::from_secs(60 * 5),
+            )),
+        );
 
         // Spawn periodic contract-directed CONNECT task.
         // When a peer is a "subscription root" (closest to contract among neighbors),
         // it sends CONNECTs toward the contract's ring location to merge disconnected
         // subscription subtrees.
         const CONTRACT_CONNECT_INTERVAL: Duration = Duration::from_secs(30);
-        GlobalExecutor::spawn(Self::contract_directed_connects(
-            ring.clone(),
-            CONTRACT_CONNECT_INTERVAL,
-        ));
+        task_monitor.register(
+            "contract_directed_connects",
+            GlobalExecutor::spawn(Self::contract_directed_connects(
+                ring.clone(),
+                CONTRACT_CONNECT_INTERVAL,
+            )),
+        );
 
         // Spawn periodic interest heartbeat task.
         // Sends full Interests { hashes } to each connected peer to keep
         // interest entries alive and prevent the death spiral where expired
         // entries block broadcast delivery.
-        GlobalExecutor::spawn(Self::interest_heartbeat(ring.clone()));
+        task_monitor.register(
+            "interest_heartbeat",
+            GlobalExecutor::spawn(Self::interest_heartbeat(ring.clone())),
+        );
 
         Ok(ring)
     }
@@ -645,14 +679,16 @@ impl Ring {
         interval.tick().await;
         loop {
             interval.tick().await;
-            let history = register
-                .get_router_events(10_000)
-                .await
-                .map_err(|error| {
+            let history = match register.get_router_events(10_000).await {
+                Ok(h) => h,
+                Err(error) => {
+                    // Previously this was an `expect()` that would silently panic
+                    // the task. Now that the task is monitored, returning will
+                    // trigger the BackgroundTaskMonitor and propagate the failure.
                     tracing::error!(error = %error, "Shutting down refresh router task");
-                    error
-                })
-                .expect("todo: propagate this to main thread");
+                    return;
+                }
+            };
             if !history.is_empty() {
                 let router_ref = &mut *router.write();
                 *router_ref = Router::new(&history);

--- a/crates/core/src/util/deterministic_select.rs
+++ b/crates/core/src/util/deterministic_select.rs
@@ -772,11 +772,11 @@ macro_rules! deterministic_select {
         ];
 
         let output = {
-            let mut fut1 = $fut1;
-            let mut fut2 = $fut2;
-            let mut fut3 = $fut3;
-            let mut fut4 = $fut4;
-            let mut fut5 = $fut5;
+            let fut1 = $fut1;
+            let fut2 = $fut2;
+            let fut3 = $fut3;
+            let fut4 = $fut4;
+            let fut5 = $fut5;
             tokio::pin!(fut1);
             tokio::pin!(fut2);
             tokio::pin!(fut3);


### PR DESCRIPTION
## Problem

Background tasks spawned during node construction (Ring maintenance, garbage cleanup, router refresh, subscription recovery, etc.) were fire-and-forget: their JoinHandles were discarded immediately after `GlobalExecutor::spawn`. If any such task silently died (panic, error, or unexpected return), the node would run in a degraded state with no logging or detection.

This was demonstrated by bug #3120 where a UDP listener task silently died causing 5+ hour gateway stalls and 42-52M dropped packets. While #3120's specific listen task was already fixed with direct monitoring, the same pattern existed across 10+ other critical background tasks.

**Audit findings:** 9 tasks in `Ring::new()` (connection_maintenance, refresh_router, subscription state telemetry, orphaned subscription recovery, GET subscription sweep, topology snapshots, router snapshot telemetry, contract-directed connects, interest heartbeat) plus the garbage_cleanup task in `OpManager::new()` were all fire-and-forget. The `refresh_router` task additionally contained an `expect()` that would silently panic the task.

## Solution

Introduce `BackgroundTaskMonitor` -- a thread-safe registry that collects named `JoinHandle`s from subsystem construction and provides a single future that resolves when any tracked task exits. This uses `tokio::task::JoinSet` internally to efficiently await the first completion.

Key changes:
- **New module** `node/background_task_monitor.rs` with `BackgroundTaskMonitor`
- **Ring::new()** now accepts `&BackgroundTaskMonitor` and registers all 9 background tasks
- **OpManager::new()** passes the monitor through and registers the garbage_cleanup task
- **run_node()** adds the monitor as a 5th arm in the `deterministic_select!` loop, so any background task exit triggers a CRITICAL log and node shutdown
- **refresh_router** `expect()` replaced with graceful `return` -- the monitor detects the exit
- **deterministic_select! 5-branch macro** unused-mut warnings fixed

## Testing

- 4 new unit tests in `background_task_monitor::tests`:
  - `panicking_task_is_detected` -- verifies panic detection
  - `clean_exit_is_detected` -- verifies unexpected clean return detection
  - `empty_monitor_never_resolves` -- verifies no false positives
  - `first_exit_wins` -- verifies only the first exit is reported
- All existing tests pass (`cargo test -p freenet`)
- Zero clippy warnings

## Fixes

Closes #3121
Part of #3141 (CI & Testing Redesign, Phase 1.2: Error Propagation Tests)

[AI-assisted - Claude]