### PR TITLE
fix: add explicit github_token to Claude workflows to bypass OIDC auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -151,6 +151,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--model sonnet --max-turns 25 --effort high'
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }}: "${{ github.event.pull_request.title }}"
@@ -233,6 +234,44 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const marker = '<!-- claude-rule-review -->';
+            const reviewOutcome = '${{ steps.review.outcome }}';
+
+            // If Claude step failed, post a warning instead of silently doing nothing
+            if (reviewOutcome === 'failure') {
+              const warningBody = marker + '\n' +
+                '### ⚠️ Claude Rule Review: Failed to run\n\n' +
+                'The Claude rule review step failed (likely an authentication or API issue). ' +
+                'Check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.\n\n' +
+                '---\n*Automated review against `.claude/rules/`. Advisory only — does not block merge.*';
+
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+
+              const existing = comments.find(c => c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: warningBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: warningBody,
+                });
+              }
+              core.warning('Claude rule review failed — warning comment posted on PR');
+              return;
+            }
+
             const execFile = '${{ steps.review.outputs.execution_file }}' || '/home/runner/work/_temp/claude-execution-output.json';
 
             // Read Claude's output — the file is a JSON array of Turn objects
@@ -265,7 +304,6 @@ jobs:
             const body = report + '\n\n---\n*Automated review against `.claude/rules/`. Advisory only — does not block merge.*';
 
             // Find and update existing sticky comment, or create new one
-            const marker = '<!-- claude-rule-review -->';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
@@ -62,4 +63,3 @@ jobs:
           #   - Push commits (git push, git push --force-with-lease)
           #   - Update PRs (gh pr edit, gh pr review, gh pr merge)
           #   - Comment on issues and PRs (gh issue comment, gh pr comment)
-


### PR DESCRIPTION
## Problem

All Claude workflow actions (`claude-pr-review.yml`, `claude.yml`, `ci.yml`) have been silently failing since at least 2026-02-25. The `claude-code-action@v1` attempts OIDC token exchange for GitHub App authentication, but `ACTIONS_ID_TOKEN_REQUEST_URL` is unavailable despite `id-token: write` being set. This is a [known upstream issue](https://github.com/anthropics/claude-code-action/issues/649).

The `continue-on-error: true` on the review step masked the failure completely — no comment was posted and the job showed as "success".

## Solution

- Add explicit `github_token: ${{ secrets.GITHUB_TOKEN }}` to all three Claude workflow steps, which bypasses the OIDC flow entirely
- When the Claude review step fails, post a visible warning comment on the PR with a link to the workflow logs instead of silently doing nothing

Trade-off: comments will appear from `github-actions[bot]` instead of `claude[bot]`.

## Testing

- The PR itself will exercise the `claude-pr-review.yml` workflow — the rule review should now succeed and post a comment
- Verified the OIDC error in logs of recent runs: `22445443420` (PR #3282), `22431405965` (PR #3280), `22431322523` (PR #3280)

## Fixes

Fixes silent Claude review failures on all PRs since ~2026-02-25.