### PR TITLE
fix: remove stale subscriptions from dashboard when they expire

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -190,7 +190,6 @@ pub fn record_contract_updated(key_encoded: &str) {
 }
 
 /// Record a subscription removal.
-#[cfg(test)]
 pub fn record_subscription_removed(key_encoded: &str) {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -242,6 +242,7 @@ impl HostingManager {
     /// (in the hosting cache) until evicted by LRU.
     pub fn unsubscribe(&self, contract: &ContractKey) {
         if self.active_subscriptions.remove(contract).is_some() {
+            crate::node::network_status::record_subscription_removed(&format!("{contract}"));
             debug!(%contract, "unsubscribe: removed active subscription");
         }
     }
@@ -298,6 +299,9 @@ impl HostingManager {
         });
 
         if !expired.is_empty() {
+            for contract in &expired {
+                crate::node::network_status::record_subscription_removed(&format!("{contract}"));
+            }
             info!(
                 expired_count = expired.len(),
                 "expire_stale_subscriptions: expired stale subscriptions"


### PR DESCRIPTION
## Problem

The dashboard at `http://127.0.0.1:7509/` shows a "Subscribed Contracts" card that accumulates entries forever. `record_subscription()` is called when a subscription is accepted (`subscribe.rs:1117`), but `record_subscription_removed()` was gated behind `#[cfg(test)]` and never called in production (`network_status.rs:193`).

After the subscription renewal fix (v0.1.162, PR #3363), users reported seeing 602 contracts on their dashboard despite only having 1 active subscription. The fix was working correctly (subscription renewal dropped from 350+/cycle to 2-10/cycle), but the dashboard was showing all historically-subscribed contracts.

## Approach

Make `record_subscription_removed()` available in production (remove `#[cfg(test)]`) and call it from the two production subscription removal paths:

1. **`expire_stale_subscriptions()`** — when subscriptions expire by TTL (8 minute lease)
2. **`unsubscribe()`** — when subscriptions are explicitly removed

These are the only two methods that remove entries from `active_subscriptions` (the authoritative subscription state in `HostingManager`). Other removal paths like `force_subscription_renewal()` just trigger re-subscription and shouldn't remove from the dashboard.

## Testing

- Existing `test_subscription_tracking` test already covers the `record_subscription` → `record_subscription_removed` → verify empty flow
- The test was previously only compiled with `#[cfg(test)]` for the removal function — now it validates the production code path
- `cargo fmt`, `cargo clippy --all-targets --all-features`, `cargo test -p freenet` all pass

## Why didn't CI catch this?

This is a UX bug in dashboard display logic, not a functional issue. The subscription system itself works correctly — the dashboard just wasn't cleaning up its display state. Unit tests for `network_status` already existed and covered the add/remove flow, but the removal was test-only code that was never wired into production.

[AI-assisted - Claude]