### PR TITLE
fix: prevent fast_channel overflow by eliminating inbound starvation

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -4371,6 +4371,7 @@ async fn peer_connection_listener(
         // Drain pending outbound messages before checking inbound, but with a
         // bounded limit to prevent outbound from starving inbound packet processing.
         // Remaining messages are picked up by the fair select's outbound branch.
+        // 8 messages ≈ 0.8ms of sends (8 × ~100µs per encrypt+send).
         const MAX_OUTBOUND_DRAIN: usize = 8;
         let mut drained = 0;
         loop {

--- a/crates/core/src/transport/fast_channel.rs
+++ b/crates/core/src/transport/fast_channel.rs
@@ -248,8 +248,10 @@ impl<T> FastReceiver<T> {
                 }
                 Err(crossbeam::channel::TryRecvError::Empty) => {
                     // Wait for sender notification (data available or disconnect).
-                    // Notify::notify_one() stores a permit if no waiter exists,
-                    // so rapid sends between checks won't be missed.
+                    // Notify::notify_one() stores at most one permit. Multiple
+                    // sends may coalesce into a single wakeup, but correctness
+                    // is maintained because try_recv() at the top of the loop
+                    // drains all available messages before re-entering this wait.
                     self.recv_notify.notified().await;
                 }
                 Err(crossbeam::channel::TryRecvError::Disconnected) => {
@@ -462,6 +464,20 @@ mod tests {
             "Too many poll iterations ({polls}), notification wakeup may not be working"
         );
         assert!(polls > 0, "Should have polled at least once");
+    }
+
+    #[tokio::test]
+    async fn test_burst_send_before_recv_drains_all() {
+        // Verify that multiple sends with no receiver waiting (notify_one permits
+        // coalesce into one) still result in all messages being received, because
+        // recv_async loops on try_recv after waking.
+        let (tx, rx) = bounded::<i32>(100);
+        for i in 0..50 {
+            tx.send(i).unwrap();
+        }
+        for i in 0..50 {
+            assert_eq!(rx.recv_async().await.unwrap(), i);
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -952,7 +952,8 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                 _ = async { resend_check_sleep.take().unwrap_or(Box::pin(std::future::ready(()))).await } => {
                     // Bound retransmissions per iteration to prevent monopolizing the
                     // select loop. Remaining resends are handled on the next iteration
-                    // via an immediate-ready future.
+                    // via an immediate-ready future. 4 packets keeps resend bursts
+                    // short enough for inbound branches to interleave.
                     const MAX_RESENDS_PER_ITERATION: usize = 4;
                     let mut resend_count = 0;
                     loop {


### PR DESCRIPTION
## Problem

Gateway nodes (nova ↔ vega) experience massive per-connection fast_channel overflow: ~150K packets dropped/hour on a single connection, causing 99.6% CONNECT forwarding failure rate. The network is quiet (~4 Mbps total, 220 pps from vega) — the overflow should NOT happen at this traffic level.

**Root cause**: The PeerConnection architecture systematically deprioritizes inbound packet processing. For inbound to be processed, it must win THREE layers of competition:
1. The **unbounded outbound drain loop** in `peer_connection_listener` must have no pending messages
2. The **2-branch fair select** must pick `conn.recv()` over the outbound channel
3. Inside `conn.recv()`, the **inbound branch** must be selected (1 of 7 fair branches)

This creates a feedback loop: dropped packets → retransmissions → more outbound → more starvation → more drops.

Additionally, `recv_async()` polls with exponential backoff (up to 50ms) instead of being notified by senders, adding unnecessary latency.

**Trigger**: A gateway restart caused a CONNECT storm (~3K operations in 7 minutes), saturating the nova-vega link. The cascade was self-reinforcing and survived multiple restarts. See #3207.

## Approach

Three targeted changes break the starvation feedback loop:

### 1. Notification-based recv wakeup (fast_channel.rs)

Replace the exponential backoff polling (1µs→50ms) in `recv_async()` with `Notify`-based wakeup. Every successful `send()`, `send_async()`, and `try_send()` now calls `recv_notify.notify_one()`, giving receivers instant zero-CPU wakeup. `Notify::notify_one()` stores exactly one permit if no waiter exists, so rapid sends between checks won't be missed.

### 2. Bounded outbound drain (p2p_protoc.rs)

Limit the outbound drain loop to 8 messages per iteration (`MAX_OUTBOUND_DRAIN`). Previously unbounded — if outbound traffic was sustained, inbound processing was indefinitely starved. Remaining messages are still picked up by the fair select's outbound branch on the same iteration.

### 3. Bounded retransmission loop (peer_connection.rs)

Limit retransmissions to 4 packets per select iteration (`MAX_RESENDS_PER_ITERATION`). When the limit is reached, schedules an immediate-ready future for continuation, interleaving retransmissions with other branches via fair `deterministic_select!`.

## Testing

- All 1622 existing tests pass (0 failures)
- `cargo fmt` and `cargo clippy --all-targets --all-features` clean
- Fast channel tests updated: `test_recv_async_no_busy_loop` now validates notification-based wakeup (expects <10 polls instead of <100)
- All 19 fast_channel unit + property tests pass, including stress tests (50 senders, 200 parallel channels, backpressure, rapid disconnect)
- Determinism test fingerprints may change since behavior is still deterministic for a given seed but the notification wakeup pattern differs from backoff polling

## Fixes

Addresses #3207

[AI-assisted - Claude]