### PR TITLE
feat: proactive state sync on proximity cache discovery + GET timeout fixes

### DIFF
--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -117,18 +117,7 @@ impl Transaction {
     /// This will allow, for example, to compare against any older transactions,
     /// in order to remove them.
     pub fn ttl_transaction() -> Self {
-        let id = crate::config::GlobalSimulationTime::new_ulid();
-        let ts = id.timestamp_ms();
-        const TTL_MS: u64 = crate::config::OPERATION_TTL.as_millis() as u64;
-        let ttl_epoch: u64 = ts - TTL_MS;
-
-        // Clear the ts significant bits of the ULID and replace them with the new cutoff ts.
-        const TIMESTAMP_MASK: u128 = 0x00000000000000000000FFFFFFFFFFFFFFFF;
-        let new_ulid = (id.0 & TIMESTAMP_MASK) | ((ttl_epoch as u128) << 80);
-        Self {
-            id: Ulid(new_ulid),
-            parent: None,
-        }
+        Self::ttl_transaction_with_multiplier(1)
     }
 
     /// Like [`ttl_transaction`](Self::ttl_transaction) but with a custom TTL multiplier.
@@ -141,6 +130,7 @@ impl Transaction {
         let ttl_ms = crate::config::OPERATION_TTL.as_millis() as u64 * multiplier;
         let ttl_epoch: u64 = ts.saturating_sub(ttl_ms);
 
+        // Clear the timestamp bits and replace with the cutoff timestamp.
         const TIMESTAMP_MASK: u128 = 0x00000000000000000000FFFFFFFFFFFFFFFF;
         let new_ulid = (id.0 & TIMESTAMP_MASK) | ((ttl_epoch as u128) << 80);
         Self {
@@ -935,6 +925,34 @@ mod tests {
         assert!(
             original_tx.id.timestamp_ms() - ttl_tx.id.timestamp_ms()
                 < crate::config::OPERATION_TTL.as_millis() as u64 + 5
+        );
+    }
+
+    #[test]
+    fn ttl_transaction_with_multiplier_produces_older_cutoff() {
+        let ttl_1x = Transaction::ttl_transaction();
+        let ttl_5x = Transaction::ttl_transaction_with_multiplier(5);
+
+        // 5x multiplier should produce an older (smaller timestamp) cutoff
+        assert!(ttl_5x < ttl_1x, "5x multiplier should be older than 1x");
+
+        // Verify the timestamp delta is approximately 4x OPERATION_TTL more
+        let diff = ttl_1x.id.timestamp_ms() - ttl_5x.id.timestamp_ms();
+        let expected = crate::config::OPERATION_TTL.as_millis() as u64 * 4;
+        assert!(
+            diff >= expected.saturating_sub(10) && diff <= expected + 10,
+            "Timestamp delta should be ~4x OPERATION_TTL, got {diff}ms vs expected {expected}ms"
+        );
+
+        // multiplier(1) should be equivalent to ttl_transaction()
+        let ttl_1x_via_multiplier = Transaction::ttl_transaction_with_multiplier(1);
+        let diff_1x = ttl_1x
+            .id
+            .timestamp_ms()
+            .abs_diff(ttl_1x_via_multiplier.id.timestamp_ms());
+        assert!(
+            diff_1x < 5,
+            "multiplier(1) should be ~equivalent to ttl_transaction(), diff={diff_1x}ms"
         );
     }
 

--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -1076,7 +1076,7 @@ where
                     if let Some((key, state)) =
                         get_contract_state_by_id(&op_manager, &instance_id).await
                     {
-                        tracing::info!(
+                        tracing::debug!(
                             contract = %key,
                             peer = %source_pub_key,
                             "Proximity cache overlap — broadcasting state to ensure neighbor is current"
@@ -1652,34 +1652,12 @@ async fn get_contract_state(
     op_manager: &Arc<OpManager>,
     key: &freenet_stdlib::prelude::ContractKey,
 ) -> Option<freenet_stdlib::prelude::WrappedState> {
-    use crate::contract::ContractHandlerEvent;
-
-    match op_manager
-        .notify_contract_handler(ContractHandlerEvent::GetQuery {
-            instance_id: *key.id(),
-            return_contract_code: false,
-        })
+    get_contract_state_by_id(op_manager, key.id())
         .await
-    {
-        Ok(ContractHandlerEvent::GetResponse {
-            response: Ok(store_response),
-            ..
-        }) => store_response.state,
-        Ok(ContractHandlerEvent::GetResponse {
-            response: Err(e), ..
-        }) => {
-            tracing::warn!(
-                contract = %key,
-                error = %e,
-                "Failed to get contract state"
-            );
-            None
-        }
-        _ => None,
-    }
+        .map(|(_, state)| state)
 }
 
-/// Get the contract state by instance ID, returning both the full ContractKey and state.
+/// Get the contract state by instance ID, returning both the full `ContractKey` and state.
 ///
 /// Used for proactive state sync when proximity cache discovers overlapping contracts,
 /// where we only have a `ContractInstanceId` (not a full `ContractKey`).

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1479,8 +1479,10 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                     Reverse(Transaction::ttl_transaction_with_multiplier(5));
                 for Reverse(tx) in ttl_set.split_off(&older_than).into_iter() {
                     if ops.under_progress.contains(&tx) {
-                        // Allow extended lifetime unless absolute timeout exceeded
-                        if Reverse(tx) >= absolute_cutoff {
+                        // Allow extended lifetime unless absolute timeout exceeded.
+                        // Reverse flips ordering: Reverse(tx) < absolute_cutoff means
+                        // tx is newer than the 5× TTL cutoff, so keep it alive.
+                        if Reverse(tx) < absolute_cutoff {
                             delayed.push(tx);
                             continue;
                         }

--- a/crates/core/src/node/proximity_cache.rs
+++ b/crates/core/src/node/proximity_cache.rs
@@ -44,6 +44,24 @@ pub struct ProximityCacheResult {
     pub overlapping_contracts: Vec<ContractInstanceId>,
 }
 
+impl ProximityCacheResult {
+    /// Shorthand for a response-only result with no overlapping contracts.
+    fn response_only(response: ProximityCacheMessage) -> Self {
+        Self {
+            response: Some(response),
+            overlapping_contracts: vec![],
+        }
+    }
+
+    /// Shorthand for a result with no response and no overlapping contracts.
+    fn empty() -> Self {
+        Self {
+            response: None,
+            overlapping_contracts: vec![],
+        }
+    }
+}
+
 /// Manages proximity-based cache tracking for UPDATE forwarding.
 ///
 /// Tracks:
@@ -192,11 +210,15 @@ impl ProximityCacheManager {
                 // Don't respond to responses - this prevents ping-pong.
                 // The is_response flag indicates the sender was already responding
                 // to our announcement, so they already know we have these contracts.
+                //
+                // Returning empty overlapping_contracts here means only the initial
+                // announcer's side triggers proactive state sync. This is intentional:
+                // if the responding peer has newer state, the CRDT merge at the
+                // broadcast recipient produces CurrentWon → emits its own
+                // BroadcastStateChange back — so stale state self-corrects within
+                // one round-trip.
                 if is_response {
-                    return ProximityCacheResult {
-                        response: None,
-                        overlapping_contracts: vec![],
-                    };
+                    return ProximityCacheResult::empty();
                 }
 
                 // Find contracts that are:
@@ -244,10 +266,9 @@ impl ProximityCacheManager {
                     "PROXIMITY_CACHE: Responding to cache state request"
                 );
 
-                ProximityCacheResult {
-                    response: Some(ProximityCacheMessage::CacheStateResponse { contracts }),
-                    overlapping_contracts: vec![],
-                }
+                ProximityCacheResult::response_only(ProximityCacheMessage::CacheStateResponse {
+                    contracts,
+                })
             }
 
             ProximityCacheMessage::CacheStateResponse { contracts } => {
@@ -589,6 +610,8 @@ mod tests {
             result.response.is_some(),
             "Expected reciprocal announcement for overlapping contract"
         );
+        assert_eq!(result.overlapping_contracts.len(), 1);
+        assert_eq!(result.overlapping_contracts[0], *key.id());
 
         if let Some(ProximityCacheMessage::CacheAnnounce {
             added,
@@ -636,6 +659,10 @@ mod tests {
             result.response.is_none(),
             "No response expected when contracts don't overlap"
         );
+        assert!(
+            result.overlapping_contracts.is_empty(),
+            "No overlapping contracts when contracts don't match"
+        );
     }
 
     #[test]
@@ -664,6 +691,12 @@ mod tests {
             result.response.is_some(),
             "Expected response for partial overlap"
         );
+        assert_eq!(
+            result.overlapping_contracts.len(),
+            1,
+            "Only contract X should overlap"
+        );
+        assert_eq!(result.overlapping_contracts[0], *key_x.id());
 
         if let Some(ProximityCacheMessage::CacheAnnounce {
             added,
@@ -734,6 +767,10 @@ mod tests {
         assert!(
             a_second_result.response.is_none(),
             "Ping-pong must terminate: A should not respond to B's reciprocal announcement"
+        );
+        assert!(
+            a_second_result.overlapping_contracts.is_empty(),
+            "is_response=true must not trigger proactive state sync"
         );
     }
 
@@ -964,6 +1001,8 @@ mod tests {
             a_result.response.is_some(),
             "CRITICAL: A must announce overlapping contracts when receiving CacheStateResponse"
         );
+        assert_eq!(a_result.overlapping_contracts.len(), 1);
+        assert_eq!(a_result.overlapping_contracts[0], *key.id());
 
         if let Some(ProximityCacheMessage::CacheAnnounce {
             added,
@@ -1009,6 +1048,10 @@ mod tests {
         assert!(
             result.response.is_none(),
             "No announcement needed when no contracts overlap"
+        );
+        assert!(
+            result.overlapping_contracts.is_empty(),
+            "No overlapping contracts when caches don't intersect"
         );
 
         // But B's contracts should still be tracked

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -87,9 +87,14 @@ pub(super) async fn contract_home(
     let recv_result =
         tokio::time::timeout(std::time::Duration::from_secs(30), response_recv.recv()).await;
     let response = match recv_result {
-        Err(_) | Ok(None) => {
+        Err(_) => {
             return Err(WebSocketApiError::NodeError {
-                error_cause: "GET request timed out".into(),
+                error_cause: "GET request timed out after 30s".into(),
+            });
+        }
+        Ok(None) => {
+            return Err(WebSocketApiError::NodeError {
+                error_cause: "GET response channel closed (node may be shutting down)".into(),
             });
         }
         Ok(Some(HostCallbackResult::Result {


### PR DESCRIPTION
## Problem

After fixing hosting collapse (contracts losing upstream subscriptions), two production problems remained:

1. **No proactive state sync**: When a peer discovers a neighbor shares a contract (via proximity cache), it only records that fact for future UPDATE targeting. It never pushes updates to stale neighbors. After restart, peers serve stale state indefinitely until the next UPDATE.

2. **GET requests hang forever**: The web gateway calls `response_recv.recv().await` with no timeout. GET operations that reach a peer without the contract get stuck in `under_progress` state, exempt from the 60s garbage cleanup timeout. Result: 76% GET failure rate in production.

3. **under_progress GC exemption is unbounded**: Operations marked `under_progress` are exempt from garbage collection with no absolute limit, causing permanent resource leaks for stuck operations.

## Approach

### Proactive State Sync
When proximity cache discovers overlapping contracts with a neighbor (via `CacheAnnounce` or `CacheStateResponse`), emit `BroadcastStateChange` for each shared contract. The existing broadcast path at `p2p_protoc.rs:4026` already:
- Computes summaries and deltas per target peer
- Skips peers whose summaries match (no-op if neighbor is already current)
- Handles delta=None (uses full state)

So this is safe to fire even if the neighbor already has the latest state.

**Key design**: `handle_message()` now returns `ProximityCacheResult` containing both the response message and a list of overlapping contracts, keeping the proximity cache module focused on cache tracking while letting the caller (`node/mod.rs`) handle the broadcast side-effect.

### GET Timeout
30s `tokio::time::timeout` around `response_recv.recv().await` in `path_handlers.rs`. Timeout or channel close returns a clean error instead of hanging forever.

### under_progress Absolute Timeout
Added `Transaction::ttl_transaction_with_multiplier(5)` to create a 5× TTL cutoff (5 minutes). Operations in `under_progress` exceeding this absolute timeout are cleaned up with a warning log, following the "cleanup exemptions MUST be time-bounded" rule from AGENTS.md.

## Testing

- All 17 proximity cache unit tests updated and passing
- All 1752 library tests passing
- `cargo fmt` and `cargo clippy --all-targets` clean
- Proactive sync verified via existing broadcast path (no-op when summaries match)

## Files Changed

| File | Change |
|------|--------|
| `proximity_cache.rs` | New `ProximityCacheResult` struct, updated `handle_message()` return type |
| `node/mod.rs` | Trigger `BroadcastStateChange` for overlapping contracts, add `get_contract_state_by_id()` helper |
| `path_handlers.rs` | 30s timeout on GET response channel |
| `op_state_manager.rs` | Absolute 5×TTL timeout for `under_progress` operations |
| `message.rs` | `Transaction::ttl_transaction_with_multiplier()` |

[AI-assisted - Claude]