### PR TITLE
fix: address review feedback from PRs #3341 and #3347

### DIFF
--- a/.cargo
+++ b/.cargo
@@ -1,1 +1,0 @@
-/home/ian/code/freenet/freenet-core/main/.cargo

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 aider_stdlib_map.md
 
+# Cargo config (developer-local symlink for shared target dir)
+.cargo
+
 # Local tools and notes
 .local-tools/
 *.local/

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4181,30 +4181,11 @@ async fn test_client_disconnect_triggers_upstream_unsubscribe(ctx: &mut TestCont
         }
     }
 
-    // In a 3-node topology (gateway, node-a, node-b), the upstream peer for
-    // node-b's subscription may be the gateway. The Unsubscribe message goes
-    // node-b → gateway, and the gateway may or may not chain-propagate to
-    // node-a depending on its own subscription state. If upstream peer
-    // registration failed silently during the subscribe handshake (source_addr
-    // was None or peer lookup failed), no Unsubscribe is sent at all.
-    //
-    // We assert on UnsubscribeSent (local observable) which proves the client
-    // disconnect triggered the unsubscribe path. UnsubscribeReceived depends
-    // on network delivery and chain propagation, which is timing-sensitive.
-    if unsubscribe_sent_count > 0 {
-        tracing::info!("UnsubscribeSent confirmed — disconnect triggered unsubscribe path");
-    }
-    if unsubscribe_received_count > 0 {
-        tracing::info!("UnsubscribeReceived confirmed — upstream received unsubscribe");
-    }
-
-    // At minimum, one of the unsubscribe events must have been observed.
-    // UnsubscribeSent proves node-b attempted to send, UnsubscribeReceived
-    // proves the upstream got it. Either confirms the disconnect → unsubscribe
-    // path works.
+    // The polling loop above waits up to 30s for UnsubscribeReceived.
+    // Assert the strong condition: upstream must have received the unsubscribe.
     assert!(
-        unsubscribe_sent_count > 0 || unsubscribe_received_count > 0,
-        "Client disconnect should trigger Unsubscribe upstream \
+        unsubscribe_received_count > 0,
+        "Upstream node should have received the Unsubscribe message after client disconnect \
          (sent={unsubscribe_sent_count}, received={unsubscribe_received_count})"
     );
 


### PR DESCRIPTION
## Summary

- Remove accidentally committed `.cargo` symlink from git tracking and add to `.gitignore` — this was a developer-local path that breaks builds for other contributors (flagged in #3341 review)
- Restore strong test assertion in `test_client_disconnect_triggers_upstream_unsubscribe`: require `unsubscribe_received_count > 0` instead of the weakened `sent || received` disjunction (flagged in #3347 review)

## Test plan

- [ ] CI passes with the restored strong assertion
- [ ] `.cargo` no longer tracked by git

[AI-assisted - Claude]