### PR TITLE
fix: enforce 50 MiB MAX_STATE_SIZE at storage and executor layers

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::node::OpManager;
 use crate::wasm_runtime::{
-    BackendEngine, RuntimeConfig, SharedModuleCache, DEFAULT_MODULE_CACHE_CAPACITY,
+    BackendEngine, RuntimeConfig, SharedModuleCache, DEFAULT_MODULE_CACHE_CAPACITY, MAX_STATE_SIZE,
 };
 use freenet_stdlib::prelude::RelatedContract;
 use lru::LruCache;
@@ -868,6 +868,35 @@ where
 
         let mut updates = match update {
             Either::Left(incoming_state) => {
+                // Fast-reject oversized state before expensive WASM validation.
+                // A malicious contract could return `Valid` for any state, so this check must
+                // happen at the node level before any WASM execution.
+                let incoming_size = incoming_state.as_ref().len();
+                if incoming_size > MAX_STATE_SIZE {
+                    tracing::warn!(
+                        contract = %key,
+                        size_bytes = incoming_size,
+                        limit_bytes = MAX_STATE_SIZE,
+                        "Rejecting oversized state before WASM validation"
+                    );
+                    if remove_if_fail {
+                        if let Err(e) = self.runtime.remove_contract(&key) {
+                            tracing::warn!(
+                                contract = %key,
+                                error = %e,
+                                "failed to remove contract after size rejection"
+                            );
+                        }
+                    }
+                    return Err(ExecutorError::request(StdContractError::Put {
+                        key,
+                        cause: format!(
+                            "state size {incoming_size} bytes exceeds maximum allowed {MAX_STATE_SIZE} bytes"
+                        )
+                        .into(),
+                    }));
+                }
+
                 let result = self
                     .runtime
                     .validate_state(&key, &params, &incoming_state, &related_contracts)
@@ -1061,6 +1090,9 @@ where
                 }));
             }
             Err(StateStoreError::Any(err)) => return Err(ExecutorError::other(err)),
+            Err(err @ StateStoreError::StateTooLarge { .. }) => {
+                return Err(ExecutorError::other(err))
+            }
         };
 
         for (id, state) in related_contracts
