### PR TITLE
fix: add allow-popups to iframe sandbox and shell message bridge

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -438,8 +438,14 @@ function freenetBridge(authToken) {
     // Handle shell-level messages (title, favicon) from iframe
     if (msg.__freenet_shell__) {
       if (msg.type === 'title' && typeof msg.title === 'string') {
-        document.title = msg.title;
+        // Truncate to prevent UI spoofing with excessively long titles
+        document.title = msg.title.slice(0, 128);
       } else if (msg.type === 'favicon' && typeof msg.href === 'string') {
+        // Only allow https: and data: schemes to prevent exfiltration
+        try {
+          var scheme = msg.href.split(':')[0].toLowerCase();
+          if (scheme !== 'https' && scheme !== 'data') return;
+        } catch(e) { return; }
         var link = document.querySelector('link[rel="icon"]');
         if (link) link.href = msg.href;
       }
@@ -835,6 +841,25 @@ mod tests {
             html.contains(&format!("freenetBridge(\"{}\")", token.as_str())),
             "auth token not passed to bridge"
         );
+        // Default title and favicon must be present
+        assert!(
+            html.contains("<title>Freenet</title>"),
+            "shell page title mismatch"
+        );
+        assert!(
+            html.contains(r#"<link rel="icon" href="https://freenet.org/favicon.ico">"#),
+            "favicon link missing"
+        );
+        // Shell message handler must be present in bridge JS
+        assert!(
+            html.contains("__freenet_shell__"),
+            "bridge JS must handle shell-level messages (title/favicon)"
+        );
+        // Security: allow-popups-to-escape-sandbox must NOT be present
+        assert!(
+            !html.contains("allow-popups-to-escape-sandbox"),
+            "allow-popups-to-escape-sandbox must not be set (security)"
+        );
     }
 
     #[tokio::test]
@@ -1002,6 +1027,19 @@ mod tests {
         assert!(
             SHELL_BRIDGE_JS.contains("connections.delete(msg.id)"),
             "bridge JS must clean up connections"
+        );
+        // Shell message handler must validate types and restrict favicon schemes
+        assert!(
+            SHELL_BRIDGE_JS.contains("typeof msg.title === 'string'"),
+            "bridge JS must type-check title before setting"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("typeof msg.href === 'string'"),
+            "bridge JS must type-check favicon href before setting"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("scheme !== 'https' && scheme !== 'data'"),
+            "bridge JS must restrict favicon href to https/data schemes"
         );
     }
 


### PR DESCRIPTION
## Problem

Two user-reported issues with River running inside the Freenet gateway's sandboxed iframe:

1. **Links don't work** (freenet/river#117): Clicking any link in River does nothing because the iframe sandbox attribute only includes `allow-scripts allow-forms`, missing `allow-popups` which is required for `target="_blank"` links to open.

2. **Wrong browser tab title and no favicon** (freenet/river#116): The browser tab shows "Freenet Contract" instead of the room name, and there's no favicon. Since River runs in a sandboxed iframe, `document.title` only affects the iframe's internal document, not the browser tab.

## Approach

**allow-popups**: Simply add `allow-popups` to the existing sandbox attribute. This is the minimal permission needed — it allows the iframe to open new windows/tabs via links but doesn't grant any other capabilities.

**Title/favicon**: The shell page (parent of the iframe) owns the browser tab title. We add a `__freenet_shell__` postMessage listener alongside the existing `__freenet_ws__` WebSocket bridge. Contracts can send `{__freenet_shell__: true, type: "title", title: "..."}` to update the tab title, and `{type: "favicon", href: "..."}` to update the favicon. This is a generic mechanism that any Freenet contract can use, not River-specific.

The default title is changed from "Freenet Contract" to "Freenet" and a default favicon is added pointing to freenet.org/favicon.ico.

## Testing

- Updated existing `shell_page_contains_iframe_and_bridge` test to verify the new sandbox attribute
- All 4 shell_page tests pass locally
- `cargo fmt` and `cargo clippy` clean

The companion River PR (freenet/river#<TBD>) adds the postMessage call in `set_document_title()`.

## Fixes

Fixes freenet/river#117
Fixes freenet/river#116

[AI-assisted - Claude]