### PR TITLE
fix: forward update notifications to subscribers when local apply fails

### DIFF
--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -599,6 +599,31 @@ impl Operation for UpdateOp {
                                     tracing::warn!(tx = %id, error = %e, "failed to send ResyncRequest");
                                 }
                             }
+
+                            // Even though we couldn't apply the update locally (e.g.,
+                            // missing contract parameters at this relay node), we must
+                            // still forward the payload to downstream subscribers.
+                            // Without this, relay nodes that acquired a contract via
+                            // subscribe (without contract code) become black holes for
+                            // update notifications.
+                            tracing::info!(
+                                tx = %id,
+                                contract = %key,
+                                event = "relay_forward_on_local_failure",
+                                "Forwarding update to subscribers despite local apply failure"
+                            );
+                            if let Err(e) = op_manager
+                                .notify_node_event(
+                                    crate::message::NodeEvent::BroadcastStateChange {
+                                        key: *key,
+                                        new_state: state_for_telemetry.clone(),
+                                    },
+                                )
+                                .await
+                            {
+                                tracing::warn!(tx = %id, error = %e, "failed to forward BroadcastStateChange");
+                            }
+
                             return Err(err);
                         }
                     };


### PR DESCRIPTION
## Summary

When a relay node receives a `BroadcastTo` update for a contract it acquired via subscribe (without contract code/parameters), the delta application fails with "missing contract parameters". Previously this caused the handler to return `Err` immediately, silently dropping the update and preventing it from reaching downstream subscribers.

This turns relay nodes into "black holes" for update notifications — they subscribe to contracts but never forward updates they receive.

## Root Cause

After v0.1.160, `#3360` changed GET to cache contract code but subscribe does not cache it. When a relay node acquires a contract via subscribe (which happens naturally as part of the subscription relay chain), it stores the contract state but not the WASM code or parameters. When an update arrives at this relay:

1. `upsert_contract_state` is called to apply the delta
2. It fails because the contract parameters are missing (no WASM to execute)
3. The `BroadcastTo` handler returns `Err(err)` immediately
4. **The update is never forwarded to downstream subscribers**

This is particularly impactful in star topologies where the gateway acts as a routing hub — if the gateway is a relay for a contract, no subscriber behind it receives updates.

## Fix

Emit a `BroadcastStateChange` event before returning the error, so the update payload is still forwarded to downstream subscribers even when the relay cannot apply it locally. The relay also sends a `ResyncRequest` to the sender to eventually fix its own local state (existing behavior).

## Test Plan

- Tested with a 7-node local network (gateway + 3 app nodes + 3 guardian nodes)
- Before fix: `product_count_increments_for_subscriber` integration test consistently timed out — subscriber on node 3002 never received update notifications for contracts PUT on node 3004, because the gateway (3001) couldn't apply the delta and dropped it
- After fix: All 11 integration test steps pass, including Step 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)