### PR TITLE
fix: add per-contract fair queuing to prevent event loop starvation

### DIFF
--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -146,6 +146,12 @@ pub struct RuntimePool {
     delegate_notification_rx: Option<super::DelegateNotificationReceiver>,
     /// Per-contract executor usage tracking (for observability).
     /// Not used for enforcement since the event loop is sequential.
+    /// Tracked via RAII `InFlightGuard` in: `fetch_contract`, `upsert_contract_state`,
+    /// `summarize_contract_state`, `get_contract_state_delta`.
+    /// Intentionally NOT tracked in: `execute_delegate_request` (no contract key),
+    /// `register_contract_notifier` (synchronous, no executor checkout),
+    /// `lookup_key`, `get_subscription_info`, `notify_subscription_error`,
+    /// `remove_client` (read-only / no executor checkout).
     in_flight_contracts: HashMap<ContractKey, usize>,
 }
 
@@ -316,6 +322,11 @@ impl RuntimePool {
     /// Record that an executor has been checked out for the given contract.
     /// Observability-only — the sequential event loop means at most one contract
     /// is ever in flight at a time.
+    ///
+    /// Panic safety: WASM panics are caught at the wasmer FFI boundary and
+    /// converted to errors (not Rust panics), so `track_contract_return` is
+    /// guaranteed to run after `track_contract_checkout` in the methods below.
+    /// There are no `?` operators between the checkout/return calls.
     fn track_contract_checkout(&mut self, key: &ContractKey) {
         *self.in_flight_contracts.entry(*key).or_insert(0) += 1;
     }

--- a/crates/core/src/contract/fair_queue.rs
+++ b/crates/core/src/contract/fair_queue.rs
@@ -201,7 +201,7 @@ impl FairEventQueue {
     }
 
     /// Returns the total number of queued events across all contracts.
-    #[allow(dead_code)] // Used for metrics/logging
+    #[cfg(test)]
     pub(super) fn total_queued(&self) -> usize {
         self.total_queued
     }
@@ -582,5 +582,277 @@ mod tests {
 
         assert_eq!(queue.total_queued(), 1);
         assert!(queue.contract_queues.contains_key(&contract_id));
+    }
+
+    #[test]
+    fn test_default_queue_per_slot_limit() {
+        let mut queue = FairEventQueue::new();
+
+        // Fill default queue to per-slot limit with ClientDisconnect events
+        for i in 0..MAX_QUEUED_PER_CONTRACT as u64 {
+            queue
+                .try_push(make_event_id(i), make_delegate_event())
+                .expect("should succeed within limit");
+        }
+
+        // One more should be rejected
+        let result = queue.try_push(
+            make_event_id(MAX_QUEUED_PER_CONTRACT as u64),
+            make_delegate_event(),
+        );
+        assert!(
+            result.is_err(),
+            "should reject when default queue per-slot limit exceeded"
+        );
+    }
+
+    #[test]
+    fn test_interleaved_push_pop() {
+        let mut queue = FairEventQueue::new();
+        let a = make_contract_id(1);
+        let b = make_contract_id(2);
+
+        // Push event for A, pop (gets A)
+        queue.try_push(make_event_id(0), make_get_event(a)).unwrap();
+        let (id0, _) = queue.pop().expect("should pop A");
+        assert_eq!(id0.id, 0);
+
+        // Push events for B and A
+        queue.try_push(make_event_id(1), make_get_event(b)).unwrap();
+        queue.try_push(make_event_id(2), make_get_event(a)).unwrap();
+
+        // Round-robin should give B first (B was added after A was drained,
+        // so B is at front of round_robin)
+        let (id1, ev1) = queue.pop().expect("should pop B");
+        let ContractHandlerEvent::GetQuery { instance_id, .. } = ev1 else {
+            panic!("unexpected event type");
+        };
+        assert_eq!(instance_id, b, "expected B (id={})", id1.id);
+
+        // Then A
+        let (id2, ev2) = queue.pop().expect("should pop A");
+        let ContractHandlerEvent::GetQuery { instance_id, .. } = ev2 else {
+            panic!("unexpected event type");
+        };
+        assert_eq!(instance_id, a, "expected A (id={})", id2.id);
+
+        assert!(queue.pop().is_none());
+    }
+
+    #[test]
+    fn test_interleaved_three_contracts() {
+        let mut queue = FairEventQueue::new();
+        let a = make_contract_id(1);
+        let b = make_contract_id(2);
+        let c = make_contract_id(3);
+
+        // Fill: A(3), B(2), C(1)
+        for i in 0..3u64 {
+            queue.try_push(make_event_id(i), make_get_event(a)).unwrap();
+        }
+        for i in 3..5u64 {
+            queue.try_push(make_event_id(i), make_get_event(b)).unwrap();
+        }
+        queue.try_push(make_event_id(5), make_get_event(c)).unwrap();
+
+        // Pop 3 — should be one from each (A, B, C in round-robin)
+        let mut first_round = Vec::new();
+        for _ in 0..3 {
+            let (_, ev) = queue.pop().unwrap();
+            let ContractHandlerEvent::GetQuery { instance_id, .. } = ev else {
+                panic!("unexpected");
+            };
+            first_round.push(instance_id);
+        }
+        assert_eq!(first_round, vec![a, b, c]);
+
+        // C is now drained, so second round is A, B
+        let mut second_round = Vec::new();
+        for _ in 0..2 {
+            let (_, ev) = queue.pop().unwrap();
+            let ContractHandlerEvent::GetQuery { instance_id, .. } = ev else {
+                panic!("unexpected");
+            };
+            second_round.push(instance_id);
+        }
+        assert_eq!(second_round, vec![a, b]);
+
+        // Third round: only A remains
+        let (_, ev) = queue.pop().unwrap();
+        let ContractHandlerEvent::GetQuery { instance_id, .. } = ev else {
+            panic!("unexpected");
+        };
+        assert_eq!(instance_id, a);
+
+        assert!(queue.pop().is_none());
+    }
+
+    /// Test that extract_contract_id correctly routes all event variants.
+    #[test]
+    fn test_extract_contract_id_all_variants() {
+        use freenet_stdlib::prelude::UpdateData;
+        use tokio::sync::mpsc;
+
+        let code = ContractCode::from(vec![99u8; 32]);
+        let params = Parameters::from(vec![88u8; 8]);
+        let key = ContractKey::from_params_and_code(&params, &code);
+        let contract_id = *key.id();
+
+        // Events that SHOULD map to a contract queue (Some)
+        let contract_events: Vec<(&str, ContractHandlerEvent)> = vec![
+            (
+                "PutQuery",
+                ContractHandlerEvent::PutQuery {
+                    key,
+                    state: WrappedState::new(vec![1]),
+                    related_contracts: RelatedContracts::default(),
+                    contract: None,
+                },
+            ),
+            (
+                "UpdateQuery",
+                ContractHandlerEvent::UpdateQuery {
+                    key,
+                    data: UpdateData::Delta(freenet_stdlib::prelude::StateDelta::from(vec![2])),
+                    related_contracts: RelatedContracts::default(),
+                },
+            ),
+            (
+                "GetQuery",
+                ContractHandlerEvent::GetQuery {
+                    instance_id: contract_id,
+                    return_contract_code: false,
+                },
+            ),
+            (
+                "GetSummaryQuery",
+                ContractHandlerEvent::GetSummaryQuery { key },
+            ),
+            (
+                "GetDeltaQuery",
+                ContractHandlerEvent::GetDeltaQuery {
+                    key,
+                    their_summary: freenet_stdlib::prelude::StateSummary::from(vec![3]),
+                },
+            ),
+            (
+                "RegisterSubscriberListener",
+                ContractHandlerEvent::RegisterSubscriberListener {
+                    key: contract_id,
+                    client_id: crate::client_events::ClientId::next(),
+                    summary: None,
+                    subscriber_listener: mpsc::unbounded_channel().0,
+                },
+            ),
+            (
+                "NotifySubscriptionError",
+                ContractHandlerEvent::NotifySubscriptionError {
+                    key: contract_id,
+                    reason: "test".to_string(),
+                },
+            ),
+        ];
+
+        for (name, event) in &contract_events {
+            let result = extract_contract_id(event);
+            assert_eq!(
+                result,
+                Some(contract_id),
+                "{name} should route to contract queue"
+            );
+        }
+
+        // Events that SHOULD map to the default queue (None)
+        let default_events: Vec<(&str, ContractHandlerEvent)> = vec![
+            (
+                "DelegateRequest",
+                ContractHandlerEvent::DelegateRequest {
+                    req: freenet_stdlib::client_api::DelegateRequest::ApplicationMessages {
+                        key: freenet_stdlib::prelude::DelegateKey::new(
+                            [1u8; 32],
+                            freenet_stdlib::prelude::CodeHash::new([0u8; 32]),
+                        ),
+                        params: Parameters::from(vec![]),
+                        inbound: vec![],
+                    },
+                    attested_contract: None,
+                },
+            ),
+            (
+                "DelegateResponse",
+                ContractHandlerEvent::DelegateResponse(vec![]),
+            ),
+            (
+                "ClientDisconnect",
+                ContractHandlerEvent::ClientDisconnect {
+                    client_id: crate::client_events::ClientId::next(),
+                },
+            ),
+            (
+                "PutResponse",
+                ContractHandlerEvent::PutResponse {
+                    new_value: Ok(WrappedState::new(vec![])),
+                    state_changed: false,
+                },
+            ),
+            (
+                "GetResponse",
+                ContractHandlerEvent::GetResponse {
+                    key: None,
+                    response: Ok(crate::contract::handler::StoreResponse {
+                        state: None,
+                        contract: None,
+                    }),
+                },
+            ),
+            (
+                "UpdateResponse",
+                ContractHandlerEvent::UpdateResponse {
+                    new_value: Ok(WrappedState::new(vec![])),
+                    state_changed: false,
+                },
+            ),
+            (
+                "UpdateNoChange",
+                ContractHandlerEvent::UpdateNoChange { key },
+            ),
+            (
+                "RegisterSubscriberListenerResponse",
+                ContractHandlerEvent::RegisterSubscriberListenerResponse,
+            ),
+            (
+                "QuerySubscriptionsResponse",
+                ContractHandlerEvent::QuerySubscriptionsResponse,
+            ),
+            (
+                "GetSummaryResponse",
+                ContractHandlerEvent::GetSummaryResponse {
+                    key,
+                    summary: Ok(freenet_stdlib::prelude::StateSummary::from(vec![])),
+                },
+            ),
+            (
+                "GetDeltaResponse",
+                ContractHandlerEvent::GetDeltaResponse {
+                    key,
+                    delta: Ok(freenet_stdlib::prelude::StateDelta::from(vec![])),
+                },
+            ),
+            (
+                "NotifySubscriptionErrorResponse",
+                ContractHandlerEvent::NotifySubscriptionErrorResponse,
+            ),
+            (
+                "QuerySubscriptions",
+                ContractHandlerEvent::QuerySubscriptions {
+                    callback: mpsc::channel::<crate::message::QueryResult>(1).0,
+                },
+            ),
+        ];
+
+        for (name, event) in &default_events {
+            let result = extract_contract_id(event);
+            assert_eq!(result, None, "{name} should route to default queue");
+        }
     }
 }

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -167,7 +167,7 @@ impl ContractHandler for NetworkContractHandler {
     }
 }
 
