### PR TITLE
fix: dashboard subscribed contracts last update always blank

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -1448,6 +1448,9 @@ where
             "Contract state updated"
         );
 
+        // Record update timestamp for dashboard display
+        crate::node::network_status::record_contract_updated(&format!("{key}"));
+
         if let Err(err) = self
             .send_update_notification(key, parameters, new_state)
             .await

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1768,7 +1768,8 @@ async fn deliver_update_result(
     };
 
     let host_result = op.to_host_result();
-    crate::node::network_status::record_contract_updated(&format!("{key}"));
+    // Note: record_contract_updated is called in commit_state_update (the single
+    // chokepoint for all state updates), so we don't call it here to avoid double-counting.
 
     op_manager
         .result_router_tx


### PR DESCRIPTION
## Problem

The "Last Update" column for subscribed contracts on the dashboard always shows a dash, despite active updates arriving via River UI.

## Root Cause

`record_contract_updated()` was only called from `deliver_update_result()` in `operations/update.rs` — the originator path when a node initiates an update locally. When a node *receives* an update from the network, all four receiver code paths (`RequestUpdate`, `BroadcastTo`, `BroadcastToStreaming` full state, `BroadcastToStreaming` streaming) set `new_state = None`, completing the operation via `OperationResult::Completed` without ever reaching `deliver_update_result`.

## Approach

Move the `record_contract_updated()` call to `commit_state_update()` in the contract executor (`contract/executor/runtime.rs`). This is the single chokepoint where **all** state updates are applied — both originated and received — making it impossible to miss a path. Remove the now-redundant call from `deliver_update_result()` to avoid double-counting.

This is a 1-line addition + 1-line removal (replaced with comment explaining why the old call was removed).

## Testing

- All 1628 lib tests pass
- Existing `test_subscription_tracking` in `network_status.rs` validates that `record_contract_updated` correctly sets the timestamp
- This was a wiring bug (missing call site), not a logic bug — the function worked correctly, it just wasn't being called from the receiver path

## Verification

After deploy: subscribe to a River room on the dashboard, send messages from another peer, verify "Last Update" column shows a recent timestamp.

[AI-assisted - Claude]