### PR TITLE
fix: propagate EmptyRing/PeerNotJoined from operations as type-safe ErrorKind

### DIFF
--- a/crates/core/src/client_events/mod.rs
+++ b/crates/core/src/client_events/mod.rs
@@ -323,10 +323,32 @@ async fn report_op_init_error(
         "{op_name} request failed"
     );
 
-    let error_response = Err(ErrorKind::OperationError {
-        cause: format!("{op_name} operation failed: {err}").into(),
-    }
-    .into());
+    // Convert ring errors to type-safe ErrorKind variants so that downstream
+    // consumers (e.g. the HTTP handler's SERVICE_UNAVAILABLE page) can match on
+    // them instead of relying on error message string contents.
+    let error_kind = match err {
+        OpError::RingError(crate::ring::RingError::EmptyRing) => ErrorKind::EmptyRing,
+        OpError::RingError(crate::ring::RingError::PeerNotJoined) => ErrorKind::PeerNotJoined,
+        OpError::RingError(crate::ring::RingError::ConnError(_))
+        | OpError::RingError(crate::ring::RingError::NoCachingPeers(_))
+        | OpError::ConnError(_)
+        | OpError::ContractError(_)
+        | OpError::ExecutorError(_)
+        | OpError::UnexpectedOpState
+        | OpError::InvalidStateTransition { .. }
+        | OpError::NotificationError
+        | OpError::NotificationChannelError(_)
+        | OpError::IncorrectTxType(..)
+        | OpError::OpNotPresent(_)
+        | OpError::OpNotAvailable(_)
+        | OpError::StreamCancelled
+        | OpError::OrphanStreamClaimFailed
+        | OpError::StatePushed => ErrorKind::OperationError {
+            cause: format!("{op_name} operation failed: {err}").into(),
+        },
+    };
+
+    let error_response = Err(error_kind.into());
 
     if let Err(e) = op_manager.result_router_tx.send((tx, error_response)).await {
         tracing::error!(

--- a/crates/core/src/server/errors.rs
+++ b/crates/core/src/server/errors.rs
@@ -222,3 +222,37 @@ fn connecting_page() -> String {
 </html>"#
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_ring_returns_service_unavailable() {
+        let err = WebSocketApiError::AxumError {
+            error: ErrorKind::EmptyRing,
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn peer_not_joined_returns_service_unavailable() {
+        let err = WebSocketApiError::AxumError {
+            error: ErrorKind::PeerNotJoined,
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn other_axum_error_returns_internal_server_error() {
+        let err = WebSocketApiError::AxumError {
+            error: ErrorKind::OperationError {
+                cause: "something broke".into(),
+            },
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -3148,7 +3148,10 @@ async fn test_get_notfound_no_forwarding_targets(ctx: &mut TestContext) -> TestR
             // An error is also acceptable if it's fast - the key is we don't timeout
             // "No ring connections found" is returned when gateway has no peers
             let err_str = e.to_string();
-            if err_str.contains("No ring connections") || err_str.contains("not found") {
+            if err_str.contains("no ring connections")
+                || err_str.contains("No ring connections")
+                || err_str.contains("not found")
+            {
                 tracing::info!(
                     "✓ Received fast error response in {:?}: {}",
                     elapsed,

--- a/crates/core/tests/operations_before_join.rs
+++ b/crates/core/tests/operations_before_join.rs
@@ -1,6 +1,6 @@
 //! Tests for operations attempted before peer join completes.
 //!
-//! Verifies that PUT, GET, and SUBSCRIBE operations return PEER_NOT_JOINED error
+//! Verifies that PUT, GET, and SUBSCRIBE operations return PeerNotJoined error
 //! when the peer hasn't joined the network yet.
 
 use freenet::{


### PR DESCRIPTION
## Problem

PR #3178 replaced string-based error detection with type-safe `matches!()` in `errors.rs`, but missed the `report_op_init_error` path. When operations like GET return `RingError::EmptyRing` (e.g., `get.rs:190`), the error flows through:

```
RingError::EmptyRing → OpError::RingError(...) → report_op_init_error → ErrorKind::OperationError { cause: "..." }
```

The new `matches!(error, ErrorKind::EmptyRing | ErrorKind::PeerNotJoined)` check in `errors.rs` doesn't match `ErrorKind::OperationError`, so the HTTP handler returns **500** instead of **503** with the friendly "Connecting to Freenet..." page.

**User impact**: When a browser visits a contract URL while the gateway has no ring connections (common during startup), users see a generic 500 error instead of the auto-refreshing "Connecting" page.

## Approach

Fix `report_op_init_error` to detect `OpError::RingError` variants and convert them to the appropriate type-safe `ErrorKind` (`EmptyRing` or `PeerNotJoined`) instead of always wrapping in `ErrorKind::OperationError`.

This completes the type-safe error migration that #3178 started — now both the direct event loop path AND the operation error reporting path produce type-safe variants.

## Testing

- Added 3 unit tests for `WebSocketApiError::into_response`:
  - `empty_ring_returns_service_unavailable` — verifies 503
  - `peer_not_joined_returns_service_unavailable` — verifies 503
  - `other_axum_error_returns_internal_server_error` — verifies 500
- Fixed stale doc comment in `operations_before_join.rs`
- All existing tests pass (`cargo test -p freenet`)

[AI-assisted - Claude]