### PR TITLE
fix: send subscribe NotFound instead of generic Aborted on forwarding failure

### DIFF
--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -1120,6 +1120,9 @@ where
                     tx_type = ?tx.transaction_type(),
                     "Received Aborted message, delegating to handle_aborted_op"
                 );
+                // Empty gateways: Aborted messages arrive over p2p connections, not
+                // from the gateway join path. The gateways list is only used by
+                // Connect retries; other operation types ignore it entirely.
                 if let Err(err) = handle_aborted_op(tx, &op_manager, &[]).await {
                     if !matches!(err, OpError::StatePushed) {
                         tracing::error!(

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -564,6 +564,13 @@ impl SubscribeOp {
     }
 
     /// Build a NotFound result to send back to the requester, or fail locally if we're the originator.
+    ///
+    /// # Information disclosure note
+    /// Before this fix, subscribe failures caused a 60s timeout which provided implicit
+    /// rate limiting on network probing. Instant NotFound responses allow faster contract
+    /// hosting enumeration. The risk is low (contract locations are already somewhat
+    /// predictable from the DHT topology), but future hardening could add jitter or
+    /// rate-limit NotFound responses if probing becomes a practical concern.
     fn not_found_result(
         id: Transaction,
         instance_id: ContractInstanceId,
@@ -601,6 +608,18 @@ impl SubscribeOp {
         }
     }
 
+    /// Check whether this operation should forward a NotFound upstream on abort.
+    fn should_forward_not_found_on_abort(
+        &self,
+    ) -> Option<(ContractInstanceId, std::net::SocketAddr)> {
+        let requester_addr = self.requester_addr?;
+        if let SubscribeState::AwaitingResponse(data) = &self.state {
+            Some((data.instance_id, requester_addr))
+        } else {
+            None
+        }
+    }
+
     /// Handle aborted connections by failing the operation immediately.
     ///
     /// Unlike Get operations, Subscribe doesn't have alternative routes to try.
@@ -613,41 +632,38 @@ impl SubscribeOp {
             "Subscribe operation aborted due to connection failure"
         );
 
-        // If we're an intermediate node, forward NotFound upstream so the
-        // originator gets a fast failure instead of waiting for the 60s timeout.
-        // Mirrors the pattern in GetOp::handle_abort.
-        if let Some(requester_addr) = self.requester_addr {
-            if let SubscribeState::AwaitingResponse(data) = &self.state {
-                let instance_id = data.instance_id;
-                tracing::warn!(
-                    tx = %self.id,
-                    %instance_id,
-                    requester = %requester_addr,
-                    phase = "not_found",
-                    "Subscribe aborted at intermediate node - sending NotFound to upstream"
-                );
+        // Forward NotFound upstream so the originator gets a fast failure instead of
+        // a 60s timeout. Uses notify_op_change because handle_abort lacks NetworkBridge
+        // access; the round-trip through process_message is functionally equivalent.
+        if let Some((instance_id, requester_addr)) = self.should_forward_not_found_on_abort() {
+            tracing::warn!(
+                tx = %self.id,
+                %instance_id,
+                requester = %requester_addr,
+                phase = "not_found",
+                "Subscribe aborted at intermediate node - sending NotFound to upstream"
+            );
 
-                let response_op = SubscribeOp {
-                    id: self.id,
-                    state: SubscribeState::Failed,
-                    requester_addr: self.requester_addr,
-                    requester_pub_key: self.requester_pub_key,
-                    is_renewal: self.is_renewal,
-                    stats: self.stats,
-                };
+            let response_op = SubscribeOp {
+                id: self.id,
+                state: SubscribeState::Failed,
+                requester_addr: self.requester_addr,
+                requester_pub_key: self.requester_pub_key,
+                is_renewal: self.is_renewal,
+                stats: self.stats,
+            };
 
-                op_manager
-                    .notify_op_change(
-                        NetMessage::from(SubscribeMsg::Response {
-                            id: self.id,
-                            instance_id,
-                            result: SubscribeMsgResult::NotFound,
-                        }),
-                        OpEnum::Subscribe(response_op),
-                    )
-                    .await?;
-                return Err(OpError::StatePushed);
-            }
+            op_manager
+                .notify_op_change(
+                    NetMessage::from(SubscribeMsg::Response {
+                        id: self.id,
+                        instance_id,
+                        result: SubscribeMsgResult::NotFound,
+                    }),
+                    OpEnum::Subscribe(response_op),
+                )
+                .await?;
+            return Err(OpError::StatePushed);
         }
 
         if op_manager.is_sub_operation(self.id) {

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -1087,6 +1087,38 @@ fn test_subscribe_renewal_reports_outcome() {
 /// Verify that create_unsubscribe_op produces the correct routing state.
 ///
 /// This is the only non-trivial unit test for the unsubscribe message path:
+/// it validates that the temporary operation created for routing carries the
+/// correct target address so `peek_next_hop_addr` can resolve it.
+#[test]
+fn test_create_unsubscribe_op() {
+    let instance_id = ContractInstanceId::new([77u8; 32]);
+    let tx = Transaction::new::<SubscribeMsg>();
+    let target_addr: SocketAddr = "10.0.0.1:9000".parse().unwrap();
+
+    let op = create_unsubscribe_op(instance_id, tx, target_addr);
+
+    assert_eq!(op.id, tx);
+    assert!(!op.is_renewal);
+
+    match &op.state {
+        SubscribeState::AwaitingResponse(data) => {
+            assert_eq!(data.next_hop, Some(target_addr));
+            assert_eq!(data.instance_id, instance_id);
+        }
+        other @ SubscribeState::PrepareRequest(_)
+        | other @ SubscribeState::Completed(_)
+        | other @ SubscribeState::Failed => {
+            panic!("Expected AwaitingResponse state, got {:?}", other)
+        }
+    }
+
+    assert_eq!(op.get_next_hop_addr(), Some(target_addr));
+}
+
+// =============================================================================
+// NotFound Response Tests (#3241)
+// =============================================================================
+
 /// Regression test for #3241: forwarding peers must send SubscribeMsgResult::NotFound
 /// instead of returning Err(NoCachingPeers) when they can't route a subscribe request.
 ///
@@ -1148,42 +1180,119 @@ fn test_not_found_result_intermediate_node_sends_notfound() {
 /// a fast failure notification.
 #[test]
 fn test_not_found_result_originator_returns_error() {
+    use crate::operations::OpError;
+    use crate::ring::RingError;
+
     let tx = Transaction::new::<SubscribeMsg>();
     let instance_id = ContractInstanceId::new([42u8; 32]);
 
-    // Originator (no requester_addr) should return Err
+    // Originator (no requester_addr) should return Err(RingError::NoCachingPeers)
     let result = SubscribeOp::not_found_result(tx, instance_id, None, "no closer peers");
 
-    assert!(
-        result.is_err(),
-        "Originator should get an error, not a message"
-    );
+    match result {
+        Err(OpError::RingError(RingError::NoCachingPeers(id))) => {
+            assert_eq!(
+                id, instance_id,
+                "Error should reference the correct contract"
+            );
+        }
+        Err(other) => panic!("Expected NoCachingPeers error, got: {other}"),
+        Ok(_) => panic!("Originator should get an error, not a message"),
+    }
 }
 
-/// it validates that the temporary operation created for routing carries the
-/// correct target address so `peek_next_hop_addr` can resolve it.
+/// Verify should_forward_not_found_on_abort state guard: only AwaitingResponse
+/// with a requester_addr triggers the forwarding path. Other states (PrepareRequest,
+/// Failed) and originator ops (no requester_addr) must return None.
 #[test]
-fn test_create_unsubscribe_op() {
-    let instance_id = ContractInstanceId::new([77u8; 32]);
+fn test_should_forward_not_found_on_abort_state_guard() {
     let tx = Transaction::new::<SubscribeMsg>();
-    let target_addr: SocketAddr = "10.0.0.1:9000".parse().unwrap();
+    let instance_id = ContractInstanceId::new([42u8; 32]);
+    let requester: SocketAddr = "10.0.0.1:9000".parse().unwrap();
 
-    let op = create_unsubscribe_op(instance_id, tx, target_addr);
+    // Case 1: PrepareRequest state with requester → should NOT forward
+    let op_prepare = SubscribeOp {
+        id: tx,
+        state: SubscribeState::PrepareRequest(super::PrepareRequestData {
+            id: tx,
+            instance_id,
+            is_renewal: false,
+        }),
+        requester_addr: Some(requester),
+        requester_pub_key: None,
+        is_renewal: false,
+        stats: None,
+    };
+    assert!(
+        op_prepare.should_forward_not_found_on_abort().is_none(),
+        "PrepareRequest state must not trigger forwarding"
+    );
 
-    assert_eq!(op.id, tx);
-    assert!(!op.is_renewal);
+    // Case 2: Failed state with requester → should NOT forward
+    let op_failed = SubscribeOp {
+        id: tx,
+        state: SubscribeState::Failed,
+        requester_addr: Some(requester),
+        requester_pub_key: None,
+        is_renewal: false,
+        stats: None,
+    };
+    assert!(
+        op_failed.should_forward_not_found_on_abort().is_none(),
+        "Failed state must not trigger forwarding"
+    );
 
-    match &op.state {
-        SubscribeState::AwaitingResponse(data) => {
-            assert_eq!(data.next_hop, Some(target_addr));
-            assert_eq!(data.instance_id, instance_id);
-        }
-        other @ SubscribeState::PrepareRequest(_)
-        | other @ SubscribeState::Completed(_)
-        | other @ SubscribeState::Failed => {
-            panic!("Expected AwaitingResponse state, got {:?}", other)
-        }
-    }
+    // Case 3: Completed state with requester → should NOT forward
+    let op_completed = SubscribeOp {
+        id: tx,
+        state: SubscribeState::Completed(super::CompletedData {
+            key: ContractKey::from_id_and_code(instance_id, CodeHash::new([99u8; 32])),
+        }),
+        requester_addr: Some(requester),
+        requester_pub_key: None,
+        is_renewal: false,
+        stats: None,
+    };
+    assert!(
+        op_completed.should_forward_not_found_on_abort().is_none(),
+        "Completed state must not trigger forwarding"
+    );
 
-    assert_eq!(op.get_next_hop_addr(), Some(target_addr));
+    // Case 4: AwaitingResponse with NO requester (originator) → should NOT forward
+    let op_originator = SubscribeOp {
+        id: tx,
+        state: SubscribeState::AwaitingResponse(super::AwaitingResponseData {
+            instance_id,
+            next_hop: None,
+        }),
+        requester_addr: None,
+        requester_pub_key: None,
+        is_renewal: false,
+        stats: None,
+    };
+    assert!(
+        op_originator.should_forward_not_found_on_abort().is_none(),
+        "Originator (no requester_addr) must not trigger forwarding"
+    );
+
+    // Case 5: AwaitingResponse WITH requester → SHOULD forward
+    let op_intermediate = SubscribeOp {
+        id: tx,
+        state: SubscribeState::AwaitingResponse(super::AwaitingResponseData {
+            instance_id,
+            next_hop: None,
+        }),
+        requester_addr: Some(requester),
+        requester_pub_key: None,
+        is_renewal: false,
+        stats: None,
+    };
+    let result = op_intermediate.should_forward_not_found_on_abort();
+    assert!(
+        result.is_some(),
+        "Intermediate node in AwaitingResponse must trigger forwarding"
+    );
+    let (fwd_instance_id, fwd_addr) = result.unwrap();
+    assert_eq!(fwd_instance_id, instance_id);
+    assert_eq!(fwd_addr, requester);
 }


### PR DESCRIPTION
## Problem

When a non-originating peer receives a subscribe request and cannot forward it (HTL exhausted, no closer peers, or no peer address), it returns `Err(RingError::NoCachingPeers)`. This gets caught by `handle_op_result` which sends a generic `NetMessageV1::Aborted(tx_id)` back to the source peer.

The pure network handler then silently drops `Aborted` messages at `node/mod.rs` with `return Ok(None)`, so the failure never propagates back to the originator. The originator's subscribe operation hangs until the 60s TTL timeout.

The `SubscribeMsgResult::NotFound` response path exists and works correctly for upstream propagation, but forwarding peers never use it.

## Approach

**Part 1 — Use NotFound instead of Err for subscribe forwarding failures:**

Added `SubscribeOp::not_found_result()` helper that sends `SubscribeMsg::Response { result: NotFound }` back to `requester_addr` for intermediate nodes, or returns `Err` for the originator. Converted all 3 `NoCachingPeers` error paths to use this helper:
- HTL exhausted (`subscribe.rs:~974`)
- No closer peers in routing table (`subscribe.rs:~998`)
- Selected peer has unknown address (`subscribe.rs:~1019`)

This feeds into the existing NotFound propagation chain (lines 1174+) which already correctly forwards NotFound upstream to the originator.

**Part 2 — Fix silent Aborted drop and enhance handle_abort:**

- Replaced `NetMessageV1::Aborted(_) => return Ok(None)` in `handle_pure_network_message_v1` with delegation to `handle_aborted_op()` — already used in `p2p_protoc.rs` for real network messages, was just missing in the in-memory bridge path.
- Enhanced `SubscribeOp::handle_abort()` to forward NotFound upstream when `requester_addr` is `Some` (intermediate node), mirroring how `GetOp::handle_abort()` already does this. Previously it only handled originator/client notification.

## Testing

- `test_not_found_result_intermediate_node_sends_notfound` — verifies intermediate nodes get `SendAndComplete` with `SubscribeMsgResult::NotFound` routed to the requester
- `test_not_found_result_originator_returns_error` — verifies originators get `Err(NoCachingPeers)` for local failure handling

**Why didn't CI catch this?** The subscribe test suite had no tests covering `process_message` failure paths — all existing tests construct end-states directly. The `not_found_result` unit tests close this gap for the forwarding failure paths.

## Fixes

Closes #3241

[AI-assisted - Claude]