### PR TITLE
fix: bypass readiness gating for CONNECT operations in connection maintenance

### DIFF
--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -1012,6 +1012,9 @@ impl ConnectionManager {
     }
 
     /// Route an op to the most optimal target.
+    /// Note: this applies readiness gating (`check_readiness=true`). For CONNECT
+    /// operations that need to bypass readiness, use `routing_candidates` directly.
+    #[cfg(test)]
     pub fn routing(
         &self,
         target: Location,

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -1961,10 +1961,26 @@ impl Ring {
                 self_addr = ?self.connection_manager.get_own_addr(),
                 "Looking for peer to route through"
             );
-            if let Some(target) =
-                self.connection_manager
-                    .routing(ideal_location, None, skip_list, &router)
-            {
+            // CONNECT operations bypass readiness gating — peers need to route
+            // through ANY ring connection to acquire new connections, even if those
+            // connections haven't advertised readiness yet. Without this, peers get
+            // stuck below the readiness threshold: they can't initiate CONNECTs
+            // because routing() filters out all their "not ready" connections,
+            // but they can't become ready without more connections.
+            let candidates = self.connection_manager.routing_candidates(
+                ideal_location,
+                None,
+                skip_list,
+                false, // bypass readiness — this is a CONNECT for connection acquisition
+            );
+            let selected = if !candidates.is_empty() {
+                let (selected, _) =
+                    router.select_k_best_peers_with_telemetry(candidates.iter(), ideal_location, 1);
+                selected.into_iter().next().cloned()
+            } else {
+                None
+            };
+            if let Some(target) = selected {
                 tracing::debug!(
                     query_target = %target,
                     target_location = %ideal_location,
@@ -1976,7 +1992,7 @@ impl Ring {
                     current_connections,
                     is_gateway,
                     target_location = %ideal_location,
-                    "acquire_new: routing() returned None - cannot find peer to query"
+                    "acquire_new: no routing candidates found - cannot find peer to query"
                 );
                 return Ok(None);
             }


### PR DESCRIPTION
## Problem

Network-wide connection deadlock: peers can't acquire enough connections to become "ready" because `connection_maintenance` routes CONNECTs through `routing()`, which filters out all unready peers.

**The chicken-and-egg:**
1. Peers need ≥3 connections to broadcast `ReadyState`
2. `connection_maintenance` → `acquire_new()` → `routing()` → `routing_candidates(..., check_readiness=true)` filters out peers that haven't sent `ReadyState`
3. After initial join gives 1-2 connections, peers get stuck — they can't initiate more CONNECTs because all their connections are "not ready"
4. Result: network-wide stall where almost no peer becomes ready

**Evidence from production (v0.1.144):**
- Nova gateway: broadcast `ReadyState` only 3 times in 22 hours, received 0 back from any peer
- Technic peer: 9 ring additions in first hour, broadcast `ReadyState` once, received 0 back, then 0 new connections for 3+ hours
- Multiple user reports of inability to connect to River (diagnostic reports 33WH5H, XX5JCH)

Note: the CONNECT operation itself (in `connect.rs`) correctly bypasses readiness with `routing_candidates(..., false)`. But `connection_maintenance`'s `acquire_new()` used `routing()` which always applies readiness gating — this is the bug.

## Solution

In `acquire_new()` (the connection maintenance path that initiates CONNECTs to fill the routing table), call `routing_candidates()` directly with `check_readiness=false` instead of going through `routing()`.

This is consistent with how `connect.rs` already handles CONNECT operations — readiness gating exists to prevent non-CONNECT operations (GET, PUT, SUBSCRIBE, UPDATE) from routing through peers that might be false subscription roots (e.g., peers behind symmetric NAT with only a gateway connection). CONNECTs themselves should always be routable.

The `routing()` method is now only used in tests (marked `#[cfg(test)]`).

## Testing

- All 60 `connection_manager` tests pass
- `cargo clippy --all-targets` clean
- Full CI will validate

## Fixes

Fixes the network-wide connectivity stall reported by multiple users on Matrix.

[AI-assisted - Claude]