### PR TITLE
fix: spawn broadcast fan-out to prevent event loop self-deadlock

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -440,6 +440,11 @@ impl P2pConnManager {
         let gateways_arc = Arc::new(gateways.clone());
         let key_pair = config.key_pair.clone();
 
+        // Bridge channel capacity: must exceed the max number of connected peers
+        // to avoid self-deadlock when the event loop broadcasts inline. The primary
+        // mitigation is spawning fan-out via broadcast_to_peers(), but this provides
+        // defense-in-depth. Do NOT fan-out more than this many sends inline on the
+        // event loop — use broadcast_to_peers() instead.
         let (tx_bridge_cmd, rx_bridge_cmd) = mpsc::channel(512);
         let bridge = P2pBridge::new(
             tx_bridge_cmd,


### PR DESCRIPTION
## Problem

The vega gateway deadlocked at 07:50 UTC on Feb 27 when `handle_broadcast_ready_state` tried to send a ReadyState message to each of 101 connected peers. The bridge event channel (`ev_listener_tx` → `conn_bridge_rx`) had capacity 100 (`mpsc::channel(100)`). Since the event loop is both the producer (broadcasting inline) and the sole consumer (via PrioritySelect P5), send #101 blocks forever — classic self-deadlock.

101 active connections is normal for a busy gateway: ~14 inbound/min × 5min zombie window + 19 ring peers ≈ 90-100 steady state.

PR #3285 fixed the same class of bug for `broadcast_state_to_peers` by spawning via `tokio::spawn`, but missed three other broadcast functions with identical inline fan-out patterns.

## Approach

Apply the same spawn-off-event-loop pattern from PR #3285 to the three remaining broadcast functions:
- `handle_broadcast_proximity_cache`
- `handle_broadcast_change_interests`
- `handle_broadcast_ready_state`

Extract a shared `send_to_peers()` static helper to avoid duplicating the per-peer send+warn loop. Under `simulation_tests`, calls are inline (not spawned) to preserve deterministic message ordering.

Also bump the channel capacity from 100 → 512 as defense-in-depth. This alone doesn't fix the structural deadlock (only spawn does), but provides margin against burst pressure from concurrent spawned operations.

## Testing

- `cargo fmt && cargo clippy --all-targets --all-features` — clean
- `cargo test -p freenet` — all pass
- Deploy to vega and verify stability with >100 active connections

[AI-assisted - Claude]