### PR TITLE
feat: add .reg sidecar files for delegate index crash recovery

### DIFF
--- a/crates/core/src/wasm_runtime/delegate_store.rs
+++ b/crates/core/src/wasm_runtime/delegate_store.rs
@@ -250,6 +250,16 @@ impl DelegateStore {
         let code_hash = *key.code_hash();
         self.delegate_cache.remove(&code_hash);
 
+        // Remove .reg file FIRST to prevent resurrection on crash.
+        // If we crash after ReDb removal but before .reg removal, startup
+        // reconciliation would restore the deleted delegate from the stale .reg.
+        let reg_path = self.delegates_dir.join(key.encode()).with_extension("reg");
+        if let Err(err) = std::fs::remove_file(&reg_path) {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                return Err(err.into());
+            }
+        }
+
         // Remove from ReDb index
         self.db
             .remove_delegate_index(key)
@@ -257,14 +267,6 @@ impl DelegateStore {
 
         // Remove from in-memory index
         self.key_to_code_part.remove(key);
-
-        // Remove .reg file (keyed by delegate_key)
-        let reg_path = self.delegates_dir.join(key.encode()).with_extension("reg");
-        if let Err(err) = std::fs::remove_file(&reg_path) {
-            if err.kind() != std::io::ErrorKind::NotFound {
-                return Err(err.into());
-            }
-        }
 
         // Remove .wasm file (keyed by code_hash) only if no other delegate uses it
         let other_delegates_use_code = self


### PR DESCRIPTION
## Problem

Delegate key changes cause data loss because the `DelegateKey → CodeHash` index (ReDb) is the sole source of truth. When ReDb entries are lost (as happened during the KEY_DATA→ReDb migration), delegates become unreachable even though WASM files and encrypted secrets exist on disk. Since `DelegateKey = BLAKE3(code_hash || params)`, the index can't be rebuilt from disk alone because params aren't stored anywhere outside ReDb.

This also makes backups difficult — users need to back up both files AND the opaque ReDb database, and there's no way to verify or reconstruct the index from files alone.

## Approach

Add `.reg` (registration record) sidecar files alongside existing WASM files as a supplementary backup for the ReDb index. ReDb remains the primary runtime store; `.reg` files provide crash recovery.

**Storage layout:**
```
~/.local/share/freenet/delegates/
├── {code_hash}.wasm            # WASM binary (existing)
├── {delegate_key}.reg          # NEW: registration record
├── db/                         # ReDb database (existing, now rebuildable)
```

**`.reg` file format** (binary, 37 bytes for empty params):
```
version: u8 (currently 1)
code_hash: [u8; 32]
params_len: u32 LE
params: [u8; params_len]
```

**Write order** (belt-and-suspenders):
1. Write `{code_hash}.wasm` (idempotent)
2. Write `{delegate_key}.reg` (idempotent)
3. Update ReDb index
4. Update DashMap
5. Insert cache

**Startup reconciliation:**
1. Load from ReDb (primary, fast)
2. Scan `.reg` files and restore any missing ReDb entries
3. Log warnings for orphaned files

**Backup story:** `rsync ~/.local/share/freenet/delegates/` (exclude `db/`). On restore, ReDb rebuilds automatically from `.reg` files on startup.

## Testing

7 unit tests covering:
- `store_and_load` — basic store/fetch round-trip, verifies `.reg` file created
- `reg_files_restore_lost_redb_entries` — deletes ReDb entry, new DelegateStore rebuilds from `.reg`
- `store_repairs_missing_index_when_file_exists` — WASM exists but no index entry, `store_delegate` repairs
- `store_handles_same_code_different_params` — same WASM, different params = different delegate keys
- `remove_delegate_cleans_reg_file` — removal cleans up `.reg` file and WASM
- `idempotent_store_preserves_reg` — storing same delegate twice doesn't corrupt `.reg`
- `parse_reg_file_validation` — rejects truncated/corrupt `.reg` files gracefully

All tests pass locally. `cargo fmt` and `cargo clippy` clean.

## Related

See #3342 for broader discussion of ReDb's role across the codebase.

[AI-assisted - Claude]