### PR TITLE
feat: add --purge and --keep-data flags to service uninstall

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -6,7 +6,9 @@
 
 use anyhow::{Context, Result};
 use clap::Subcommand;
+use directories::ProjectDirs;
 use freenet::config::ConfigPaths;
+use freenet::tracing::tracer::get_log_dir;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -74,6 +76,12 @@ pub enum ServiceCommand {
         /// Uninstall the system-wide service instead of the user service
         #[arg(long)]
         system: bool,
+        /// Also remove all Freenet data, config, and logs
+        #[arg(long, conflicts_with = "keep_data")]
+        purge: bool,
+        /// Only remove the service (skip interactive prompt)
+        #[arg(long, conflicts_with = "purge")]
+        keep_data: bool,
     },
     /// Check the status of the Freenet service
     Status {
@@ -120,7 +128,11 @@ impl ServiceCommand {
     ) -> Result<()> {
         match self {
             ServiceCommand::Install { system } => install_service(*system),
-            ServiceCommand::Uninstall { system } => uninstall_service(*system),
+            ServiceCommand::Uninstall {
+                system,
+                purge,
+                keep_data,
+            } => uninstall_service(*system, *purge, *keep_data),
             ServiceCommand::Status { system } => service_status(*system),
             ServiceCommand::Start { system } => start_service(*system),
             ServiceCommand::Stop { system } => stop_service(*system),
@@ -131,6 +143,109 @@ impl ServiceCommand {
             }
         }
     }
+}
+
+/// Determine whether the user wants to purge data directories.
+///
+/// - `--purge` → true
+/// - `--keep-data` → false
+/// - Neither → prompt interactively (defaults to false if stdin is not a TTY)
+fn should_purge(purge: bool, keep_data: bool) -> Result<bool> {
+    if purge {
+        return Ok(true);
+    }
+    if keep_data {
+        return Ok(false);
+    }
+
+    use std::io::{self, BufRead, IsTerminal, Write};
+
+    // Check if stdin is a TTY for interactive prompting
+    if io::stdin().is_terminal() {
+        print!("Also remove all Freenet data, config, and logs? [y/N] ");
+        io::stdout().flush()?;
+        let mut line = String::new();
+        io::stdin().lock().read_line(&mut line)?;
+        let answer = line.trim().to_ascii_lowercase();
+        Ok(answer == "y" || answer == "yes")
+    } else {
+        println!("Non-interactive mode: keeping data. Use --purge to also remove data, config, and logs.");
+        Ok(false)
+    }
+}
+
+/// Remove a directory if it exists, printing what is being removed.
+fn remove_if_exists(label: &str, path: &Path) -> Result<()> {
+    if path.exists() {
+        println!("Removing {label}: {}", path.display());
+        std::fs::remove_dir_all(path)
+            .with_context(|| format!("Failed to remove {label} directory: {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Remove Freenet data, config, cache, and log directories.
+///
+/// When `system_mode` is true on Linux, resolves directories for the service
+/// user (via SUDO_USER) rather than root's home directory.
+fn purge_data_dirs(#[allow(unused_variables)] system_mode: bool) -> Result<()> {
+    // On Linux with --system, the service runs as the SUDO_USER, not root.
+    // We need to resolve that user's directories, not root's.
+    #[cfg(target_os = "linux")]
+    let home_override: Option<std::path::PathBuf> = if system_mode {
+        std::env::var("SUDO_USER")
+            .ok()
+            .map(|u| home_dir_for_user(&u))
+    } else {
+        None
+    };
+    #[cfg(not(target_os = "linux"))]
+    let home_override: Option<std::path::PathBuf> = None;
+
+    // If we have a home override (system mode), construct paths manually using
+    // XDG defaults. Otherwise use ProjectDirs which resolves from the current user.
+    if let Some(ref home) = home_override {
+        // XDG defaults for the service user
+        remove_if_exists("data", &home.join(".local/share/Freenet"))?;
+        remove_if_exists("config", &home.join(".config/Freenet"))?;
+        remove_if_exists("cache", &home.join(".cache/Freenet"))?;
+        // Also remove lowercase cache dir used by webapp cache
+        remove_if_exists("cache", &home.join(".cache/freenet"))?;
+        remove_if_exists("logs", &home.join(".local/state/freenet"))?;
+    } else {
+        match ProjectDirs::from("", "The Freenet Project Inc", "Freenet") {
+            Some(ref dirs) => {
+                let data_dir = dirs.data_dir();
+                remove_if_exists("data", data_dir)?;
+
+                let config_dir = dirs.config_dir();
+                // On macOS, config_dir == data_dir; skip if already removed
+                if config_dir != data_dir {
+                    remove_if_exists("config", config_dir)?;
+                }
+
+                remove_if_exists("cache", dirs.cache_dir())?;
+            }
+            None => {
+                eprintln!("Warning: Could not determine Freenet directories. Data and config may not have been removed.");
+            }
+        }
+
+        // Also remove lowercase "freenet" cache dir used by webapp cache
+        // (may differ from uppercase "Freenet" on case-sensitive filesystems)
+        if let Some(ref dirs) = ProjectDirs::from("", "The Freenet Project Inc", "freenet") {
+            let cache_dir = dirs.cache_dir();
+            if cache_dir.exists() {
+                remove_if_exists("cache", cache_dir)?;
+            }
+        }
+
+        if let Some(log_dir) = get_log_dir() {
+            remove_if_exists("logs", &log_dir)?;
+        }
+    }
+
+    Ok(())
 }
 
 /// Path to the system-wide systemd service file.
@@ -464,7 +579,7 @@ WantedBy=multi-user.target
 }
 
 #[cfg(target_os = "linux")]
-fn uninstall_service(system: bool) -> Result<()> {
+fn uninstall_service(system: bool, purge: bool, keep_data: bool) -> Result<()> {
     use std::fs;
 
     let system_mode = use_system_mode(system);
@@ -492,6 +607,11 @@ fn uninstall_service(system: bool) -> Result<()> {
     drop(systemctl(system_mode, &["daemon-reload"]));
 
     println!("Freenet service uninstalled.");
+
+    if should_purge(purge, keep_data)? {
+        purge_data_dirs(system_mode)?;
+        println!("All Freenet data, config, and logs removed.");
+    }
 
     Ok(())
 }
@@ -716,7 +836,7 @@ fn check_no_system_flag(system: bool) -> Result<()> {
 }
 
 #[cfg(target_os = "macos")]
-fn uninstall_service(system: bool) -> Result<()> {
+fn uninstall_service(system: bool, purge: bool, keep_data: bool) -> Result<()> {
     use std::fs;
 
     check_no_system_flag(system)?;
@@ -743,6 +863,11 @@ fn uninstall_service(system: bool) -> Result<()> {
     }
 
     println!("Freenet service uninstalled.");
+
+    if should_purge(purge, keep_data)? {
+        purge_data_dirs(false)?;
+        println!("All Freenet data, config, and logs removed.");
+    }
 
     Ok(())
 }
@@ -930,7 +1055,7 @@ fn check_no_system_flag_windows(system: bool) -> Result<()> {
 }
 
 #[cfg(target_os = "windows")]
-fn uninstall_service(system: bool) -> Result<()> {
+fn uninstall_service(system: bool, purge: bool, keep_data: bool) -> Result<()> {
     check_no_system_flag_windows(system)?;
 
     // Stop if running
@@ -949,6 +1074,11 @@ fn uninstall_service(system: bool) -> Result<()> {
     }
 
     println!("Freenet scheduled task uninstalled.");
+
+    if should_purge(purge, keep_data)? {
+        purge_data_dirs(false)?;
+        println!("All Freenet data, config, and logs removed.");
+    }
 
     Ok(())
 }
@@ -1036,7 +1166,7 @@ fn install_service(_system: bool) -> Result<()> {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-fn uninstall_service(_system: bool) -> Result<()> {
+fn uninstall_service(_system: bool, _purge: bool, _keep_data: bool) -> Result<()> {
     anyhow::bail!("Service management is not supported on this platform")
 }
 
@@ -1175,5 +1305,21 @@ mod tests {
         // Verify RunAtLoad is set
         assert!(plist_content.contains("<key>RunAtLoad</key>"));
         assert!(plist_content.contains("<true/>"));
+    }
+
+    #[test]
+    fn test_should_purge_with_purge_flag() {
+        assert!(should_purge(true, false).unwrap());
+    }
+
+    #[test]
+    fn test_should_purge_with_keep_data_flag() {
+        assert!(!should_purge(false, true).unwrap());
+    }
+
+    #[test]
+    fn test_should_purge_no_flags_non_tty() {
+        // In CI/test environments stdin is not a TTY, so this should default to false
+        assert!(!should_purge(false, false).unwrap());
     }
 }


### PR DESCRIPTION
## Problem

`freenet service uninstall` only removes the systemd/launchd/schtasks service file. All data (contracts, delegates, secrets, databases), config (`config.toml`, `gateways.toml`), cache, and logs persist across multiple platform-specific directories. Users wanting a clean reinstall must manually find and `rm -rf` each one.

## Solution

Add `--purge` and `--keep-data` flags to `freenet service uninstall`:

```
freenet service uninstall              → prompt: "Also remove all data, config, and logs? [y/N]"
freenet service uninstall --purge      → remove everything (no prompt)
freenet service uninstall --keep-data  → service only (no prompt)
```

The flags are mutually exclusive (enforced by clap `conflicts_with`). When neither flag is passed and stdin is not a TTY (piped/scripted), defaults to service-only with a hint about `--purge`.

Directories removed on purge (resolved via `ProjectDirs` + `get_log_dir()`):

| Platform | Data dir | Config dir | Cache dir | Log dir |
|----------|----------|------------|-----------|---------|
| Linux | `~/.local/share/Freenet/` | `~/.config/Freenet/` | `~/.cache/Freenet/` + `~/.cache/freenet/` | `~/.local/state/freenet/` |
| macOS | `~/Library/Application Support/Freenet/` | (same as data) | `~/Library/Caches/Freenet/` + `~/Library/Caches/freenet/` | `~/Library/Logs/freenet/` |
| Windows | `%LOCALAPPDATA%\...\Freenet\` | `%APPDATA%\...\Freenet\` | `%LOCALAPPDATA%\...\Freenet\cache\` | `%LOCALAPPDATA%\freenet\logs\` |

### System-mode awareness

When uninstalling a system service (`--system --purge`), the purge resolves directories for the **service user** (via `SUDO_USER`) rather than root's home directory. This matches the install behavior which uses the same `SUDO_USER` detection.

## Testing

- `cargo build -p freenet` — compiles clean
- `cargo clippy -p freenet --bin freenet` — no warnings
- `cargo fmt` — formatted
- Unit tests for `should_purge()` (3 tests: purge flag, keep-data flag, non-TTY default)
- Manual verification of `--purge`, `--keep-data`, interactive prompt, and piped stdin scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]