-#[derive(Eq)]
+#[derive(Debug, Eq)]
 pub(crate) struct EventId {
     pub(crate) id: u64,
 }
@@ -541,6 +541,12 @@ impl ContractHandlerChannel<ContractHandlerHalve> {
     /// the `waiting_response` map.
     pub fn drop_waiting_response(&mut self, id: EventId) {
         self.end.waiting_response.remove(&id.id);
+    }
+
+    /// Check if a waiting_response entry exists for the given event ID.
+    #[cfg(test)]
+    pub fn has_waiting_response(&self, id: &EventId) -> bool {
+        self.end.waiting_response.contains_key(&id.id)
     }
 
     pub async fn recv_from_sender(
@@ -1041,6 +1047,70 @@ pub mod test {
                 std::mem::discriminant(other)
             ),
         }
+    }
+
+    #[tokio::test]
+    async fn try_recv_from_sender_empty_channel() {
+        let (_send_halve, mut rcv_halve, _) = contract_handler_channel();
+
+        // Empty channel should return Ok(None)
+        let result = rcv_halve.try_recv_from_sender();
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn try_recv_from_sender_receives_event() {
+        let (send_halve, mut rcv_halve, _) = contract_handler_channel();
+
+        let contract = ContractContainer::Wasm(ContractWasmAPIVersion::V1(WrappedContract::new(
+            Arc::new(ContractCode::from(vec![10, 11, 12])),
+            Parameters::from(vec![13]),
+        )));
+        let key = contract.key();
+
+        // Send an event from another task
+        let _h = GlobalExecutor::spawn(async move {
+            send_halve
+                .send_to_handler(ContractHandlerEvent::PutQuery {
+                    key,
+                    state: vec![20, 21].into(),
+                    related_contracts: RelatedContracts::default(),
+                    contract: None,
+                })
+                .await
+        });
+
+        // Wait briefly for the event to arrive
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // try_recv should succeed
+        let result = rcv_halve.try_recv_from_sender();
+        assert!(result.is_ok());
+        let (id, event) = result.unwrap().expect("should have received an event");
+        // Verify we got a valid EventId (any u64 is valid)
+
+        let ContractHandlerEvent::PutQuery { state, .. } = event else {
+            panic!("expected PutQuery event");
+        };
+        assert_eq!(state.as_ref(), &[20, 21]);
+
+        // The waiting_response entry should be populated
+        assert!(rcv_halve.end.waiting_response.contains_key(&id.id));
+    }
+
+    #[tokio::test]
+    async fn try_recv_from_sender_disconnected() {
+        let (send_halve, mut rcv_halve, _) = contract_handler_channel();
+
+        // Drop the sender to disconnect the channel
+        drop(send_halve);
+
+        let result = rcv_halve.try_recv_from_sender();
+        assert!(
+            matches!(result, Err(super::ContractError::NoEvHandlerResponse)),
+            "Expected NoEvHandlerResponse, got {:?}",
+            result
+        );
     }
 }
 

