### PR TITLE
fix: exclude already-connected peers from connect visited filter

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1036,11 +1036,20 @@ impl ConnectOp {
 
         // Exclude already-connected peers and recently-failed NAT addresses so routing
         // nodes don't forward back to peers we already have a ring connection with.
+        //
+        // Bloom filter saturation note: VisitedPeers uses a 512-bit filter with k=4 hash
+        // functions. Pre-loading N entries raises the false-positive rate; at typical
+        // network sizes (≤ 20 connections in current deployments) the FP rate is negligible
+        // (~0.01%). At DEFAULT_MAX_CONNECTIONS (200), the rate reaches ~39%, which would
+        // cause routing to occasionally skip reachable peers. This is an accepted trade-off
+        // for current network sizes. If production nodes routinely reach high connection
+        // counts, consider capping pre-populated entries to the N closest connected peers
+        // (since greedy routing preferentially selects nearby peers anyway).
         for addr in exclude_addrs {
             visited.mark_visited(*addr);
         }
         if !exclude_addrs.is_empty() {
-            tracing::info!(
+            tracing::debug!(
                 excluded_addrs = exclude_addrs.len(),
                 "connect: pre-populated visited filter with excluded peer addresses (failed + connected)"
             );
@@ -2147,8 +2156,15 @@ pub(crate) async fn join_ring_request(
         .min(u8::MAX as usize) as u8;
     let target_connections = op_manager.ring.connection_manager.min_connections;
 
-    let mut exclude_addrs = op_manager.ring.connection_manager.recently_failed_addrs();
-    exclude_addrs.extend(op_manager.ring.connection_manager.connected_peer_addrs());
+    let failed_addrs = op_manager.ring.connection_manager.recently_failed_addrs();
+    let connected_addrs = op_manager.ring.connection_manager.connected_peer_addrs();
+    tracing::debug!(
+        failed = failed_addrs.len(),
+        connected = connected_addrs.len(),
+        "connect: pre-populating bloom filter with excluded peer addresses"
+    );
+    let mut exclude_addrs = failed_addrs;
+    exclude_addrs.extend(connected_addrs);
     let (tx, mut op, msg) = ConnectOp::initiate_join_request(
         own.clone(),
         gateway.clone(),

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -1378,7 +1378,13 @@ impl ConnectionManager {
         self.recently_failed_addrs.write().remove(&addr);
     }
 
-    /// Return addresses of all currently established ring connections.
+    /// Return addresses of all peers tracked in `location_for_peer` (established and pending).
+    ///
+    /// `location_for_peer` contains both fully-established ring connections and entries added
+    /// during `should_accept()` for in-progress handshakes. Returning both is intentional:
+    /// excluding pending peers from the bloom filter is conservative but correct — we don't
+    /// want the connect state machine to route a new request to a peer whose handshake is
+    /// still in flight, since that would create a duplicate connection attempt.
     pub fn connected_peer_addrs(&self) -> Vec<SocketAddr> {
         self.location_for_peer.read().keys().copied().collect()
     }

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -2211,8 +2211,15 @@ impl Ring {
         let ttl = self.max_hops_to_live.max(1).min(u8::MAX as usize) as u8;
         let target_connections = self.connection_manager.min_connections;
 
-        let mut exclude_addrs = self.connection_manager.recently_failed_addrs();
-        exclude_addrs.extend(self.connection_manager.connected_peer_addrs());
+        let failed_addrs = self.connection_manager.recently_failed_addrs();
+        let connected_addrs = self.connection_manager.connected_peer_addrs();
+        tracing::debug!(
+            failed = failed_addrs.len(),
+            connected = connected_addrs.len(),
+            "acquire_new: pre-populating bloom filter with excluded peer addresses"
+        );
+        let mut exclude_addrs = failed_addrs;
+        exclude_addrs.extend(connected_addrs);
         let (tx, op, msg) = ConnectOp::initiate_join_request(
             joiner.clone(),
             query_target.clone(),

--- a/crates/core/tests/simulation_smoke.rs
+++ b/crates/core/tests/simulation_smoke.rs
@@ -1056,3 +1056,114 @@ async fn test_stale_reservation_cleanup_frees_capacity() {
     let reserved_after = sim.reserved_connections_count(&gw).unwrap();
     assert!(reserved_after < reserved_before);
 }
+
+// =============================================================================
+// Connection Growth Tests (#3303)
+// =============================================================================
+
+/// Regression test for #3303: nodes must grow ring connections past the initial gateway.
+///
+/// ## The Bug
+/// `initiate_join_request` only excluded recently-failed NAT addresses from the routing
+/// bloom filter. Already-connected ring peers were never excluded. Routing nodes always
+/// forwarded connect requests to the nearest already-connected peer, which then "reused
+/// the existing transport" instead of forming a new ring connection.
+/// The result: `ring_connections` never grew. Observed stuck at 3 for 26+ consecutive
+/// jitter cycles in production.
+///
+/// ## Core Fix Validation
+/// The core fix — pre-populating the bloom filter with already-connected peer addresses —
+/// is validated directly by the unit test `test_initiate_join_request_excludes_connected_peers`
+/// in `operations/connect.rs`. That test verifies the bloom filter IS pre-populated and that
+/// routing candidates correctly exclude already-connected peers.
+///
+/// ## What This Integration Test Checks
+/// With 1 gateway + 5 nodes, after sufficient virtual time every non-gateway node must
+/// have at least 2 ring connections (gateway + at least one other peer). This ensures:
+/// 1. Basic ring connectivity is maintained: each node participates in the DHT.
+/// 2. Connection maintenance successfully grows rings beyond just the initial gateway
+///    connection (every node bootstraps with at least the gateway connection).
+/// 3. The fix does not break the ability of nodes to acquire new connections at all.
+///
+/// ## Scope Note
+/// Testing that nodes reach `min_connections` reliably in simulation is difficult because
+/// `bootstrap_target_locations` (used when connections < 5) always targets a node's own
+/// ring location. In small networks, all peers near that location are often already
+/// connected, so routing terminates at the gateway (which correctly becomes terminus
+/// but is already connected). The production fix is most impactful in larger networks
+/// where diverse non-connected peers exist near any target location.
+#[test_log::test(tokio::test(flavor = "current_thread"))]
+async fn test_connection_growth_past_initial_peers() {
+    use freenet::dev_tool::NodeLabel;
+
+    const SEED: u64 = 0x3303_C0FF_EE01;
+    const NETWORK_NAME: &str = "conn-growth-3303";
+    const MIN_CONNECTIONS: usize = 3;
+    // 1 gateway + 5 nodes = 6 peers total.
+    let mut sim = SimNetwork::new(NETWORK_NAME, 1, 5, 7, 3, 6, MIN_CONNECTIONS, SEED).await;
+    sim.with_start_backoff(Duration::from_millis(50));
+    let _handles = sim
+        .start_with_rand_gen::<rand::rngs::SmallRng>(SEED, 3, 20)
+        .await;
+
+    // Allow enough virtual time for initial bootstrap + several connection-maintenance cycles.
+    // FAST_CHECK_TICK_DURATION = 1s in test mode.
+    let_network_run(&mut sim, Duration::from_secs(60)).await;
+
+    // Every non-gateway node must have at least 2 ring connections (gateway + at least one
+    // more peer). The fix must not break normal connection acquisition; nodes that can grow
+    // beyond the gateway must do so.
+    //
+    // Node labels start at 1 (index 0 is the gateway).
+    for i in 1..=5 {
+        let label = NodeLabel::node(NETWORK_NAME, i);
+        let count = sim.connection_count(&label).unwrap_or(0);
+        assert!(
+            count >= 2,
+            "Node {} has {} connections, expected >= 2 — basic ring connectivity is broken \
+             (each node should connect to gateway + at least one ring peer)",
+            i,
+            count,
+        );
+    }
+}
+
+/// Edge case for #3303: fully-connected small network should work correctly.
+///
+/// When a node is already connected to all available peers in a tiny network
+/// (1 gateway + 2 nodes, max 2 connections each), the bloom filter will eventually
+/// exclude all peers — but this is correct behavior since there is nobody new to
+/// connect to. Verifies that the fix doesn't break operation in the degenerate case
+/// where the exclude list saturates all available peers.
+#[test_log::test(tokio::test(flavor = "current_thread"))]
+async fn test_fully_saturated_small_network() {
+    use freenet::dev_tool::NodeLabel;
+
+    const SEED: u64 = 0x3303_C0FF_EE02;
+    const NETWORK_NAME: &str = "saturation-3303";
+    // Very small: 1 gateway + 2 nodes, min=2. Maximum possible connections per node = 2.
+    let mut sim = SimNetwork::new(NETWORK_NAME, 1, 2, 7, 3, 4, 2, SEED).await;
+    sim.with_start_backoff(Duration::from_millis(50));
+    let _handles = sim
+        .start_with_rand_gen::<rand::rngs::SmallRng>(SEED, 2, 10)
+        .await;
+
+    let_network_run(&mut sim, Duration::from_secs(60)).await;
+
+    // All nodes should be connected to something (connectivity is satisfied even though
+    // the exclude list may contain all available peers once fully connected).
+    let gw = NodeLabel::gateway(NETWORK_NAME, 0);
+    let gw_count = sim.connection_count(&gw).unwrap_or(0);
+    assert!(gw_count >= 1, "Gateway should have at least 1 connection");
+
+    // Node labels start at 1 (index 0 is the gateway).
+    for i in 1..=2 {
+        let label = NodeLabel::node(NETWORK_NAME, i);
+        let count = sim.connection_count(&label).unwrap_or(0);
+        assert!(
+            count >= 1,
+            "Node {} should be connected (got 0) — fix must not break fully-saturated networks",
+            i
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Nodes can get permanently stuck at a low connection count (e.g. 3) despite `target_connections=10`. Every connect cycle runs but makes no progress because all `ConnectResponse` messages route back to the **same already-connected peer**.

Observed in production for 26+ consecutive jitter cycles:
```
active_connections=3 ring_connections=3   # unchanged for 60+ minutes
ConnectResponse acceptor_pub_key=nQEV7NyyXFiFJgxn target_connections=10 accepted_count=0→1 satisfied=false
connect_peer: reusing existing transport remote=nQEV7NyyXFiFJgxn@104.15.81.138:41328
connect_peer: transport entry already has pub_key
connect joined peer peer_id=104.15.81.138:41328   # same peer, count unchanged
Transaction timed out tx_type=Connect elapsed_ms=62000
```

The root cause: `initiate_join_request` only pre-populated the bloom filter with `recently_failed_addrs` (NAT traversal failures). Already-connected ring peers were never added to the visited filter. Routing nodes therefore freely forwarded connect requests to the closest available peer — which was always `nQEV7NyyXFiFJgxn` at location 0.31, closest to the joiner's location 0.49. Location jitter (up to ±0.25) didn't help because it only changes the *desired* location, not which peers the routing avoids.

## Approach

Pre-populate the bloom filter with both recently-failed addresses **and** already-connected peer addresses at both `initiate_join_request` call sites:

1. `join_ring_request` in `operations/connect.rs`
2. Contract-directed CONNECT in `ring/mod.rs`

The new `connected_peer_addrs()` method on `ConnectionManager` reads directly from `location_for_peer` — the authoritative map of established ring connections.

Alternatives considered:
- Detecting "reusing existing transport" on the joiner side and sending a `ConnectFailed` back — this would work but requires an extra round-trip; excluding them upfront is simpler and prevents wasted work on relay nodes too.
- Filtering `ConnectResponse` on the joiner side — same issue, the work was already done.

## Testing

Added regression test `test_initiate_join_request_excludes_connected_peers` that:
1. Calls `initiate_join_request` with a list of already-connected peer addresses as `exclude_addrs`
2. Verifies those addresses appear in the visited bloom filter of the resulting `ConnectRequest`
3. Verifies an unrelated address is not in the filter

The test would have failed before this fix (exclude_addrs previously mapped to the parameter previously named `recently_failed_addrs` which only covered NAT failures, not connected peers).

**Why didn't CI catch this?** The simulation tests don't run long enough for the stuck-connection scenario to manifest — nodes converge within the test window. A targeted test of the bloom filter initialization was missing.

## Fixes

Closes #3303

[AI-assisted - Claude]