### PR TITLE
fix: prevent cancellation of process_host_response and select starvation

### DIFF
--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -630,14 +630,15 @@ async fn websocket_interface(
             }
         };
 
-        // IMPORTANT: client_stream.next() is the only part inside the select future.
-        // process_client_request runs in the branch handler AFTER the select resolves,
-        // so it cannot be cancelled by other branches (listeners, responses, pings).
-        // Previously, process_client_request ran inside the select future and could be
-        // cancelled mid-execution if a subscription notification or host response arrived
-        // during an .await point (e.g., waiting_for_transaction_result). This left
-        // operations registered in the router but never started — a silent hang.
-        tokio::select! { biased;
+        // IMPORTANT: Only cancellation-safe futures (recv, next, tick) go inside the
+        // select futures below. Processing functions (process_client_request,
+        // process_host_response) run in branch handlers AFTER the select resolves,
+        // so they cannot be cancelled by other branches.
+        //
+        // NOTE: Do NOT add `biased;` here. Biased select polls branches in declaration
+        // order, which starves host responses, subscription notifications, and pings
+        // when client messages arrive in bursts.
+        tokio::select! {
             next_msg = client_stream.next() => {
                 let next_msg = match next_msg
                     .ok_or_else::<ClientError, _>(|| ErrorKind::Disconnect.into())
@@ -687,8 +688,10 @@ async fn websocket_interface(
                     },
                 }
             }
-            msg = async { process_host_response(response_rx.recv().await, client_id, encoding_protoc, &mut server_sink).await } => {
-                let msg = match msg {
+            msg = response_rx.recv() => {
+                // process_host_response runs in the branch handler (not the select future)
+                // so it cannot be cancelled by other branches resolving first.
+                let msg = match process_host_response(msg, client_id, encoding_protoc, &mut server_sink).await {
                     Ok(msg) => msg,
                     Err(err) => {
                         notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
@@ -697,8 +700,7 @@ async fn websocket_interface(
                 };
                 if let Some(NewSubscription { key, callback }) = msg {
                     tracing::debug!(cli_id = %client_id, contract = %key, "added new notification listener");
-                    let active_listeners = contract_updates.clone();
-                    let active_listeners = &mut *active_listeners.lock().await;
+                    let active_listeners = &mut *contract_updates.lock().await;
                     active_listeners.push_back((key, callback));
                 }
             }


### PR DESCRIPTION
## Problem

PR #3063 fixed a cancellation bug where `process_client_request` ran inside a `select!` future and could be cancelled mid-execution. The same pattern remains in the host response branch: `process_host_response` (which calls `server_sink.send().await` at line 973) runs inside the select future and can be cancelled if another branch resolves first — silently dropping host responses to the WebSocket client.

Additionally, `biased` on the `select!` creates a starvation risk: if client messages fire continuously, host responses, subscriptions, and pings never get polled.

## Approach

**Extract `process_host_response` from the select future:** Only `response_rx.recv()` (cancellation-safe — a cancelled recv just retries next iteration) lives inside the select future. `process_host_response` runs in the branch handler to completion, matching the pattern already established for `process_client_request` in #3063.

**Remove `biased;`:** Without `biased`, tokio randomly polls branches each iteration, preventing starvation of host responses/subscriptions/pings when client messages arrive in bursts.

## Testing

- `cargo fmt` — no changes needed
- `cargo clippy -p freenet --all-targets` — no new warnings
- `cargo test -p freenet` — all 1631 tests pass, 0 failures
- Existing WebSocket test in `crates/fdev/tests/websocket_response.rs` exercises the response path

## Fixes

Closes #3079

[AI-assisted - Claude]