### PR TITLE
fix: dashboard dark mode respects OS prefers-color-scheme

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -856,13 +856,20 @@ p:last-child { margin-bottom: 0; }
 /// and so toggleTheme() is reachable from the button's onclick attribute.
 /// The page auto-refreshes every 5 s, so restoring the saved theme before
 /// render is essential to avoid a flash of the wrong theme on each refresh.
+/// Theme priority: localStorage override > OS prefers-color-scheme > light.
 const JS: &str = r##"
 (function() {
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     try {
-        if (localStorage.getItem('theme') === 'dark') {
+        var saved = localStorage.getItem('theme');
+        if (saved === 'dark' || (saved === null && prefersDark)) {
             document.documentElement.setAttribute('data-theme', 'dark');
         }
-    } catch (e) { /* localStorage unavailable (e.g. private browsing) */ }
+    } catch (e) {
+        if (prefersDark) {
+            document.documentElement.setAttribute('data-theme', 'dark');
+        }
+    }
 })();
 
 function toggleTheme() {
@@ -871,7 +878,7 @@ function toggleTheme() {
     if (isDark) {
         document.documentElement.removeAttribute('data-theme');
         if (icon) icon.textContent = '\uD83C\uDF19'; /* moon */
-        try { localStorage.removeItem('theme'); } catch (e) {}
+        try { localStorage.setItem('theme', 'light'); } catch (e) {}
     } else {
         document.documentElement.setAttribute('data-theme', 'dark');
         if (icon) icon.textContent = '\u2600\uFE0F'; /* sun */


### PR DESCRIPTION
## Problem

The peer dashboard's dark mode only checks `localStorage` for a saved preference, defaulting to light mode for new visitors regardless of their OS setting. Users with dark OS themes see a bright white dashboard until they manually toggle.

## Approach

Use `window.matchMedia('(prefers-color-scheme: dark)')` as the fallback when no user preference is saved in localStorage. Priority chain: saved preference > OS preference > light.

Also changed the toggle to save `'light'` explicitly (instead of removing the key) so that a user who manually switches to light mode on a dark OS doesn't get reverted back to dark on next page load.

## Testing

- `cargo test -p freenet --lib -- server::home_page` — all 10 tests pass
- Manual verification: the JS logic correctly handles all cases:
  - No saved pref + dark OS → dark mode
  - No saved pref + light OS → light mode  
  - Saved `'dark'` → dark mode (regardless of OS)
  - Saved `'light'` → light mode (regardless of OS)
  - Private browsing (localStorage throws) + dark OS → dark mode

[AI-assisted - Claude]