--- a/crates/core/src/contract/mod.rs
+++ b/crates/core/src/contract/mod.rs
@@ -42,6 +42,11 @@ use self::executor::DelegateNotificationReceiver;
 /// Maximum iterations when handling contract requests to prevent infinite loops
 const MAX_CONTRACT_REQUEST_ITERATIONS: usize = 100;
 
+/// Maximum delegate notifications to drain per iteration.
+/// Matches the same bounded-drain pattern as MAX_DRAIN_BATCH for contract events,
+/// preventing delegate notification channel growth under sustained contract load.
+const MAX_DELEGATE_DRAIN_BATCH: usize = 16;
+
 /// Handle a delegate request, including any contract request messages in the response.
 ///
 /// When a delegate emits contract request messages, this function:
@@ -524,11 +529,22 @@ where
 
     loop {
         // Drain pending events from the channel into the fair queue (bounded batch).
-        // This runs every iteration regardless of queue state, ensuring new events
-        // are picked up promptly.
+        // Capped at MAX_DRAIN_BATCH (256) to bound the synchronous work per iteration
+        // before yielding back to the Tokio scheduler. Each iteration of this loop is
+        // a non-blocking try_recv + HashMap insert, so 256 iterations complete in
+        // single-digit microseconds even at peak load.
         for _ in 0..fair_queue::MAX_DRAIN_BATCH {
             match contract_handler.channel().try_recv_from_sender()? {
                 Some((id, event)) => {
+                    // Process ClientDisconnect inline — it's a lightweight cleanup
+                    // operation that should never be delayed or compete with
+                    // DelegateRequest events for the default queue's limited capacity.
+                    if let ContractHandlerEvent::ClientDisconnect { client_id } = &event {
+                        let client_id = *client_id;
+                        contract_handler.executor().remove_client(client_id);
+                        contract_handler.channel().drop_waiting_response(id);
+                        continue;
+                    }
                     if let Err(rejected) = fair_queue.try_push(id, event) {
                         send_queue_full_response(contract_handler.channel(), rejected).await;
                     }
@@ -537,10 +553,17 @@ where
             }
         }
 
-        // Check for delegate notifications (non-blocking) even when the fair queue
+        // Drain delegate notifications (non-blocking, bounded) even when the fair queue
         // has work. This prevents delegate starvation under sustained contract load.
-        if let Some(notification) = try_recv_delegate_notification(&mut delegate_rx) {
-            handle_delegate_notification(&mut contract_handler, notification).await;
+        // We drain up to MAX_DELEGATE_DRAIN_BATCH to handle bursts (e.g., a contract
+        // update triggering many delegate notifications simultaneously).
+        for _ in 0..MAX_DELEGATE_DRAIN_BATCH {
+            match try_recv_delegate_notification(&mut delegate_rx) {
+                Some(notification) => {
+                    handle_delegate_notification(&mut contract_handler, notification).await;
+                }
+                None => break,
+            }
         }
 
         // Process one event from the fair queue (round-robin across contracts)
@@ -624,7 +647,7 @@ async fn send_queue_full_response(
         }
     };
     if let Err(error) = channel.send_to_sender(rejected.id, response).await {
-        tracing::debug!(
+        tracing::warn!(
             error = %error,
             "Failed to send queue-full response (client may have disconnected)"
         );
@@ -1208,4 +1231,268 @@ pub(crate) enum ContractError {
         key: ContractKey,
         error: ExecutorError,
     },
+}
+
+#[cfg(test)]
+#[allow(clippy::wildcard_enum_match_arm)]
+mod tests {
+    use super::*;
+    use crate::config::GlobalExecutor;
+    use std::time::Duration;
+
+    fn make_contract_key() -> ContractKey {
+        let code = ContractCode::from(vec![42u8; 32]);
+        let params = Parameters::from(vec![7u8; 8]);
+        ContractKey::from_params_and_code(&params, &code)
+    }
+
+    /// Helper: send an event through the sender halve and receive it on the handler side,
+    /// then wrap it as a RejectedEvent. This simulates the normal drain path where
+    /// try_recv_from_sender inserts into waiting_response, followed by queue rejection.
+    async fn setup_rejected_event(
+        send_halve: handler::ContractHandlerChannel<handler::SenderHalve>,
+        rcv_halve: &mut handler::ContractHandlerChannel<handler::ContractHandlerHalve>,
+        event: ContractHandlerEvent,
+    ) -> (
+        Box<fair_queue::RejectedEvent>,
+        tokio::task::JoinHandle<Result<ContractHandlerEvent, anyhow::Error>>,
+    ) {
+        // Spawn the sender — it blocks until the response arrives
+        let handle = GlobalExecutor::spawn(async move {
+            send_halve
+                .send_to_handler(event)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))
+        });
+
+        // Receive on the handler side (populates waiting_response)
+        let (id, received_event) =
+            tokio::time::timeout(Duration::from_millis(200), rcv_halve.recv_from_sender())
+                .await
+                .expect("timeout waiting for event")
+                .expect("channel should be open");
+
+        let rejected = Box::new(fair_queue::RejectedEvent {
+            id,
+            event: received_event,
+        });
+
+        (rejected, handle)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_queue_full_response_put_query() {
+        let (send_halve, mut rcv_halve, _) = handler::contract_handler_channel();
+        let key = make_contract_key();
+
+        let (rejected, handle) = setup_rejected_event(
+            send_halve,
+            &mut rcv_halve,
+            ContractHandlerEvent::PutQuery {
+                key,
+                state: WrappedState::new(vec![1, 2, 3]),
+                related_contracts: RelatedContracts::default(),
+                contract: None,
+            },
+        )
+        .await;
+
+        send_queue_full_response(&mut rcv_halve, rejected).await;
+
+        let response = tokio::time::timeout(Duration::from_millis(200), handle)
+            .await
+            .expect("timeout")
+            .expect("task should complete")
+            .expect("should get response");
+
+        match response {
+            ContractHandlerEvent::PutResponse {
+                new_value,
+                state_changed,
+            } => {
+                assert!(new_value.is_err(), "should be an error response");
+                assert!(!state_changed);
+            }
+            other => panic!("expected PutResponse, got {other}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_queue_full_response_get_query() {
+        let (send_halve, mut rcv_halve, _) = handler::contract_handler_channel();
+        let key = make_contract_key();
+
+        let (rejected, handle) = setup_rejected_event(
+            send_halve,
+            &mut rcv_halve,
+            ContractHandlerEvent::GetQuery {
+                instance_id: *key.id(),
+                return_contract_code: false,
+            },
+        )
+        .await;
+
+        send_queue_full_response(&mut rcv_halve, rejected).await;
+
+        let response = tokio::time::timeout(Duration::from_millis(200), handle)
+            .await
+            .expect("timeout")
+            .expect("task should complete")
+            .expect("should get response");
+
+        match response {
+            ContractHandlerEvent::GetResponse { response, .. } => {
+                assert!(response.is_err(), "should be an error response");
+            }
+            other => panic!("expected GetResponse, got {other}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_queue_full_response_update_query() {
+        let (send_halve, mut rcv_halve, _) = handler::contract_handler_channel();
+        let key = make_contract_key();
+
+        let (rejected, handle) = setup_rejected_event(
+            send_halve,
+            &mut rcv_halve,
+            ContractHandlerEvent::UpdateQuery {
+                key,
+                data: UpdateData::Delta(StateDelta::from(vec![1])),
+                related_contracts: RelatedContracts::default(),
+            },
+        )
+        .await;
+
+        send_queue_full_response(&mut rcv_halve, rejected).await;
+
+        let response = tokio::time::timeout(Duration::from_millis(200), handle)
+            .await
+            .expect("timeout")
+            .expect("task should complete")
+            .expect("should get response");
+
+        match response {
+            ContractHandlerEvent::UpdateResponse {
+                new_value,
+                state_changed,
+            } => {
+                assert!(new_value.is_err(), "should be an error response");
+                assert!(!state_changed);
+            }
+            other => panic!("expected UpdateResponse, got {other}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_queue_full_response_get_summary_query() {
+        let (send_halve, mut rcv_halve, _) = handler::contract_handler_channel();
+        let key = make_contract_key();
+
+        let (rejected, handle) = setup_rejected_event(
+            send_halve,
+            &mut rcv_halve,
+            ContractHandlerEvent::GetSummaryQuery { key },
+        )
+        .await;
+
+        send_queue_full_response(&mut rcv_halve, rejected).await;
+
+        let response = tokio::time::timeout(Duration::from_millis(200), handle)
+            .await
+            .expect("timeout")
+            .expect("task should complete")
+            .expect("should get response");
+
+        match response {
+            ContractHandlerEvent::GetSummaryResponse {
+                key: resp_key,
+                summary,
+            } => {
+                assert_eq!(resp_key, key);
+                assert!(summary.is_err(), "should be an error response");
+            }
+            other => panic!("expected GetSummaryResponse, got {other}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_queue_full_response_get_delta_query() {
+        let (send_halve, mut rcv_halve, _) = handler::contract_handler_channel();
+        let key = make_contract_key();
+
+        let (rejected, handle) = setup_rejected_event(
+            send_halve,
+            &mut rcv_halve,
+            ContractHandlerEvent::GetDeltaQuery {
+                key,
+                their_summary: StateSummary::from(vec![1, 2]),
+            },
+        )
+        .await;
+
+        send_queue_full_response(&mut rcv_halve, rejected).await;
+
+        let response = tokio::time::timeout(Duration::from_millis(200), handle)
+            .await
+            .expect("timeout")
+            .expect("task should complete")
+            .expect("should get response");
+
+        match response {
+            ContractHandlerEvent::GetDeltaResponse {
+                key: resp_key,
+                delta,
+            } => {
+                assert_eq!(resp_key, key);
+                assert!(delta.is_err(), "should be an error response");
+            }
+            other => panic!("expected GetDeltaResponse, got {other}"),
+        }
+    }
+
+    /// Verify that fire-and-forget events (RegisterSubscriberListener, delegates, etc.)
+    /// have their waiting_response entry cleaned up via drop_waiting_response when rejected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_queue_full_response_fire_and_forget_cleans_waiting_response() {
+        let (send_halve, mut rcv_halve, _) = handler::contract_handler_channel();
+        let key = make_contract_key();
+
+        let (rejected, handle) = setup_rejected_event(
+            send_halve,
+            &mut rcv_halve,
+            ContractHandlerEvent::RegisterSubscriberListener {
+                key: *key.id(),
+                client_id: crate::client_events::ClientId::next(),
+                summary: None,
+                subscriber_listener: tokio::sync::mpsc::unbounded_channel().0,
+            },
+        )
+        .await;
+
+        // Verify waiting_response was populated
+        assert!(
+            rcv_halve.has_waiting_response(&rejected.id),
+            "waiting_response should contain the event"
+        );
+
+        let rejected_id = handler::EventId { id: rejected.id.id };
+        send_queue_full_response(&mut rcv_halve, rejected).await;
+
+        // Verify waiting_response was cleaned up
+        assert!(
+            !rcv_halve.has_waiting_response(&rejected_id),
+            "waiting_response should be cleaned up after rejection"
+        );
+
+        // The sender should get a RecvError (NoEvHandlerResponse) since we dropped the oneshot
+        let result = tokio::time::timeout(Duration::from_millis(200), handle)
+            .await
+            .expect("timeout")
+            .expect("task should complete");
+        assert!(
+            result.is_err(),
+            "fire-and-forget rejection should produce an error"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Implements per-contract fair queuing for the WASM executor event loop to prevent a single contract from monopolizing the sequential event processor. Events are bucketed by contract and processed in round-robin order, ensuring all contracts receive fair access to execution time.

## Key Changes

- **New `FairEventQueue` module** (`crates/core/src/contract/fair_queue.rs`):
  - Maintains per-contract event queues with round-robin scheduling
  - Enforces per-contract limit (`MAX_QUEUED_PER_CONTRACT = 100`) and global limit (`MAX_TOTAL_FAIR_QUEUE = 5,000`)
  - Routes events to appropriate queues based on contract identity via `extract_contract_id()`
  - Implements `try_push()` for enqueuing with backpressure and `pop()` for round-robin dequeuing
  - Includes comprehensive test coverage for fairness, limits, and edge cases

- **Updated event loop** (`crates/core/src/contract/mod.rs`):
  - Integrates `FairEventQueue` into `contract_handling()` main loop
  - Drains incoming events in bounded batches (`MAX_DRAIN_BATCH = 256`) to fill the fair queue
  - Processes one event per iteration in round-robin order
  - Checks for delegate notifications non-blocking even when fair queue has work, preventing delegate starvation
  - Falls back to blocking `tokio::select!` only when fair queue is empty
  - Added `send_queue_full_response()` to handle rejected events with appropriate error responses

- **Handler improvements** (`crates/core/src/contract/handler.rs`):
  - Made `EventId.id` public for fair queue access
  - Added `try_recv_from_sender()` for non-blocking event reception during drain phase

- **Runtime pool observability** (`crates/core/src/contract/executor/runtime.rs`):
  - Added `contracts_in_flight` tracking to `PoolHealthStatus` for metrics
  - Added `in_flight_contracts` map and tracking methods for observability (sequential loop means at most 1 contract in flight at a time)

## Implementation Details

- **Backpressure strategy**: Per-contract limits catch misbehaving contracts; global limit bounds total memory before mediator's `MAX_PENDING_REQUESTS` limit
- **Fairness guarantee**: Round-robin rotation ensures no contract can starve others, even under sustained load
- **Delegate protection**: Non-blocking delegate notification checks prevent delegate starvation during high contract load
- **Error handling**: Rejected events receive appropriate error responses (or dropped oneshot senders for fire-and-forget events)
- **Comprehensive testing**: 11 test cases covering round-robin fairness, per-contract limits, global limits, default queue participation, stress scenarios with many contracts, and mixed hot/cold contract loads

https://claude.ai/code/session_01RpKKcL76k4cf7fYPYJbs9d