### PR TITLE
fix: don't cancel in-progress CI runs on main branch

### DIFF
--- a/.github/workflows/benchmarks-extended.yml
+++ b/.github/workflows/benchmarks-extended.yml
@@ -22,10 +22,11 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-# Cancel in-progress runs when a new commit is pushed
+# Cancel in-progress runs when a new commit is pushed.
+# On main, never cancel — each merge must complete its run (#3311).
 concurrency:
   group: benchmarks-extended-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   extended-benchmark:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,10 +15,11 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-# Cancel in-progress runs when a new commit is pushed
+# Cancel in-progress runs when a new commit is pushed.
+# On main, never cancel — each merge must complete its run (#3311).
 concurrency:
   group: benchmarks-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   benchmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,12 @@ on:
       - '.github/FUNDING.yml'
   merge_group:
 
-# Cancel in-progress runs when a new commit is pushed to the same branch
+# Cancel in-progress runs when a new commit is pushed to the same branch.
+# On main, never cancel — each merge must complete its CI run. Otherwise a
+# fast succession of merges silently cancels earlier builds (#3311).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Fast checks first - fail fast on simple issues

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -7,10 +7,11 @@ on:
     branches: [main]
     tags: ['v*']
 
-# Cancel in-progress runs when a new commit is pushed to main
+# Cancel in-progress runs when a new commit is pushed to the same ref.
+# On main, never cancel — each merge must complete its build (#3311).
 concurrency:
   group: cross-compile-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build-x86_64-linux:


### PR DESCRIPTION
## Problem

All four workflows that run on main pushes (ci, cross-compile, benchmarks, benchmarks-extended) use `cancel-in-progress: true` with `github.ref` as the concurrency group key. Since main pushes all share `refs/heads/main`, a new merge cancels the previous in-progress build.

Observed during v0.1.154 release: cross-compile run [22492359074](https://github.com/freenet/freenet-core/actions/runs/22492359074/job/65158118815) was cancelled when another PR merged immediately after. A silently cancelled build could hide a real CI failure.

## Approach

Change `cancel-in-progress` to only apply on non-main refs:

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

This preserves the useful behavior of cancelling stale PR builds while ensuring every main-branch commit gets a full CI run.

Affected workflows:
- `.github/workflows/ci.yml`
- `.github/workflows/cross-compile.yml`
- `.github/workflows/benchmarks.yml`
- `.github/workflows/benchmarks-extended.yml`

## Testing

- Verified the expression syntax is valid GitHub Actions YAML
- PR branches still get `cancel-in-progress: true` (expression evaluates to true when ref != main)
- Main branch gets `cancel-in-progress: false` (expression evaluates to false)

## Fixes

Closes #3311

[AI-assisted - Claude]