### PR TITLE
fix: disable auto-update for dirty (source-modified) builds

### DIFF
--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -192,9 +192,23 @@ async fn run_network_node_with_signals(
     //   1. Reset backoff on fresh mismatch (prevents stale disk state)
     //   2. Exit code 42 at max backoff + 0 connections (trusts gateway signal)
     //   3. Hard timeout: 6h isolated with mismatch forces exit regardless
+    //   4. Disabled for dirty builds — `freenet update` replaces the binary with a
+    //      prebuilt release, which would discard local modifications (#3245)
     let (update_tx, mut update_rx) = tokio::sync::oneshot::channel::<String>();
+    let auto_update_disabled = !build_info::GIT_DIRTY.is_empty();
     let update_check_task = GlobalExecutor::spawn(async move {
         use std::time::Instant;
+
+        if auto_update_disabled {
+            tracing::info!(
+                git_dirty = build_info::GIT_DIRTY,
+                "Auto-update disabled: this is a dirty (locally modified) build. \
+                 Run `freenet update` manually if needed."
+            );
+            // Don't exit — just sit idle forever so the oneshot channel stays open
+            std::future::pending::<()>().await;
+            return;
+        }
 
         const HARD_EXIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6 * 3600);
 


### PR DESCRIPTION
## Problem

When a user builds Freenet from source with local modifications, the auto-update mechanism still triggers on version mismatch. `freenet update` downloads a prebuilt release binary from GitHub, silently discarding the user's local changes. The user then has to manually rebuild from source.

This was observed in diagnostic report FPKSGQ: the node detected a version mismatch (0.1.147 vs gateway's 0.1.148), exited for auto-update, but the update either failed or replaced the source build, causing confusion.

## Solution

Check `GIT_DIRTY` (set at build time by build.rs) when the auto-update monitor task starts. If the build has local modifications (non-empty `GIT_DIRTY`), log an info message and sit idle rather than monitoring for version mismatches. The oneshot channel stays open to prevent the select! in the caller from triggering prematurely.

Users with dirty builds can still run `freenet update` manually when they choose to.

## Testing

- All 5 `auto_update` unit tests pass
- Build succeeds with no new clippy warnings
- The change is a simple early-return guard in the async task, with no impact on other code paths

## Fixes

Closes #3245

[AI-assisted - Claude]