### PR TITLE
test: address remaining conformance test review items

### DIFF
--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -797,7 +797,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -838,7 +838,7 @@ mod test {
     }
 
     /// Helper to create a test contract with given code bytes
-    fn create_test_contract(code_bytes: &[u8]) -> ContractContainer {
+    pub(crate) fn create_test_contract(code_bytes: &[u8]) -> ContractContainer {
         use freenet_stdlib::prelude::*;
 
         let code = ContractCode::from(code_bytes.to_vec());

--- a/crates/core/src/contract/executor/pool_tests/conformance_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/conformance_tests.rs
@@ -35,7 +35,6 @@
 
 use either::Either;
 use freenet_stdlib::prelude::*;
-use std::sync::Arc;
 
 use crate::contract::executor::mock_runtime::MockRuntime;
 use crate::contract::executor::mock_wasm_runtime::MockWasmRuntime;
@@ -58,15 +57,7 @@ async fn create_mock_wasm_executor() -> Executor<MockWasmRuntime, MockStateStora
         .expect("create MockWasmRuntime executor")
 }
 
-/// Helper to create a test contract.
-fn test_contract(code_bytes: &[u8]) -> ContractContainer {
-    let code = ContractCode::from(code_bytes.to_vec());
-    let params = Parameters::from(vec![]);
-    ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
-        Arc::new(code),
-        params,
-    )))
-}
+use super::super::mock_runtime::test::create_test_contract as test_contract;
 
 // =========================================================================
 // Invariant: PUT new contract → Updated result with same state
@@ -77,6 +68,8 @@ async fn conformance_put_new_contract_both_return_updated() {
     let mut mock = create_mock_runtime_executor().await;
     let mut wasm = create_mock_wasm_executor().await;
 
+    // Non-WASM bytes are fine here: neither runtime executes contract code
+    // during PUT (upsert_contract_state stores state without validation).
     let contract = test_contract(b"conformance_put_test");
     let key = contract.key();
     let state = WrappedState::new(vec![10, 20, 30]);

--- a/crates/core/src/contract/executor/pool_tests/wasm_conformance_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/wasm_conformance_tests.rs
@@ -374,9 +374,13 @@ async fn wasm_conformance_state_and_delta() -> Result<(), Box<dyn std::error::Er
         .update_state(&wasm.contract_key, &params, &current, &updates)?;
     let mock_result = mock.update_state(&wasm.contract_key, &params, &current, &updates)?;
 
+    let wasm_state = wasm_result.unwrap_valid();
+    let mock_state = mock_result.unwrap_valid();
+    assert_eq!(wasm_state.as_ref(), mock_state.as_ref());
     assert_eq!(
-        wasm_result.unwrap_valid().as_ref(),
-        mock_result.unwrap_valid().as_ref(),
+        wasm_state.as_ref(),
+        state_part.as_ref(),
+        "StateAndDelta must use the State part"
     );
     Ok(())
 }


### PR DESCRIPTION
## Problem

PR #3184 was merged with 3 minor review items still open (from [this review comment](https://github.com/freenet/freenet-core/pull/3184#issuecomment-3941021733)):

1. `test_contract()` helper duplicated between `conformance_tests.rs` and `mock_runtime.rs`
2. `wasm_conformance_state_and_delta` only asserts both runtimes agree, but doesn't verify the actual value
3. No comment explaining why non-WASM bytes are acceptable in PUT conformance test

## Solution

- **Dedup helper**: Made `mock_runtime::test::create_test_contract` `pub(crate)` and reuse it from conformance tests via import alias
- **Semantic assertion**: Added `assert_eq!(wasm_state.as_ref(), state_part.as_ref())` to verify the `StateAndDelta` update actually uses the state part, not just that both runtimes return the same (possibly wrong) result
- **Comment**: Added clarifying comment that PUT doesn't execute contract code, so non-WASM bytes are fine

## Testing

All 18 conformance tests pass (10 mock-only + 8 WASM).

## Fixes

Follow-up to #3184