### PR TITLE
fix: cache contract code at relay peers and notify clients on GET failure

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1298,15 +1298,14 @@ fn remove_get_and_report_failure(ops: &Ops, tx: &Transaction, ring: &crate::ring
             report_timeout_failure(ring, tx, peer, contract_location);
         }
         // Log GET timeout so failures are visible in traces
-        if let Some(instance_id) = get_op.instance_id() {
-            tracing::warn!(
-                tx = %tx,
-                %instance_id,
-                elapsed_ms = tx.elapsed().as_millis(),
-                phase = "get_timeout",
-                "GET operation timed out without receiving a response"
-            );
-        }
+        let instance_id = get_op.instance_id();
+        tracing::warn!(
+            tx = %tx,
+            instance_id = ?instance_id,
+            elapsed_ms = tx.elapsed().as_millis(),
+            phase = "get_timeout",
+            "GET operation timed out without receiving a response"
+        );
         true
     } else {
         false

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use std::{future::Future, time::Instant};
 
 use crate::client_events::HostResult;
+use crate::config::GlobalExecutor;
 use crate::node::IsOperationCompleted;
 use crate::{
     contract::{ContractHandlerEvent, StoreResponse},
@@ -2020,32 +2021,43 @@ impl Operation for GetOp {
                             contract: contract.clone(),
                         });
                     } else {
-                        // Forward response to upstream, opportunistically caching
-                        // contract code so relay peers can serve future GET requests
-                        // with fetch_contract=true.
+                        // Forward response to upstream. Opportunistically cache contract
+                        // code so this relay peer can serve future GET requests with
+                        // fetch_contract=true. We don't call announce_contract_cached()
+                        // here because relay peers should not advertise contracts they
+                        // are not responsible for in the ring.
                         tracing::info!(tx = %id, contract = %key, phase = "response", "Get response received for contract at hop peer");
                         if let Some(ref code) = contract {
-                            let cached = matches!(
-                                op_manager
-                                    .notify_contract_handler(ContractHandlerEvent::PutQuery {
-                                        key,
-                                        state: value.clone(),
-                                        related_contracts: RelatedContracts::default(),
-                                        contract: Some(code.clone()),
-                                    })
-                                    .await,
-                                Ok(ContractHandlerEvent::PutResponse {
-                                    new_value: Ok(_),
-                                    ..
-                                })
-                            );
-                            tracing::debug!(
-                                tx = %id,
-                                contract = %key,
-                                phase = "relay_cache",
-                                cached,
-                                "Relay peer contract code cache attempt"
-                            );
+                            if !op_manager.ring.is_hosting_contract(&key) {
+                                let om = op_manager.clone();
+                                let cache_key = key;
+                                let v = value.clone();
+                                let c = code.clone();
+                                GlobalExecutor::spawn(async move {
+                                    let key_str = cache_key.to_string();
+                                    let cached = matches!(
+                                        om.notify_contract_handler(
+                                            ContractHandlerEvent::PutQuery {
+                                                key: cache_key,
+                                                state: v,
+                                                related_contracts: RelatedContracts::default(),
+                                                contract: Some(c),
+                                            }
+                                        )
+                                        .await,
+                                        Ok(ContractHandlerEvent::PutResponse {
+                                            new_value: Ok(_),
+                                            ..
+                                        })
+                                    );
+                                    tracing::info!(
+                                        contract = %key_str,
+                                        phase = "relay_cache",
+                                        cached,
+                                        "Relay peer contract code cache attempt"
+                                    );
+                                });
+                            }
                         }
                         new_state = None;
                         return_msg = Some(GetMsg::Response {


### PR DESCRIPTION
## Problem

GET operations fail 94% of the time (#3356). Analysis shows two issues:
1. **Silent failures**: When GET operations fail (no peers found, max retries exhausted, timeout), the client is never notified — the operation silently completes via `OperationResult::Completed` which doesn't call `send_client_result`
2. **Missing contract code at relay peers**: UPDATE broadcasts distribute only state deltas, never WASM bytecode. Peers that receive state via UPDATE can't serve `fetch_contract=true` GET requests because they lack the contract code

## Approach

1. **Client notification on GET failure**: Added `notify_get_failed()` helper that sends explicit `OperationError` to the client at three failure paths that previously completed silently
2. **Relay peer contract code caching**: When a relay peer forwards a successful GET response containing contract code, it now opportunistically caches the code+state locally via a fire-and-forget `PutQuery`. This spreads WASM code organically through the network as GETs traverse it. Relay peers don't call `announce_contract_cached()` since they shouldn't advertise contracts they're not responsible for in the ring
3. **GET timeout logging**: Added warn-level logging when GET operations time out, including transaction ID, instance ID, and elapsed time
4. **Log level upgrades**: Changed "contract code missing" logs from debug to info for production visibility

## Testing

- `cargo fmt` — clean
- `cargo clippy --all-targets` — clean  
- `cargo test -p freenet` — all tests pass
- `send_client_result` is idempotent — calling it when no client is listening logs an error but doesn't panic
- The three `notify_get_failed` call sites are correctly guarded to only fire at the original requester (not relay peers)

## Partially addresses

Related to #3356 — this fixes silent failures and missing contract code propagation but does not address the separate issue of GETs not being forwarded when `k_closest_potentially_caching()` returns empty

[AI-assisted - Claude]