### PR TITLE
fix: detect and diagnose ring/transport connection desync

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -714,14 +714,26 @@ impl P2pConnManager {
             // Periodic stats logging
             if last_stats_log.elapsed() > STATS_LOG_INTERVAL {
                 let notifier = &op_manager.to_event_listener;
+                let transport_connections = ctx.connections.len();
+                let ring_connections = op_manager.ring.connection_manager.connection_count();
                 tracing::info!(
                     iterations = loop_iteration_count,
                     slow_events = slow_event_count,
                     notification_channel_pending = notifier.notification_channel_pending(),
                     notification_channel_capacity = notifier.notifications_sender.capacity(),
-                    active_connections = ctx.connections.len(),
+                    active_connections = transport_connections,
+                    ring_connections,
                     "Event loop stats"
                 );
+                // Detect transport/ring divergence: transport has connections but ring doesn't
+                if transport_connections > 0 && ring_connections == 0 {
+                    tracing::error!(
+                        transport_connections,
+                        ring_connections,
+                        "RING_TRANSPORT_DESYNC: transport has connections but ring topology is empty - \
+                         connections are not being promoted or are being immediately pruned"
+                    );
+                }
 
                 #[cfg(all(unix, feature = "jemalloc-prof"))]
                 {

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -715,13 +715,15 @@ impl ConnectionManager {
         None
     }
 
+    /// Add a connection to the ring topology. Returns `true` if the connection
+    /// was actually inserted, `false` if it was rejected (e.g., capacity cap).
     pub fn add_connection(
         &self,
         loc: Location,
         addr: SocketAddr,
         pub_key: TransportPublicKey,
         was_reserved: bool,
-    ) {
+    ) -> bool {
         tracing::info!(
             addr = %addr,
             peer_location = %loc,
@@ -750,7 +752,7 @@ impl ConnectionManager {
             if was_reserved {
                 self.pending_reservations.write().remove(&addr);
             }
-            return;
+            return false;
         }
 
         if let Some(prev_loc) = previous_location {
@@ -778,13 +780,34 @@ impl ConnectionManager {
             let mut cbl = self.connections_by_location.write();
             cbl.entry(loc)
                 .or_default()
-                .push(Connection::new(PeerKeyLocation::new(pub_key, addr)));
+                .push(Connection::new(PeerKeyLocation::new(pub_key.clone(), addr)));
+        }
+
+        // Verify the insertion actually persisted — detect silent state corruption.
+        let count_after = self.connection_count();
+        let in_location_map = self.location_for_peer.read().contains_key(&addr);
+        if !in_location_map || count_after == 0 {
+            tracing::error!(
+                addr = %addr,
+                peer_location = %loc,
+                connection_count = count_after,
+                in_location_map,
+                "add_connection: INVARIANT VIOLATION - connection not found after insertion"
+            );
+        } else {
+            tracing::info!(
+                addr = %addr,
+                peer_location = %loc,
+                connection_count = count_after,
+                "add_connection: successfully added to ring"
+            );
         }
 
         // Remove from transient connections if present, since we're now a full ring connection.
         if self.transient_connections.remove(&addr).is_some() {
             self.transient_in_use.fetch_sub(1, Ordering::SeqCst);
         }
+        true
     }
 
     pub fn update_peer_identity(

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -1224,6 +1224,8 @@ impl Ring {
     ///
     /// Returns `true` if this connection caused us to cross the readiness threshold
     /// (i.e., we just became ready to accept non-CONNECT operations).
+    /// Returns `false` if the connection was rejected (e.g., capacity cap) or we
+    /// were already ready.
     pub async fn add_connection(&self, loc: Location, peer: PeerId, was_reserved: bool) -> bool {
         tracing::info!(
             peer = %peer,
@@ -1237,8 +1239,17 @@ impl Ring {
 
         let addr = peer.addr;
         let pub_key = peer.pub_key.clone();
-        self.connection_manager
+        let added = self
+            .connection_manager
             .add_connection(loc, addr, pub_key, was_reserved);
+        if !added {
+            tracing::warn!(
+                peer = %peer,
+                peer_location = %loc,
+                "Ring rejected connection - not updating caches or logging connection event"
+            );
+            return false;
+        }
         if let Some(own_loc) = self.connection_manager.own_location().location() {
             crate::node::network_status::set_own_location(own_loc.as_f64());
         }


### PR DESCRIPTION
## Problem

Both production gateways (nova and vega) entered a state where the ring topology reported `current_connections=0` despite the transport layer having 80-123 active connections. This caused a **16+ hour total network outage** on Feb 24, 2026.

Key evidence from vega gateway logs:
- **15 successful `add_connection()` calls** to `ConnectionManager` — zero rejections logged
- **17 `"promoted to ring"` log messages** from `handle_connect_peer`
- But `connection_count()` always returned **0** — ring topology remained empty
- `connection_maintenance` continuously logged "Node isolated with zero ring connections"

The connections were apparently being added and then silently lost, with no error or rejection log to indicate what happened.

## Solution

This PR adds diagnostic instrumentation to detect and diagnose the root cause on the next occurrence:

1. **`ConnectionManager::add_connection()` now returns `bool`** — `true` if the connection was persisted, `false` if rejected by the capacity cap. Previously returned `()`, so callers couldn't detect silent rejections.

2. **`Ring::add_connection()` respects the return value** — when the underlying add is rejected, it skips cache updates, event logging, and density refresh. Previously it unconditionally proceeded as if the connection was added.

3. **Post-insertion invariant check** — after inserting into `connections_by_location`, we verify the entry exists in both `location_for_peer` and `connections_by_location`. If not, an ERROR-level `INVARIANT VIOLATION` is logged immediately.

4. **Transport/ring divergence detection** — the event loop stats (logged every 30s) now include `ring_connections` alongside `active_connections`, and log an ERROR-level `RING_TRANSPORT_DESYNC` alert when transport has connections but ring is empty.

## Testing

- `cargo build -p freenet` — compiles cleanly
- `cargo test -p freenet` — all tests pass
- `cargo fmt` / `cargo clippy` — no new warnings from changed code

The invariant check and desync detection will trigger on the next occurrence in production, giving us the data to identify whether connections are being immediately pruned, silently dropped by a concurrent operation, or lost through some other mechanism.

## Fixes

Closes #3253

[AI-assisted - Claude]