### PR TITLE
fix: register peer interest from Summaries to prevent NO_TARGETS race

### DIFF
--- a/crates/core/src/node/mod.rs
+++ b/crates/core/src/node/mod.rs
@@ -1350,19 +1350,16 @@ async fn handle_interest_sync_message(
             );
 
             // Update peer summaries and detect stale peers (#3221).
+            // Also register unregistered peers from Summaries (NO_TARGETS fix).
             //
             // Compare each peer summary with our own before storing it. If they
             // differ, the peer missed an earlier broadcast. Emitting
             // BroadcastStateChange triggers the existing broadcast path which
             // computes deltas and sends state only to peers with stale summaries.
             //
-            // Both sides may detect the same mismatch (A sees B is stale, B sees
-            // A is stale). This is safe: the contract's merge semantics (CRDTs
-            // etc.) ensure the newer/correct state wins regardless of push order.
-            //
-            // When either summary is None, we skip the comparison. A peer with
-            // no summary has no state yet and should receive it via the normal
-            // subscription/GET flow, not via broadcast.
+            // If a peer responds with Summaries but isn't registered as interested,
+            // register them — they have the contract and are tracking its state.
+            // Without registration, they won't appear in get_broadcast_targets_update().
             let peer_key = get_peer_key_from_addr(op_manager, source);
             let mut stale_contracts = Vec::new();
 
@@ -1374,21 +1371,42 @@ async fn handle_interest_sync_message(
                         }
 
                         let their_summary = entry.to_summary();
-                        let our_summary = get_contract_summary(op_manager, &contract).await;
 
-                        let is_stale = our_summary
-                            .as_ref()
-                            .zip(their_summary.as_ref())
-                            .is_some_and(|(ours, theirs)| ours.as_ref() != theirs.as_ref());
+                        if op_manager
+                            .interest_manager
+                            .get_peer_interest(&contract, &pk)
+                            .is_some()
+                        {
+                            // Peer already registered — update summary and check staleness
+                            let our_summary = get_contract_summary(op_manager, &contract).await;
 
-                        op_manager.interest_manager.update_peer_summary(
-                            &contract,
-                            &pk,
-                            their_summary,
-                        );
+                            let is_stale = our_summary
+                                .as_ref()
+                                .zip(their_summary.as_ref())
+                                .is_some_and(|(ours, theirs)| ours.as_ref() != theirs.as_ref());
 
-                        if is_stale && !stale_contracts.contains(&contract) {
-                            stale_contracts.push(contract);
+                            op_manager.interest_manager.update_peer_summary(
+                                &contract,
+                                &pk,
+                                their_summary,
+                            );
+
+                            if is_stale && !stale_contracts.contains(&contract) {
+                                stale_contracts.push(contract);
+                            }
+                        } else {
+                            // Peer not yet registered — register with summary for delta sync
+                            op_manager.interest_manager.register_peer_interest(
+                                &contract,
+                                pk.clone(),
+                                their_summary,
+                                false,
+                            );
+                            tracing::debug!(
+                                from = %source,
+                                contract = %format!("{:.8}", contract),
+                                "Registered new peer interest from Summaries response"
+                            );
                         }
                     }
                 }

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -37,7 +37,7 @@ use crate::transport::{
 };
 use crate::{
     client_events::ClientId,
-    config::GlobalExecutor,
+    config::{GlobalExecutor, GlobalRng},
     contract::{
         ContractHandlerChannel, ExecutorToEventLoopChannel, NetworkEventListenerHalve,
         WaitingResolution,
@@ -3885,10 +3885,12 @@ impl P2pConnManager {
     }
 
     /// Maximum retry attempts when a broadcast finds no targets.
-    const MAX_BROADCAST_RETRIES: u8 = 3;
+    const MAX_BROADCAST_RETRIES: u8 = 5;
 
     /// Base delay between broadcast retries (scaled by attempt number for linear backoff).
-    const BROADCAST_RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
+    /// Total window: 2+4+6+8+10 = 30s, giving ChangeInterests/Summaries round-trips
+    /// ample time to complete and register peer interests.
+    const BROADCAST_RETRY_BASE_DELAY: Duration = Duration::from_secs(2);
 
     /// Notify interested network peers about a state change.
     ///
@@ -3940,7 +3942,9 @@ impl P2pConnManager {
                 );
                 // Schedule a delayed re-emission of BroadcastStateChange
                 let op_mgr = op_manager.clone();
-                let delay = Self::BROADCAST_RETRY_BASE_DELAY * u32::from(attempt);
+                let base_delay = Self::BROADCAST_RETRY_BASE_DELAY * u32::from(attempt);
+                let jitter = GlobalRng::random_range(0.8f64..1.2);
+                let delay = base_delay.mul_f64(jitter);
                 tokio::spawn(async move {
                     tokio::time::sleep(delay).await;
                     if let Err(e) = op_mgr


### PR DESCRIPTION
## Summary

Fixes a race condition where broadcast updates find no targets (NO_TARGETS) because peers discovered via the Summaries interest-sync response are never registered as interested.

**Root cause**: The `InterestMessage::Summaries` handler only called `update_peer_summary()`, which is a no-op when the peer isn't already in the interest table. This creates a window where:

1. Peer A puts a contract and broadcasts `ChangeInterests`
2. Peer B hasn't subscribed yet, drops `ChangeInterests` (no local interest)
3. Peer B subscribes (local-complete), broadcasts its own `ChangeInterests`
4. Peer A responds with `Summaries`, but Peer B never registered Peer A
5. Peer B tries to broadcast an update → **NO_TARGETS** (peer A is invisible)

**Fix**: When receiving Summaries, check if the peer is already registered via `get_peer_interest()`. If not, call `register_peer_interest()` with the summary they provided and `is_upstream: false`. A peer responding with Summaries proves they have the contract and are tracking its state.

### Changes

- **`crates/core/src/node/mod.rs`** — Summaries handler: register unregistered peers instead of silently dropping their summary
- **`crates/core/src/node/network_bridge/p2p_protoc.rs`** — Increase broadcast retry window from 6s to ~30s (5 retries × 2s base × linear backoff) with ±20% jitter as a safety net

### Reviewer note on `is_upstream=false`

`is_upstream` is only used in `op_state_manager.rs:642` to find the upstream peer for unsubscribe propagation. It does **not** affect delta computation or broadcast targeting. `false` is correct here: the Summaries sender is a downstream subscriber relative to us.

### Note on serialization

This PR does not touch `TransportPublicKey` serialization. The `#[serde(default)]` concern from #3284 is not applicable here.

## Replaces

Replaces #3284 (`fix/combined-fixes`), which was a combined branch where most commits have since been merged via #3202 and #3206. This PR contains only the remaining unique fix (originally commit 695ba9d4).

## Test plan

- [x] `cargo build -p freenet --release` — compiles clean
- [ ] CI `ci_quick_simulation` passes
- [ ] Integration tests with CREAM (`cargo make test-node`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)