### PR TITLE
fix: add keepalive backoff and per-peer reconnection backoff for dead nodes

### DIFF
--- a/.claude/rules/transport.md
+++ b/.claude/rules/transport.md
@@ -101,9 +101,11 @@ NAT traversal:
 
 ```
 Keep-alive:
-  → Ping every 5 seconds if no traffic
-  → 5 consecutive missed pings → connection dead
+  → Ping every 5 seconds initially
+  → After 5 unanswered pings, interval backs off: 10s → 20s → 40s → 60s cap
   → Idle timeout: 120s (RealTime), 24h (VirtualTime/simulation)
+  → On idle-timeout closure, per-peer backoff is recorded to prevent
+    rapid reconnection cycles to dead peers (#3252)
 ```
 
 ### WHEN closing connections

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2578,6 +2578,11 @@ impl P2pConnManager {
                     "Inbound connection established"
                 );
 
+                // Clear backoff on inbound connection: the peer is demonstrably alive (#3252).
+                if !remote_addr.ip().is_unspecified() {
+                    state.peer_backoff.record_success(remote_addr);
+                }
+
                 // Treat only transient connections as transient. Normal inbound dials (including
                 // gateway bootstrap from peers) should be promoted into the ring once established.
                 let is_transient = transient;
@@ -3188,7 +3193,6 @@ impl P2pConnManager {
         state: &mut EventListenerState,
         handshake_commands: &HandshakeCommandSender,
     ) -> anyhow::Result<EventResult> {
-        let _ = state;
         match event {
             Some(ConnEvent::InboundMessage(mut inbound)) => {
                 let tx = *inbound.msg.id();
@@ -3337,6 +3341,12 @@ impl P2pConnManager {
                     self.bridge
                         .op_manager
                         .on_ring_connection_lost(peer.pub_key());
+
+                    // Backoff prevents reconnect-timeout-reconnect cycles to dead peers (#3252).
+                    if !remote_addr.ip().is_unspecified() {
+                        state.peer_backoff.record_failure(remote_addr);
+                        tracing::debug!(remote = %remote_addr, "Recorded peer backoff after transport closure");
+                    }
 
                     if let Err(error) = handshake_commands
                         .send(HandshakeCommand::DropConnection { peer: peer.clone() })

--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -284,6 +284,24 @@ impl<S, T: TimeSource> Drop for PeerConnection<S, T> {
 /// Interval between keep-alive ping packets.
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(5);
 
+/// Maximum keepalive interval after backoff (caps the exponential growth).
+const MAX_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Returns the keepalive interval for the given number of pending (unanswered) pings.
+///
+/// At or below `MAX_UNANSWERED_PINGS`: returns `KEEP_ALIVE_INTERVAL` (5s).
+/// Above that threshold: doubles per additional unanswered ping, capped at 60s.
+fn keepalive_interval_for_pending(pending_count: usize) -> Duration {
+    if pending_count > MAX_UNANSWERED_PINGS {
+        let extra = (pending_count - MAX_UNANSWERED_PINGS).min(4) as u32;
+        KEEP_ALIVE_INTERVAL
+            .saturating_mul(2u32.pow(extra))
+            .min(MAX_KEEPALIVE_INTERVAL)
+    } else {
+        KEEP_ALIVE_INTERVAL
+    }
+}
+
 /// Maximum number of unanswered pings before considering the connection dead.
 ///
 /// With 5-second ping interval, 5 unanswered pings means 25 seconds of no response.
@@ -333,24 +351,19 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                 "Keep-alive task STARTED for connection"
             );
 
-            let mut interval =
-                TimeSourceInterval::new(task_time_source.clone(), KEEP_ALIVE_INTERVAL);
-
-            // Skip the first immediate tick
-            interval.tick().await;
-
             let mut tick_count = 0u64;
             let mut ping_seq = 0u64;
             let task_start_nanos = task_time_source.now_nanos();
 
             loop {
-                let tick_start_nanos = task_time_source.now_nanos();
-                interval.tick().await;
+                // Back off keepalive interval when pings go unanswered (#3252).
+                let pending_count = pending_pings_for_task.read().len();
+                let wait_duration = keepalive_interval_for_pending(pending_count);
+                task_time_source.sleep(wait_duration).await;
                 tick_count += 1;
 
                 let now_nanos = task_time_source.now_nanos();
                 let elapsed_since_start_nanos = now_nanos.saturating_sub(task_start_nanos);
-                let elapsed_since_last_tick_nanos = now_nanos.saturating_sub(tick_start_nanos);
 
                 // Use local ping sequence counter
                 let current_ping_seq = ping_seq;
@@ -362,7 +375,8 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                     tick_count,
                     ping_sequence = current_ping_seq,
                     elapsed_since_start_secs = Duration::from_nanos(elapsed_since_start_nanos).as_secs_f64(),
-                    tick_interval_ms = Duration::from_nanos(elapsed_since_last_tick_nanos).as_millis(),
+                    wait_interval_secs = wait_duration.as_secs_f64(),
+                    unanswered_pings = pending_count,
                     "Keep-alive tick - sending Ping"
                 );
 
@@ -2193,5 +2207,41 @@ mod tests {
             0,
             "All packets ACKed, flightsize should be 0"
         );
+    }
+
+    /// Keepalive interval backs off exponentially past the unanswered-ping threshold (#3252).
+    #[test]
+    fn keepalive_interval_backs_off_for_unanswered_pings() {
+        use super::{
+            keepalive_interval_for_pending, KEEP_ALIVE_INTERVAL, MAX_KEEPALIVE_INTERVAL,
+            MAX_UNANSWERED_PINGS,
+        };
+
+        // At or below threshold: base interval (5s)
+        for count in 0..=MAX_UNANSWERED_PINGS {
+            assert_eq!(
+                keepalive_interval_for_pending(count),
+                KEEP_ALIVE_INTERVAL,
+                "pending_count={count} should use base interval"
+            );
+        }
+
+        // Above threshold: exponential backoff, capped at MAX_KEEPALIVE_INTERVAL
+        let expected = [
+            (1, Duration::from_secs(10)),  // 5s * 2^1
+            (2, Duration::from_secs(20)),  // 5s * 2^2
+            (3, Duration::from_secs(40)),  // 5s * 2^3
+            (4, MAX_KEEPALIVE_INTERVAL),   // 5s * 2^4 = 80s, capped at 60s
+            (100, MAX_KEEPALIVE_INTERVAL), // far beyond threshold, still capped
+        ];
+        for (above, interval) in expected {
+            assert_eq!(
+                keepalive_interval_for_pending(MAX_UNANSWERED_PINGS + above),
+                interval,
+                "pending_count={} should produce {:?}",
+                MAX_UNANSWERED_PINGS + above,
+                interval,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

Peers send keepalive pings every 5 seconds to offline nodes indefinitely (5+ hours observed, reported by Ivvor on Matrix). The cycle is:

1. Connection established → keepalive pings every 5s (no backoff when unanswered)
2. 120s idle timeout fires → connection closed
3. `connection_maintenance` triggers reconnection (dead peer still in routing tables, no per-peer backoff recorded)
4. Goto 1

Two interacting gaps cause this:
- **Keepalive has zero backoff**: The keepalive task sends pings unconditionally every 5 seconds regardless of how many go unanswered
- **No backoff after idle-timeout closure**: When a connection dies from the 120s idle timeout, no per-peer backoff is recorded, so reconnection happens immediately

Additionally, ICMP port unreachable from the dead host is invisible — Linux silently discards ICMP errors for `send_to()` on unconnected UDP sockets.

## Approach

### 1. Keepalive backoff (`peer_connection.rs`)

Replace the fixed `TimeSourceInterval` with a dynamic sleep. After `MAX_UNANSWERED_PINGS` (5) consecutive unanswered pings, the interval doubles exponentially:

- 5s → 10s → 20s → 40s → 60s (cap)

This reduces bandwidth waste during the 120s idle timeout window. The backoff calculation is extracted into `keepalive_interval_for_pending()` for testability.

### 2. Per-peer backoff on transport closure (`p2p_protoc.rs`)

When `handle_transport_event` processes a `TransportClosed` event, it now calls `state.peer_backoff.record_failure(remote_addr)`. This is checked in `handle_connect_peer` before initiating new connections, preventing immediate reconnection to the same dead peer.

The existing `PeerConnectionBackoff` provides exponential backoff (30s → 60s → 120s → 240s → 600s cap), and `record_success()` clears it when the peer comes back online.

### 3. Clear backoff on inbound connections

When a peer connects inbound to us, it's demonstrably alive — any existing backoff for that peer is cleared via `record_success()`. This prevents the scenario where a peer has backoff recorded from a previous closure but is actually reachable (it connected to us).

### Note on isolation recovery (issue point C)

The issue mentions that `reset_all_backoff()` in isolation recovery could undermine per-peer backoff. This is naturally addressed by the architecture: `peer_backoff` lives in `EventListenerState` (event loop scope), while `reset_all_backoff()` runs in `connection_maintenance` (Ring scope) and only clears location-based and gateway-specific backoff. The per-peer backoff survives isolation recovery without any additional changes.

## Testing

- Unit test `keepalive_interval_backs_off_for_unanswered_pings` validates the interval calculation at all boundary conditions (at threshold, above threshold, at cap, far beyond cap)
- The per-peer backoff uses the existing `PeerConnectionBackoff` infrastructure which is already tested
- `cargo fmt && cargo clippy --all-targets && cargo test` all pass

## Fixes

Closes #3252

[AI-assisted - Claude]