### PR TITLE
test: enable parking_lot deadlock detection in test builds (#3104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3784,8 +3799,10 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
+ "backtrace",
  "cfg-if",
  "libc",
+ "petgraph",
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -122,6 +122,7 @@ freenet-stdlib = { features = ["net", "testing"], workspace = true }
 freenet-macros = { path = "../freenet-macros" }
 httptest = { workspace = true }
 libc = { workspace = true }  # For sendmmsg syscall batching benchmarks
+parking_lot = { workspace = true, features = ["deadlock_detection"] }
 rstest = { workspace = true }
 statrs = { workspace = true }
 tempfile = { workspace = true }
@@ -172,7 +173,7 @@ sqlite = ["sqlx"]
 trace = ["tracing-subscriber", "tracing-appender"]
 trace-ot = ["opentelemetry-jaeger", "trace", "tracing-opentelemetry", "opentelemetry-otlp"]
 websocket = ["axum/ws"]
-testing = ["freenet-stdlib/testing"]
+testing = ["freenet-stdlib/testing", "parking_lot/deadlock_detection"]
 console-subscriber = ["dep:console-subscriber"]
 test-network = ["dep:freenet-test-network"]
 bench = []  # Exposes internal test infrastructure for benchmarking

--- a/crates/core/src/deadlock_detection.rs
+++ b/crates/core/src/deadlock_detection.rs
@@ -1,0 +1,224 @@
+//! Deadlock detection support using parking_lot's `deadlock_detection` feature.
+//!
+//! When the `deadlock_detection` feature is enabled on parking_lot (automatically
+//! enabled in test builds via dev-dependencies and the `testing` feature flag),
+//! this module provides a background thread that periodically checks for deadlocks
+//! in parking_lot Mutex/RwLock usage.
+//!
+//! # How it works
+//!
+//! The `parking_lot` crate has an optional `deadlock_detection` feature that
+//! instruments all Mutex/RwLock operations to track lock ordering. When enabled,
+//! `parking_lot::deadlock::check_deadlock()` can detect cycles in lock acquisition.
+//!
+//! This feature is enabled automatically in test builds via:
+//! - The `testing` feature flag: `testing = ["freenet-stdlib/testing", "parking_lot/deadlock_detection"]`
+//! - Dev-dependencies: `parking_lot = { workspace = true, features = ["deadlock_detection"] }`
+//!
+//! In non-test builds, the feature is not enabled and there is zero overhead.
+//!
+//! # Usage
+//!
+//! Call [`init_deadlock_detector`] at the start of a test to spawn a background
+//! thread that monitors for deadlocks. The returned [`DeadlockDetectorGuard`]
+//! keeps the detector running until dropped.
+//!
+//! ```ignore
+//! #[test]
+//! fn my_test() {
+//!     let _detector = freenet::deadlock_detection::init_deadlock_detector();
+//!     // ... test code using parking_lot locks ...
+//! }
+//! ```
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Guard that keeps the deadlock detector thread running.
+///
+/// The detector thread is stopped when this guard is dropped.
+pub struct DeadlockDetectorGuard {
+    shutdown: Arc<AtomicBool>,
+}
+
+impl Drop for DeadlockDetectorGuard {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Start a background thread that periodically checks for deadlocks.
+///
+/// Returns a guard that keeps the detector running. When the guard is dropped,
+/// the detector thread will stop at its next check interval.
+///
+/// The detector checks every `interval` for deadlocked threads. When a deadlock
+/// is detected, it logs the deadlock information via `eprintln!` and optionally
+/// panics (controlled by the `panic_on_deadlock` parameter).
+///
+/// # Arguments
+///
+/// * `interval` - How often to check for deadlocks
+/// * `panic_on_deadlock` - If true, panics when a deadlock is detected
+///
+/// # Note
+///
+/// This function works correctly whether or not the `deadlock_detection` feature
+/// is enabled on parking_lot. Without the feature, `check_deadlock()` always
+/// returns an empty vec, making this a harmless no-op.
+pub fn init_deadlock_detector_with_config(
+    interval: Duration,
+    panic_on_deadlock: bool,
+) -> DeadlockDetectorGuard {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_clone = shutdown.clone();
+
+    std::thread::Builder::new()
+        .name("deadlock-detector".into())
+        .spawn(move || {
+            while !shutdown_clone.load(Ordering::Relaxed) {
+                std::thread::sleep(interval);
+
+                let deadlocks = parking_lot::deadlock::check_deadlock();
+                if deadlocks.is_empty() {
+                    continue;
+                }
+
+                let mut report = format!("{} deadlock(s) detected!\n", deadlocks.len());
+                for (i, threads) in deadlocks.iter().enumerate() {
+                    report.push_str(&format!("Deadlock #{i}:\n"));
+                    for t in threads {
+                        report.push_str(&format!(
+                            "  Thread Id {:#?}\n  Backtrace:\n{:#?}\n",
+                            t.thread_id(),
+                            t.backtrace()
+                        ));
+                    }
+                }
+
+                eprintln!("{report}");
+
+                if panic_on_deadlock {
+                    panic!("Deadlock detected! See error output above for details.");
+                }
+            }
+        })
+        .expect("failed to spawn deadlock detector thread");
+
+    DeadlockDetectorGuard { shutdown }
+}
+
+/// Start a deadlock detector with default settings.
+///
+/// Checks every 1 second and panics on deadlock detection. This is the
+/// recommended configuration for tests -- catching deadlocks quickly and
+/// failing fast.
+pub fn init_deadlock_detector() -> DeadlockDetectorGuard {
+    init_deadlock_detector_with_config(Duration::from_secs(1), true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+
+    /// Verify that the deadlock detector can be initialized and dropped cleanly,
+    /// and that normal lock usage does not produce false positives.
+    #[test]
+    fn test_detector_lifecycle_no_false_positives() {
+        let guard = init_deadlock_detector_with_config(Duration::from_millis(100), false);
+
+        let mutex = Arc::new(Mutex::new(0));
+        let m = mutex.clone();
+
+        // Normal lock usage should not trigger deadlock detection
+        let handle = std::thread::spawn(move || {
+            let mut val = m.lock();
+            *val += 1;
+        });
+        handle.join().unwrap();
+
+        assert_eq!(*mutex.lock(), 1);
+
+        // Let the detector run a few check cycles to confirm no false positives
+        std::thread::sleep(Duration::from_millis(350));
+        drop(guard);
+    }
+
+    /// Verify that parking_lot's deadlock detection feature is active and can
+    /// detect a real AB/BA deadlock.
+    ///
+    /// This test creates a classic deadlock pattern: Thread 1 holds lock A and
+    /// waits for lock B, while Thread 2 holds lock B and waits for lock A.
+    /// We then call `check_deadlock()` and verify it reports the cycle.
+    ///
+    /// **Important**: `check_deadlock()` clears detected deadlocks on each call
+    /// (it returns deadlocks "since the last call"). This test must not share
+    /// a process with other tests that call `check_deadlock()`, otherwise they
+    /// can consume each other's results. With nextest (one process per test),
+    /// this is guaranteed. With `cargo test`, use `--test-threads=1` or run
+    /// this test in isolation.
+    #[test]
+    fn test_deadlock_is_detected() {
+        use std::sync::Barrier;
+
+        // Drain any pre-existing deadlock state from prior tests
+        let _ = parking_lot::deadlock::check_deadlock();
+
+        let lock_a = Arc::new(Mutex::new(()));
+        let lock_b = Arc::new(Mutex::new(()));
+        let barrier = Arc::new(Barrier::new(2));
+
+        let la1 = lock_a.clone();
+        let lb1 = lock_b.clone();
+        let b1 = barrier.clone();
+
+        // Thread 1: lock A, sync, then try to lock B (deadlock)
+        let _t1 = std::thread::spawn(move || {
+            let _a = la1.lock();
+            b1.wait();
+            let _b = lb1.lock();
+        });
+
+        let la2 = lock_a.clone();
+        let lb2 = lock_b.clone();
+        let b2 = barrier.clone();
+
+        // Thread 2: lock B, sync, then try to lock A (deadlock)
+        let _t2 = std::thread::spawn(move || {
+            let _b = lb2.lock();
+            b2.wait();
+            let _a = la2.lock();
+        });
+
+        // Wait for threads to reach the deadlock state, then check.
+        // Retry in case the lock operations haven't completed yet.
+        let mut detected = false;
+        for _ in 0..20 {
+            std::thread::sleep(Duration::from_millis(100));
+            let deadlocks = parking_lot::deadlock::check_deadlock();
+            if !deadlocks.is_empty() {
+                assert_eq!(deadlocks.len(), 1, "Expected exactly 1 deadlock cycle");
+                assert_eq!(
+                    deadlocks[0].len(),
+                    2,
+                    "Expected 2 threads in the deadlock cycle"
+                );
+                detected = true;
+                break;
+            }
+        }
+
+        assert!(
+            detected,
+            "Expected deadlock to be detected within 2 seconds. \
+             This likely means the deadlock_detection feature is not enabled on parking_lot, \
+             or another test consumed the deadlock state (use nextest or --test-threads=1)."
+        );
+
+        // Threads are permanently deadlocked; they will be cleaned up on process exit.
+        // This is safe because nextest runs each test in its own process.
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -121,4 +121,12 @@ pub mod dev_tool {
     pub use crate::transport::StreamId;
 }
 
+/// Deadlock detection for parking_lot locks in test builds.
+///
+/// Available when compiled with `--cfg test` (unit tests) or with the `testing`
+/// feature flag (integration tests). Uses parking_lot's `deadlock_detection`
+/// feature to catch Mutex/RwLock deadlocks at runtime.
+#[cfg(any(test, feature = "testing"))]
+pub mod deadlock_detection;
+
 pub mod test_utils;


### PR DESCRIPTION
## Problem

parking_lot `Mutex` and `RwLock` are used extensively throughout the core crate for synchronization. Deadlocks in these primitives manifest as mysterious test hangs with no diagnostic output, making them difficult to debug.

## Solution

Enable parking_lot's optional `deadlock_detection` feature in test builds. This instruments all lock operations to track lock-ordering cycles at runtime, catching deadlocks early with clear diagnostic output instead of silent hangs.

The feature is enabled through two mechanisms:
- **dev-dependencies**: `parking_lot = { workspace = true, features = ["deadlock_detection"] }` -- automatically active for all `cargo test` runs
- **`testing` feature flag**: `testing = ["freenet-stdlib/testing", "parking_lot/deadlock_detection"]` -- available for integration tests that enable `--features testing`

A new `deadlock_detection` module provides:
- `init_deadlock_detector()` -- spawns a background thread that calls `parking_lot::deadlock::check_deadlock()` every second and panics with backtraces on deadlock
- `init_deadlock_detector_with_config(interval, panic_on_deadlock)` -- configurable variant
- `DeadlockDetectorGuard` -- RAII guard that stops the detector when dropped

The module is gated on `#[cfg(any(test, feature = "testing"))]` so there is zero overhead in production builds.

## Testing

- `test_detector_lifecycle_no_false_positives`: Verifies the detector starts, runs, stops cleanly, and does not produce false positives on normal lock usage
- `test_deadlock_is_detected`: Creates a real AB/BA deadlock between two threads and verifies `check_deadlock()` detects it, confirming the feature is actually compiled in
- All 1512 existing unit tests pass with no regressions

## Fixes

Closes #3104
Part of #3141 (CI & Testing Redesign, Phase 3.3)

[AI-assisted - Claude]