### PR TITLE
fix: perform auto-update in-process to prevent restart death loop

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -484,8 +484,8 @@ Restart=always
 # Wait 10 seconds before restart to avoid rapid restart loops
 RestartSec=10
 # Stop restart loop after 5 failures in 2 minutes (e.g., port conflict with
-# a stale process). Without this, systemd restarts indefinitely. The counter
-# resets after a successful start, so auto-update (exit 42) is unaffected.
+# a stale process). Without this, systemd restarts indefinitely.
+# SuccessExitStatus=42 ensures auto-update exits don't count as failures.
 StartLimitBurst=5
 StartLimitIntervalSec=120
 # Allow 15 seconds for graceful shutdown before SIGKILL
@@ -496,6 +496,10 @@ TimeoutStopSec=15
 # run update before systemd restarts the service. The '-' prefix means
 # ExecStopPost failure won't affect service restart.
 ExecStopPost=-/bin/sh -c '[ "$EXIT_STATUS" = "42" ] && {binary} update --quiet || true'
+# Treat exit code 42 as success so it doesn't count against StartLimitBurst.
+# Without this, rapid update cycles (exit 42 → ExecStopPost → restart) can
+# exhaust the burst limit and permanently kill the service.
+SuccessExitStatus=42
 
 # Logging - write to files for systems without active user journald
 # (headless servers, systems without lingering enabled, etc.)
@@ -542,8 +546,8 @@ Restart=always
 # Wait 10 seconds before restart to avoid rapid restart loops
 RestartSec=10
 # Stop restart loop after 5 failures in 2 minutes (e.g., port conflict with
-# a stale process). Without this, systemd restarts indefinitely. The counter
-# resets after a successful start, so auto-update (exit 42) is unaffected.
+# a stale process). Without this, systemd restarts indefinitely.
+# SuccessExitStatus=42 ensures auto-update exits don't count as failures.
 StartLimitBurst=5
 StartLimitIntervalSec=120
 # Allow 15 seconds for graceful shutdown before SIGKILL
@@ -554,6 +558,10 @@ TimeoutStopSec=15
 # run update before systemd restarts the service. The '-' prefix means
 # ExecStopPost failure won't affect service restart.
 ExecStopPost=-/bin/sh -c '[ "$EXIT_STATUS" = "42" ] && {binary} update --quiet || true'
+# Treat exit code 42 as success so it doesn't count against StartLimitBurst.
+# Without this, rapid update cycles (exit 42 → ExecStopPost → restart) can
+# exhaust the burst limit and permanently kill the service.
+SuccessExitStatus=42
 
 # Logging - write to files for systems without active user journald
 StandardOutput=append:{log_dir}/freenet.log
@@ -1235,6 +1243,9 @@ mod tests {
         // Verify auto-update support via ExecStopPost
         assert!(service_content.contains("ExecStopPost="));
 
+        // Verify exit code 42 is treated as success (doesn't count against StartLimitBurst)
+        assert!(service_content.contains("SuccessExitStatus=42"));
+
         // Verify graceful shutdown timeout is set
         assert!(service_content.contains("TimeoutStopSec=15"));
 
@@ -1274,6 +1285,9 @@ mod tests {
         assert!(service_content.contains("StartLimitIntervalSec=120"));
         assert!(service_content.contains("LimitNOFILE=65536"));
         assert!(service_content.contains("ExecStopPost="));
+
+        // Verify exit code 42 is treated as success (doesn't count against StartLimitBurst)
+        assert!(service_content.contains("SuccessExitStatus=42"));
     }
 
     #[test]

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -712,9 +712,9 @@ fn update_service_file(
 ) -> Result<()> {
     let content = fs::read_to_string(service_path).context("Failed to read service file")?;
 
-    // Check if the auto-update hook is present
-    if content.contains("ExecStopPost=") {
-        return Ok(()); // Already has the hook
+    // Check if the auto-update hook and SuccessExitStatus are present
+    if content.contains("ExecStopPost=") && content.contains("SuccessExitStatus=42") {
+        return Ok(()); // Already up to date
     }
 
     if !quiet {


### PR DESCRIPTION
## Problem

When a node detects a version mismatch with the gateway, it exits with code 42 and relies on `ExecStopPost` to download and install the update. If `ExecStopPost` fails silently (network issue, permissions, etc.), systemd restarts the **old** binary, which re-detects the mismatch, exits 42 again, and loops. After 5 cycles in 120s, `StartLimitBurst=5` kills the service permanently.

Wayne's node (v0.1.146) hit this against the v0.1.147 gateway — 111+ "Update needed, exiting for service wrapper" log messages followed by permanent service death.

Root cause: exit code 42 counts as a failure against `StartLimitBurst`, so rapid update cycles (even when `ExecStopPost` succeeds) exhaust the burst limit.

## Approach

Add `SuccessExitStatus=42` to both user and system systemd service files so exit code 42 is treated as a clean exit and never counts against `StartLimitBurst`. This directly fixes the root cause — the update loop itself is expected behavior (exit 42 → ExecStopPost updates → restart with new binary), the bug is that systemd treats each cycle as a failure.

`ensure_service_file_updated()` now also checks for `SuccessExitStatus=42`, so existing installs get the updated service file on their next `freenet update`.

### Why not in-process update?

We considered performing the update in-process (download + install before exiting) but decided against it: changes to auto-update are high-risk because a bug could leave the entire network unable to update. `SuccessExitStatus=42` is a minimal, well-understood systemd directive that solves the immediate problem without adding new failure modes.

### Changes

| File | Change |
|------|--------|
| `service.rs` | Add `SuccessExitStatus=42` to both service generators; fix misleading comment; update tests |
| `update.rs` | Update `ensure_service_file_updated` to check for `SuccessExitStatus=42` (triggers regeneration for existing installs) |

## Testing

- `test_systemd_user_service_file_generation` — asserts `SuccessExitStatus=42` present
- `test_systemd_system_service_file_generation` — asserts `SuccessExitStatus=42` present
- `cargo fmt && cargo clippy --all-targets` — clean
- All existing tests pass

## Fixes

Closes the auto-update death loop reported by Wayne (diagnostic report A86DYV).

[AI-assisted - Claude]