### PR TITLE
fix: prevent handshake starvation in PrioritySelectStream

### DIFF
--- a/crates/core/src/node/network_bridge/priority_select.rs
+++ b/crates/core/src/node/network_bridge/priority_select.rs
@@ -132,10 +132,10 @@ where
         }
     }
 
-    /// Maximum consecutive Tier-1 (P1-P4, P6) items before force-polling protected
-    /// channels (Handshake + Tier-2 P7/P8). Prevents starvation of connection
-    /// lifecycle events and client/executor transactions under sustained
-    /// high-priority traffic. See issue #3074.
+    /// Maximum consecutive unprotected (P1-P6) items before force-polling protected
+    /// channels (Handshake, P7 Client tx, P8 Executor tx). Prevents starvation
+    /// of connection lifecycle events and client/executor transactions under
+    /// sustained high-priority traffic. See issues #3074, #3224.
     pub(crate) const MAX_HIGH_PRIORITY_BURST: u32 = 32;
 }
 
@@ -153,9 +153,9 @@ where
         // Track if any channel closed (to report after checking all sources)
         let mut first_closed_channel: Option<SelectResult> = None;
 
-        // Track whether Tier-2 channels were already polled in Phase 1
+        // Track whether protected channels were already polled in Phase 1
         // to avoid double-polling in Phase 2.
-        let mut tier2_polled_in_phase1 = false;
+        let mut force_polled_in_phase1 = false;
 
         // Phase 1: Anti-starvation — force-poll Handshake and Tier-2 (P7/P8)
         // when the high-priority streak has reached the burst limit.
@@ -169,7 +169,7 @@ where
                 streak = this.high_priority_streak,
                 "Anti-starvation: forcing poll of Handshake + Tier-2 channels"
             );
-            tier2_polled_in_phase1 = true;
+            force_polled_in_phase1 = true;
             crate::config::GlobalTestMetrics::record_anti_starvation_trigger();
 
             // Force-poll Handshake: connection lifecycle events
@@ -278,7 +278,7 @@ where
 
         // Priority 2: Handshake handler — connection lifecycle events
         // Skip if already polled during Phase 1 force-poll
