### PR TITLE
fix: prevent bootstrap loop stall from orphaned location_for_peer entries

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1492,6 +1492,14 @@ impl Operation for ConnectOp {
                                             "connect ConnectPeer failed"
                                         );
                                     }
+                                } else {
+                                    tracing::warn!(
+                                        tx=%self.id,
+                                        acceptor = %new_acceptor.peer,
+                                        elapsed_ms = self.id.elapsed().as_millis(),
+                                        "ConnectPeer callback channel closed without result; \
+                                         peer promotion may not have completed"
+                                    );
                                 }
                             }
 
@@ -1880,12 +1888,21 @@ pub(crate) async fn join_ring_request(
         "Attempting network connect"
     );
 
-    op_manager
+    if let Err(e) = op_manager
         .notify_op_change(
             NetMessage::V1(NetMessageV1::Connect(msg)),
             OpEnum::Connect(Box::new(op)),
         )
-        .await?;
+        .await
+    {
+        // Clean up the reservation that should_accept() created, so the bootstrap
+        // loop doesn't think this gateway is still "connected/pending" (#3244).
+        op_manager
+            .ring
+            .connection_manager
+            .prune_in_transit_connection(gateway_addr);
+        return Err(e);
+    }
 
     Ok(())
 }

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -992,8 +992,21 @@ impl ConnectionManager {
     }
 
     pub fn has_connection_or_pending(&self, addr: SocketAddr) -> bool {
-        if self.location_for_peer.read().contains_key(&addr) {
-            return true;
+        if let Some(loc) = self.location_for_peer.read().get(&addr).copied() {
+            // Verify the location_for_peer entry has a backing established connection.
+            // Without this check, stale entries from failed connect operations block the
+            // bootstrap loop from retrying gateways (#3244).
+            let has_established = self
+                .connections_by_location
+                .read()
+                .get(&loc)
+                .is_some_and(|conns| conns.iter().any(|c| c.location.socket_addr() == Some(addr)));
+            if has_established {
+                return true;
+            }
+            // No established connection — fall through to check pending reservations.
+            // The location_for_peer entry is orphaned and will be cleaned up by
+            // cleanup_stale_reservations().
         }
         let pending = self.pending_reservations.read();
         if let Some((_loc, created)) = pending.get(&addr) {
@@ -2248,6 +2261,47 @@ mod tests {
         // The established connection should be untouched
         assert!(cm.has_connection_or_pending(existing_addr));
         assert_eq!(cm.connection_count(), 1);
+    }
+
+    /// Regression test for #3244: has_connection_or_pending should return false for
+    /// orphaned location_for_peer entries IMMEDIATELY — without waiting for
+    /// cleanup_stale_reservations to run. The previous behavior caused the bootstrap
+    /// loop to stall for up to 65 seconds because it thought all gateways were
+    /// "connected/pending" when they actually had only stale location_for_peer entries.
+    #[test]
+    fn test_has_connection_or_pending_ignores_orphaned_location() {
+        let cm = make_connection_manager(Some(make_addr(8000)), 5, 20, false);
+        let keypair = TransportKeypair::new();
+        let existing_addr = make_addr(8001);
+        let orphan_addr = make_addr(8002);
+        let orphan_loc = Location::new(0.5);
+
+        // Establish one real connection so open > 0
+        cm.add_connection(
+            Location::new(0.1),
+            existing_addr,
+            keypair.public().clone(),
+            false,
+        );
+
+        // should_accept with open > 0 creates entries in both data structures
+        assert!(cm.should_accept(orphan_loc, orphan_addr));
+
+        // Expire the pending reservation (simulates connect timeout)
+        age_reservation(&cm, orphan_addr, Duration::from_secs(120));
+
+        // The orphaned location_for_peer entry still exists...
+        assert!(cm.location_for_peer.read().contains_key(&orphan_addr));
+        // ...but has_connection_or_pending should return false because there's
+        // no established connection backing it (the fix for #3244).
+        assert!(
+            !cm.has_connection_or_pending(orphan_addr),
+            "has_connection_or_pending should return false for orphaned location_for_peer \
+             entries without established connections (#3244)"
+        );
+
+        // Established connection should still be visible
+        assert!(cm.has_connection_or_pending(existing_addr));
     }
 
     /// Verify that cleanup_stale_reservations does NOT remove location_for_peer


### PR DESCRIPTION
## Problem

After a transport connection to a gateway succeeds but the CONNECT operation fails to complete (times out, callback channel closes, etc.), the node's bootstrap loop stalls. It logs "all gateways appear connected/pending" with `open_conns=0` indefinitely, preventing the node from retrying gateway connections for up to 65 seconds.

**Root cause:** `has_connection_or_pending()` checked `location_for_peer` entries without verifying they had a backing established connection. When `should_accept()` creates entries in both `pending_reservations` (60s TTL) and `location_for_peer` (no TTL), and the connect operation fails, the `location_for_peer` entry persists as an orphan. `has_connection_or_pending()` returns true for this orphan, causing `is_not_connected()` to filter out the gateway, so the bootstrap loop thinks all gateways are connected when none actually are.

## Solution

Three targeted changes:

1. **`has_connection_or_pending()`** now verifies that `location_for_peer` entries have a backing connection in `connections_by_location` before returning true. Orphaned entries (no established connection, no valid pending reservation) are correctly reported as not connected, allowing immediate retry.

2. **`join_ring_request()`** now cleans up the reservation created by `should_accept()` if `notify_op_change()` fails, preventing stale entries from accumulating on the error path.

3. **ConnectPeer callback** now logs a warning when the callback channel closes without delivering a result (the `rx.recv().await` returning `None` case), improving debuggability for similar issues.

## Testing

- All 64 `connection_manager` unit tests pass
- New regression test `test_has_connection_or_pending_ignores_orphaned_location` validates the fix: creates an orphaned `location_for_peer` entry (expired reservation, no established connection) and asserts `has_connection_or_pending()` returns false immediately without needing cleanup
- All 285 connect-related tests pass
- Integration tests pass (`test_basic_gateway_connectivity`, `test_three_node_network_connectivity`, etc.)

## Fixes

Closes #3244

[AI-assisted - Claude]