### PR TITLE
fix: resolve nightly simulation test failures

### DIFF
--- a/crates/core/src/client_events/mod.rs
+++ b/crates/core/src/client_events/mod.rs
@@ -2307,9 +2307,11 @@ pub(crate) mod test {
         }
 
         fn random_byte_vec(&mut self) -> Vec<u8> {
-            (0..self.gen_u8())
-                .map(|_| self.gen_u8())
-                .collect::<Vec<_>>()
+            // Generate 1..=256 bytes. Using gen_u8() + 1 ensures at least 1 byte,
+            // preventing empty states/deltas that would trip debug_assert invariants
+            // in put_contract (stored state must be non-empty after successful PUT).
+            let len = self.gen_u8() as usize + 1;
+            (0..len).map(|_| self.gen_u8()).collect::<Vec<_>>()
         }
     }
 

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -4208,8 +4208,12 @@ impl SimNetwork {
                 tokio::time::sleep(event_wait).await;
             }
 
-            // Wait for events to fully propagate
-            tokio::time::sleep(Duration::from_secs(2)).await;
+            // Wait for events to fully propagate.
+            // Must be long enough for broadcast retries (up to 3 retries × 3s backoff = 9s)
+            // plus subscription establishment and update forwarding. Recent routing changes
+            // (connect visited filter, acceptor diversity) can create topologies where
+            // subscriptions take longer to establish, making 2s insufficient.
+            tokio::time::sleep(Duration::from_secs(15)).await;
 
             // Convergence check
             let subscribed_count = {


### PR DESCRIPTION
Two issues caused nightly test failures:

1. random_byte_vec could generate 0-length states (when gen_u8() returned 0),
   triggering debug_assert in put_contract which requires non-empty state after
   a successful PUT. Fixed by ensuring at least 1 byte is always generated.

2. run_simulation_direct had only a 2-second propagation wait after events,
   which was insufficient after recent routing changes (connect visited filter,
   acceptor diversity) that create topologies requiring longer for broadcast
   retries and subscription establishment. Increased to 15 seconds to
   accommodate worst-case broadcast retry schedule (3 retries × 3s backoff).

https://claude.ai/code/session_01PY9a258dFzUayG3J3A4Lf7