-        if !tier2_polled_in_phase1 && !this.handshake_closed {
+        if !force_polled_in_phase1 && !this.handshake_closed {
             match Pin::new(&mut this.handshake_handler).poll_next(cx) {
                 Poll::Ready(Some(event)) => {
                     this.high_priority_streak += 1;
@@ -364,7 +364,7 @@ where
 
         // Priority 7: Client transaction handler
         // Skip if already polled during Phase 1 force-poll
-        if !tier2_polled_in_phase1 && !this.client_transaction_closed {
+        if !force_polled_in_phase1 && !this.client_transaction_closed {
             match Pin::new(&mut this.client_transaction_handler).poll_next(cx) {
                 Poll::Ready(Some(result)) => {
                     this.high_priority_streak = 0;
@@ -384,7 +384,7 @@ where
 
         // Priority 8: Executor transaction handler
         // Skip if already polled during Phase 1 force-poll
-        if !tier2_polled_in_phase1 && !this.executor_transaction_closed {
+        if !force_polled_in_phase1 && !this.executor_transaction_closed {
             match Pin::new(&mut this.executor_transaction_handler).poll_next(cx) {
                 Poll::Ready(Some(tx)) => {
                     this.high_priority_streak = 0;

--- a/crates/core/src/node/network_bridge/priority_select/tests.rs
+++ b/crates/core/src/node/network_bridge/priority_select/tests.rs
@@ -2542,6 +2542,53 @@ async fn test_handshake_not_starved_under_notification_load() {
     );
 }
 
+/// Handshake at P2 is polled before op_execution at P3 in normal Phase 2 polling.
+/// This tests the priority promotion (P5→P2) when P1 is Pending (empty).
+#[tokio::test]
+#[test_log::test]
+async fn test_handshake_p2_before_op_execution_p3() {
+    // P1 is empty, so Phase 2 normal polling applies.
+    // Handshake (P2) and op_execution (P3) both have one event ready.
+    // Handshake should be returned first.
+    let (_, notif_rx) = mpsc::channel(1);
+    let (op_tx, op_rx) = mpsc::channel(1);
+    let (_, conn_event_rx) = mpsc::channel(1);
+    let (_, bridge_rx) = mpsc::channel(1);
+    let (_, node_rx) = mpsc::channel(1);
+    let (hs_tx, hs_rx) = mpsc::channel(1);
+
+    hs_tx.send(dummy_handshake_event()).await.unwrap();
+    let dummy_msg = NetMessage::V1(crate::message::NetMessageV1::Aborted(
+        crate::message::Transaction::new::<crate::operations::put::PutMsg>(),
+    ));
+    let (callback_tx, _) = mpsc::channel(1);
+    op_tx.send((callback_tx, dummy_msg)).await.unwrap();
+
+    drop(hs_tx);
+    drop(op_tx);
+
+    let stream = PrioritySelectStream::new(
+        notif_rx,
+        op_rx,
+        bridge_rx,
+        MockHandshakeReceiverStream { rx: hs_rx },
+        node_rx,
+        MockClientStream,
+        MockExecutorStream,
+        conn_event_rx,
+    );
+    tokio::pin!(stream);
+
+    let events = drain_stream(&mut stream, 5).await;
+
+    assert_eq!(events.len(), 2, "Should receive both events");
+    assert_eq!(
+        events[0], "handshake",
+        "Handshake (P2) should be returned before op_execution (P3)"
+    );
+    assert_eq!(events[1], "op_execution");
+}
+
 /// Anti-starvation force-polls handshake even when P1 is continuously ready.
 /// This tests the Phase 1 mechanism — after MAX_HIGH_PRIORITY_BURST consecutive
 /// tier-1 items, the handshake channel is force-polled.


### PR DESCRIPTION
## Problem

On loaded gateways (e.g., nova with ~1300 queued notification messages), the `PrioritySelectStream` event loop never polls the Handshake channel, preventing new peers from joining the ring.

**Root cause:** `PrioritySelectStream` uses strict priority polling. When the Notification channel (P1, capacity 2048) is Ready, lower-priority channels are never polled. The Handshake channel was at P5, and the existing anti-starvation mechanism (`MAX_HIGH_PRIORITY_BURST=32`) only protected P7/P8 (client/executor transactions), not Handshake.

**Observed behavior:** Transport layer completes connections (keepalive starts, "Detected new peer identity" logged), but `p2p_protoc` never receives the `InboundConnection` event. Connecting peers time out.

First reported via diagnostic report DFUV6Q — a macOS peer unable to join a River room despite successful transport-level connections.

## Solution

Two changes to `priority_select.rs`:

1. **Promote Handshake from P5 to P2** in the polling order, so it's polled before op_execution (P3), conn_events (P4), and conn_bridge (P5). This helps when P1 is momentarily Pending.

2. **Add Handshake to the Phase 1 anti-starvation force-poll group** (alongside P7/P8). After 32 consecutive tier-1 items, Handshake is force-polled regardless of P1 state. This is the primary protection under sustained notification load.

Priority order (new):
```
P1 Notification     — operation state changes (highest volume)
P2 Handshake        — connection lifecycle (rare but blocks new peers) ← PROMOTED
P3 Op execution     — operation message dispatch
P4 Peer connection  — established connection events
P5 Conn bridge      — bridge commands
P6 Node controller  — node-level events
P7 Client tx        — protected by anti-starvation
P8 Executor tx      — protected by anti-starvation
```

## Testing

- `test_handshake_not_starved_under_notification_load` — pre-fills 100 P1 messages + 1 handshake event, verifies handshake is delivered at burst limit (index 32), not starved indefinitely
- `test_anti_starvation_includes_handshake` — verifies handshake is force-polled before client_tx in the Phase 1 group
- All 26 existing `priority_select` tests pass (including property-based tests)
- Full lib test suite: 1573 passed, 0 failed

## Fixes

Closes #3224

[AI-assisted - Claude]