@@ -1453,6 +1485,23 @@ where
         parameters: &Parameters<'_>,
         new_state: &WrappedState,
     ) -> Result<(), ExecutorError> {
+        let state_size = new_state.as_ref().len();
+        if state_size > MAX_STATE_SIZE {
+            tracing::warn!(
+                contract = %key,
+                size_bytes = state_size,
+                limit_bytes = MAX_STATE_SIZE,
+                "Rejecting oversized contract state at executor layer"
+            );
+            return Err(ExecutorError::request(StdContractError::Update {
+                key: *key,
+                cause: format!(
+                    "state size {state_size} bytes exceeds maximum allowed {MAX_STATE_SIZE} bytes"
+                )
+                .into(),
+            }));
+        }
+
         self.state_store
             .update(key, new_state.clone())
             .await

--- a/crates/core/src/wasm_runtime/mod.rs
+++ b/crates/core/src/wasm_runtime/mod.rs
@@ -32,4 +32,4 @@ pub use secrets_store::SecretsStore;
 #[allow(unused_imports)]
 pub(crate) use simulation_runtime::{InMemoryContractStore, SimulationStores};
 pub use state_store::StateStore;
-pub(crate) use state_store::{StateStorage, StateStoreError};
+pub(crate) use state_store::{StateStorage, StateStoreError, MAX_STATE_SIZE};

--- a/crates/core/src/wasm_runtime/state_store.rs
+++ b/crates/core/src/wasm_runtime/state_store.rs
@@ -4,12 +4,30 @@ use stretto::AsyncCache;
 
 use crate::config::GlobalExecutor;
 
+/// Maximum size of a single contract state blob (50 MiB).
+///
+/// This is a network-level protocol constant — identical across all nodes — so that any node
+/// can make routing and caching decisions without prior knowledge of which peer will handle a
+/// request. Making it per-node-configurable would create routing non-determinism and allow
+/// an attacker to selectively target lenient nodes.
+///
+/// 50 MiB is conservative enough to prevent disk exhaustion by malicious contracts while
+/// remaining large enough for legitimate use cases (web apps, documents, datasets). A contract
+/// whose `validate_state` returns `Valid` for arbitrarily large state cannot bypass this limit.
+pub(crate) const MAX_STATE_SIZE: usize = 50 * 1024 * 1024; // 50 MiB
+
 #[derive(thiserror::Error, Debug)]
 pub enum StateStoreError {
     #[error(transparent)]
     Any(#[from] anyhow::Error),
     #[error("missing contract: {0}")]
     MissingContract(ContractKey),
+    #[error("contract state too large for {key}: {size} bytes exceeds limit of {limit} bytes")]
+    StateTooLarge {
+        key: ContractKey,
+        size: usize,
+        limit: usize,
+    },
 }
 
 impl From<StateStoreError> for crate::wasm_runtime::ContractError {
@@ -19,6 +37,9 @@ impl From<StateStoreError> for crate::wasm_runtime::ContractError {
                 crate::wasm_runtime::ContractError::from(anyhow::format_err!(err))
             }
             err @ StateStoreError::MissingContract(_) => {
+                crate::wasm_runtime::ContractError::from(anyhow::format_err!(err))
+            }
+            err @ StateStoreError::StateTooLarge { .. } => {
                 crate::wasm_runtime::ContractError::from(anyhow::format_err!(err))
             }
         }
@@ -103,6 +124,20 @@ where
         key: &ContractKey,
         state: WrappedState,
     ) -> Result<(), StateStoreError> {
+        if state.size() > MAX_STATE_SIZE {
+            tracing::warn!(
+                contract = %key,
+                size_bytes = state.size(),
+                limit_bytes = MAX_STATE_SIZE,
+                "Rejecting oversized state at storage layer (update)"
+            );
+            return Err(StateStoreError::StateTooLarge {
+                key: *key,
+                size: state.size(),
+                limit: MAX_STATE_SIZE,
+            });
+        }
+
         // only allow updates for existing contracts
         let cache_miss = if let Some(cache) = &self.state_mem_cache {
             cache.get(key).await.is_none()
@@ -135,6 +170,20 @@ where
         state: WrappedState,
         params: Parameters<'static>,
     ) -> Result<(), StateStoreError> {
+        if state.size() > MAX_STATE_SIZE {
+            tracing::warn!(
+                contract = %key,
+                size_bytes = state.size(),
+                limit_bytes = MAX_STATE_SIZE,
+                "Rejecting oversized state at storage layer (store)"
+            );
+            return Err(StateStoreError::StateTooLarge {
+                key,
+                size: state.size(),
+                limit: MAX_STATE_SIZE,
+            });
+        }
+
         // Update memory cache first (if enabled) to prevent race condition
         if let Some(cache) = &self.state_mem_cache {
             let cost = state.size() as i64;
@@ -513,6 +562,65 @@ mod tests {
         let retrieved = store.get(&key).await.unwrap();
         assert_eq!(retrieved, empty_state);
         assert_eq!(retrieved.size(), 0);
+    }
+
+    // ============ State Size Limit Tests ============
+
+    /// Verify that store() rejects state exceeding MAX_STATE_SIZE.
+    ///
+    /// Uses new_uncached() for determinism — stretto's TinyLFU admission policy
+    /// is non-deterministic and irrelevant to the size-limit check.
+    #[tokio::test]
+    async fn test_store_rejects_oversized_state() {
+        let mock_storage = MockStateStorage::new();
+        let mut store = StateStore::new_uncached(mock_storage);
+        let key = make_test_key();
+        let oversized = make_test_state(&vec![0u8; MAX_STATE_SIZE + 1]);
+        let params = Parameters::from(vec![1, 2, 3]);
+
+        let result = store.store(key, oversized, params).await;
+
+        assert!(
+            matches!(result, Err(StateStoreError::StateTooLarge { .. })),
+            "Expected StateTooLarge, got: {result:?}"
+        );
+    }
+
+    /// Verify that update() rejects state exceeding MAX_STATE_SIZE.
+    #[tokio::test]
+    async fn test_update_rejects_oversized_state() {
+        let mock_storage = MockStateStorage::new();
+        let mut store = StateStore::new_uncached(mock_storage);
+        let key = make_test_key();
+        let small = make_test_state(&[1, 2, 3]);
+        let params = Parameters::from(vec![1, 2, 3]);
+
+        // Store a valid initial state first (update requires an existing contract)
+        store.store(key, small, params).await.unwrap();
+
+        let oversized = make_test_state(&vec![0u8; MAX_STATE_SIZE + 1]);
+        let result = store.update(&key, oversized).await;
+
+        assert!(
+            matches!(result, Err(StateStoreError::StateTooLarge { .. })),
+            "Expected StateTooLarge, got: {result:?}"
+        );
+    }
+
+    /// Verify that state at exactly MAX_STATE_SIZE is accepted (limit is inclusive).
+    #[tokio::test]
+    async fn test_store_accepts_state_at_limit() {
+        let mock_storage = MockStateStorage::new();
+        let mut store = StateStore::new_uncached(mock_storage);
+        let key = make_test_key();
+        let at_limit = make_test_state(&vec![0u8; MAX_STATE_SIZE]);
+        let params = Parameters::from(vec![1, 2, 3]);
+
+        // State of exactly MAX_STATE_SIZE bytes should be accepted
+        store
+            .store(key, at_limit, params)
+            .await
+            .expect("State at exactly MAX_STATE_SIZE should be accepted");
     }
 
     // ============ Edge Case: Large State ============


### PR DESCRIPTION
A malicious contract can return `Valid` for any state size from
`validate_state`, since that check runs untrusted WASM. Without a
node-level limit every caching peer must store whatever blob an attacker
provides, making disk exhaustion a trivial attack.

This follows the protocol-constant model used by Solana (10 MiB/account),
NEAR (4 MiB/value), IPFS (1 MiB/block), and BitTorrent DHT BEP44 (1 KB).
A per-node-configurable limit would create routing non-determinism: a
state accepted on a lenient node would be rejected on a strict one,
breaking DHT invariants. 50 MiB is conservative enough to prevent abuse
while being large enough for legitimate contracts.

Changes:
- Add `MAX_STATE_SIZE: usize = 50 * 1024 * 1024` constant in state_store.rs
- Add `StateStoreError::StateTooLarge` error variant with key/size/limit fields
- Guard `StateStore::store()` and `StateStore::update()` — last line of defense
- Guard `commit_state_update()` in runtime.rs — primary enforcement, rejects
  post-WASM merged state that grew too large via incremental delta updates
- Guard `bridged_upsert_contract_state()` for full-state PUTs before running
  any WASM — avoids loading 500 MiB blobs into the WASM VM at all
- Handle new `StateTooLarge` variant in all exhaustive match sites
- Re-export `MAX_STATE_SIZE` from `wasm_runtime` for use in executor layer
- Add three unit tests: rejects oversized store, rejects oversized update,
  accepts state at exactly the limit

All warn-level log messages include contract key, size, and limit so
operators can detect abuse attempts.

https://claude.ai/code/session_01UY7uJgEdTJFCP1Xc5yboVt