### PR TITLE
fix: address review items from upstream Unsubscribe PR (#3143)

### DIFF
--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.1.149"
+version = "0.1.151"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -30,7 +30,7 @@
 mod cache;
 
 use crate::util::backoff::{ExponentialBackoff, TrackedBackoff};
-use crate::util::time_source::InstantTimeSrc;
+use crate::util::time_source::{InstantTimeSrc, TimeSource};
 pub use cache::{AccessType, RecordAccessResult};
 use cache::{HostingCache, DEFAULT_HOSTING_BUDGET_BYTES, DEFAULT_MIN_TTL};
 use dashmap::{DashMap, DashSet};
@@ -137,9 +137,15 @@ pub(crate) struct HostingManager {
     /// This is the single source of truth for which contracts we're hosting.
     hosting_cache: RwLock<HostingCache<InstantTimeSrc>>,
 
-    /// Downstream peers subscribed to contracts we host.
-    /// Used to determine when it's safe to unsubscribe upstream.
+    /// Downstream peers subscribed to contracts we host, with lease timestamps.
+    /// Drives `should_unsubscribe_upstream()` decisions.
+    ///
+    /// Must be kept in sync with `InterestManager::interested_peers`
+    /// (see `InterestManager` docs for the dual-tracking relationship).
     downstream_subscribers: DashMap<ContractKey, HashMap<PeerKey, Instant>>,
+
+    /// Time source for downstream subscriber lease tracking.
+    time_source: InstantTimeSrc,
 
     /// Contracts with subscription requests currently in-flight.
     pending_subscription_requests: DashSet<ContractKey>,
@@ -168,6 +174,7 @@ impl HostingManager {
                 InstantTimeSrc::new(),
             )),
             downstream_subscribers: DashMap::new(),
+            time_source: InstantTimeSrc::new(),
             pending_subscription_requests: DashSet::new(),
             subscription_backoff: RwLock::new(TrackedBackoff::new(
                 backoff_config,
@@ -415,7 +422,7 @@ impl HostingManager {
         self.downstream_subscribers
             .entry(*contract)
             .or_default()
-            .insert(peer, Instant::now());
+            .insert(peer, self.time_source.now());
     }
 
     /// Renew a downstream peer's subscription lease.
@@ -424,7 +431,7 @@ impl HostingManager {
     pub fn renew_downstream_subscriber(&self, contract: &ContractKey, peer: &PeerKey) -> bool {
         if let Some(mut peers) = self.downstream_subscribers.get_mut(contract) {
             if peers.contains_key(peer) {
-                peers.insert(peer.clone(), Instant::now());
+                peers.insert(peer.clone(), self.time_source.now());
                 return true;
             }
         }
@@ -456,7 +463,7 @@ impl HostingManager {
     /// Remove downstream subscribers whose leases have expired.
     /// Returns the contracts that lost all downstream subscribers.
     pub fn expire_stale_downstream_subscribers(&self) -> Vec<ContractKey> {
-        let now = Instant::now();
+        let now = self.time_source.now();
         let mut fully_unsubscribed = Vec::new();
 
         let keys: Vec<ContractKey> = self
@@ -1706,5 +1713,82 @@ mod tests {
             !manager.should_unsubscribe_upstream(&contract),
             "Contract with remaining downstream should NOT trigger unsubscribe"
         );
+    }
+
+    // =========================================================================
+    // Unsubscribe Handler Logic Tests
+    // =========================================================================
+
+    fn make_interest_manager() -> crate::ring::interest::InterestManager<InstantTimeSrc> {
+        crate::ring::interest::InterestManager::new(InstantTimeSrc::new())
+    }
+
+    /// Contract found + peer resolved → removes both tracking structures,
+    /// triggers upstream unsubscribe propagation.
+    #[test]
+    fn test_unsubscribe_handler_contract_found_peer_resolved() {
+        let manager = HostingManager::new();
+        let interest = make_interest_manager();
+        let contract = make_contract_key(1);
+        let peer = make_peer_key(10);
+
+        manager.add_downstream_subscriber(&contract, peer.clone());
+        interest.register_peer_interest(&contract, peer.clone(), None, true);
+        assert!(!manager.should_unsubscribe_upstream(&contract));
+
+        manager.remove_downstream_subscriber(&contract, &peer);
+        interest.remove_peer_interest(&contract, &peer);
+
+        assert!(!manager.has_downstream_subscribers(&contract));
+        assert!(manager.should_unsubscribe_upstream(&contract));
+    }
+
+    /// Removing an unknown peer is a noop; existing entries remain intact.
+    #[test]
+    fn test_unsubscribe_handler_unknown_peer_is_noop() {
+        let manager = HostingManager::new();
+        let contract = make_contract_key(2);
+        let known_peer = make_peer_key(20);
+        let unknown_peer = make_peer_key(99);
+
+        manager.add_downstream_subscriber(&contract, known_peer.clone());
+
+        assert!(!manager.remove_downstream_subscriber(&contract, &unknown_peer));
+        assert!(manager.has_downstream_subscribers(&contract));
+        assert!(!manager.should_unsubscribe_upstream(&contract));
+    }
+
+    /// Removing from an untracked contract is a noop; other contracts unaffected.
+    #[test]
+    fn test_unsubscribe_handler_unknown_contract_is_noop() {
+        let manager = HostingManager::new();
+        let known_contract = make_contract_key(3);
+        let unknown_contract = make_contract_key(99);
+        let peer = make_peer_key(30);
+
+        manager.add_downstream_subscriber(&known_contract, peer.clone());
+
+        assert!(!manager.remove_downstream_subscriber(&unknown_contract, &peer));
+        assert!(manager.has_downstream_subscribers(&known_contract));
+        assert!(!manager.has_downstream_subscribers(&unknown_contract));
+    }
+
+    /// `downstream_subscribers` is authoritative for unsubscribe decisions,
+    /// independent of `InterestManager` state.
+    #[test]
+    fn test_unsubscribe_dual_tracking_authority() {
+        let manager = HostingManager::new();
+        let interest = make_interest_manager();
+        let contract = make_contract_key(4);
+        let peer = make_peer_key(40);
+
+        manager.add_downstream_subscriber(&contract, peer.clone());
+        interest.register_peer_interest(&contract, peer.clone(), None, true);
+
+        manager.remove_downstream_subscriber(&contract, &peer);
+
+        assert!(manager.should_unsubscribe_upstream(&contract));
+        // InterestManager still tracks the peer — independent of unsubscribe decision
+        assert!(interest.remove_peer_interest(&contract, &peer));
     }
 }

--- a/crates/core/src/ring/interest.rs
+++ b/crates/core/src/ring/interest.rs
@@ -244,6 +244,12 @@ pub fn is_delta_efficient(summary_size: usize, state_size: usize) -> bool {
 /// It unifies what was previously split between the subscription tree and proximity cache.
 ///
 /// Generic over `T: TimeSource` to support deterministic simulation testing.
+///
+/// **Dual-tracking with `HostingManager::downstream_subscribers`:** both must be
+/// kept in sync during register/remove operations. This manager drives UPDATE
+/// broadcast targeting and upstream peer lookup; `downstream_subscribers` drives
+/// unsubscribe-upstream decisions. See the Unsubscribe handler in
+/// `operations/subscribe.rs` for the sync point.
 pub struct InterestManager<T: TimeSource> {
     /// Track interested peers and their summaries for each contract.
     /// Key: ContractKey, Value: Map of PeerKey -> PeerInterest


### PR DESCRIPTION
## Problem

PR #3143 introduced upstream Unsubscribe message propagation but left several follow-up items tracked in #3216:

1. `HostingManager` uses `Instant::now()` directly instead of the `TimeSource` abstraction required for deterministic simulation testing (DST).
2. No unit tests covering the 3 Unsubscribe handler scenarios (contract+peer found, peer unresolved, contract not found).
3. The dual-tracking relationship between `HostingManager::downstream_subscribers` and `InterestManager::interested_peers` is undocumented — making it easy for future changes to desync them.

## Solution

### TimeSource adoption in HostingManager

Added a `time_source: InstantTimeSrc` field to `HostingManager` and replaced all 3 `Instant::now()` calls in downstream subscriber methods with `self.time_source.now()`:
- `add_downstream_subscriber`
- `renew_downstream_subscriber`
- `expire_stale_downstream_subscribers`

This aligns `HostingManager` with the DST pattern already used by `HostingCache<T: TimeSource>` and `InterestManager<T: TimeSource>` in the same module.

### Unit tests for Unsubscribe handler logic

The issue requests testing the `process_message` Unsubscribe handler "through a mock `OpManager`". Direct `process_message` testing was evaluated but is not feasible without significant infrastructure changes: `OpManager` is a concrete struct (not trait-based), `Ring::new` spawns 5+ background tasks, and `has_contract` requires a live async channel responder. No mock or test constructor for `OpManager` exists anywhere in the codebase.

Instead, added 4 component-level tests in `hosting.rs` that cover the 3 cases requested in the issue, plus one additional test for the dual-tracking design contract:

| Issue case | Test | What it validates |
|------------|------|-------------------|
| Contract found + peer resolved | `test_unsubscribe_handler_contract_found_peer_resolved` | Removes peer from both `HostingManager` and `InterestManager`, verifies `should_unsubscribe_upstream` triggers |
| Peer unresolved → skips removal | `test_unsubscribe_handler_unknown_peer_is_noop` | Removing an unknown peer leaves existing entries intact |
| Contract not found → silently ignored | `test_unsubscribe_handler_unknown_contract_is_noop` | Removing from an untracked contract is a safe noop |
| *(additional)* | `test_unsubscribe_dual_tracking_authority` | `downstream_subscribers` is authoritative for unsubscribe decisions, independent of `InterestManager` state |

### Dual-tracking documentation

Added doc comments documenting the sync contract between the two tracking structures:
- `HostingManager::downstream_subscribers` — notes it drives `should_unsubscribe_upstream()` decisions and must be kept in sync with `InterestManager`
- `InterestManager` struct docs — explains the dual-tracking relationship, which manager drives what, and where the sync point lives (`operations/subscribe.rs`)

## Fixes

Closes #3216