### PR TITLE
feat: add clickable peer detail page to local dashboard

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -3238,7 +3238,7 @@ impl P2pConnManager {
 
         if newly_inserted {
             tracing::info!(peer_id = ?peer_id, %peer_addr, is_transient, "handle_successful_connection: inserted new connection entry");
-            crate::node::network_status::record_peer_connected(peer_addr, None);
+            crate::node::network_status::record_peer_connected(peer_addr, None, None);
             if promote_to_ring {
                 // Only prune reservation when promoting to ring - transient connections
                 // don't go through should_accept() so they have no reservation to prune
@@ -3282,7 +3282,12 @@ impl P2pConnManager {
                     .ring
                     .add_connection(loc, PeerId::new(peer_addr, peer.pub_key().clone()), true)
                     .await;
-                crate::node::network_status::record_peer_connected(peer_addr, Some(loc.as_f64()));
+                let pkl = crate::ring::PeerKeyLocation::new(peer.pub_key().clone(), peer_addr);
+                crate::node::network_status::record_peer_connected(
+                    peer_addr,
+                    Some(loc.as_f64()),
+                    Some(pkl),
+                );
                 // Only count as NAT success for non-gateway peers (gateway connections are direct)
                 if !crate::node::network_status::is_known_gateway(&peer_addr) {
                     crate::node::network_status::record_nat_attempt(true);

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -9,7 +9,23 @@ use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Instant;
 
+use crate::ring::PeerKeyLocation;
+use crate::router::Router;
+
 static NETWORK_STATUS: OnceLock<Arc<RwLock<NetworkStatus>>> = OnceLock::new();
+static ROUTER: OnceLock<Arc<parking_lot::RwLock<Router>>> = OnceLock::new();
+
+/// Store a reference to the Router for the dashboard.
+pub fn set_router(router: Arc<parking_lot::RwLock<Router>>) {
+    // OnceLock::set returns Err if already initialized; this is expected on repeated calls
+    #[allow(clippy::let_underscore_must_use)]
+    let _ = ROUTER.set(router);
+}
+
+/// Get the Router reference (if set).
+pub(crate) fn get_router() -> Option<Arc<parking_lot::RwLock<Router>>> {
+    ROUTER.get().cloned()
+}
 
 /// Tracked network connection status for diagnostic display.
 pub struct NetworkStatus {
@@ -39,6 +55,7 @@ pub struct ConnectedPeer {
     pub is_gateway: bool,
     pub location: Option<f64>,
     pub connected_since: Instant,
+    pub peer_key_location: Option<PeerKeyLocation>,
 }
 
 /// Info about a subscribed contract.
@@ -55,6 +72,9 @@ pub struct OperationStats {
     pub puts: (u32, u32),
     pub updates: (u32, u32),
     pub subscribes: (u32, u32),
+    /// Count of broadcast updates received via subscription streaming.
+    /// These are push-based and don't have success/failure semantics.
+    pub updates_received: u32,
 }
 
 /// NAT traversal attempt counters.
@@ -137,7 +157,11 @@ pub fn record_gateway_failure(address: SocketAddr, reason: FailureReason) {
 }
 
 /// Record a successful peer connection.
-pub fn record_peer_connected(addr: SocketAddr, location: Option<f64>) {
+pub fn record_peer_connected(
+    addr: SocketAddr,
+    location: Option<f64>,
+    peer_key_location: Option<PeerKeyLocation>,
+) {
     if let Some(status) = NETWORK_STATUS.get() {
         if let Ok(mut s) = status.write() {
             // Remove any existing entry for this address
@@ -148,6 +172,7 @@ pub fn record_peer_connected(addr: SocketAddr, location: Option<f64>) {
                 is_gateway,
                 location,
                 connected_since: Instant::now(),
+                peer_key_location,
             });
             s.gateway_failures.clear();
         }
@@ -217,6 +242,15 @@ pub fn record_op_result(op_type: OpType, success: bool) {
     }
 }
 
+/// Record a broadcast update received via subscription streaming.
+pub fn record_update_received() {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.op_stats.updates_received = s.op_stats.updates_received.saturating_add(1);
+        }
+    }
+}
+
 /// Record a NAT traversal attempt.
 pub fn record_nat_attempt(success: bool) {
     if let Some(status) = NETWORK_STATUS.get() {
@@ -269,6 +303,7 @@ pub struct PeerSnapshot {
     pub is_gateway: bool,
     pub location: Option<f64>,
     pub connected_secs: u64,
+    pub peer_key_location: Option<PeerKeyLocation>,
 }
 
 /// Snapshot of a subscribed contract.
@@ -286,6 +321,8 @@ pub struct OpStatsSnapshot {
     pub puts: (u32, u32),
     pub updates: (u32, u32),
     pub subscribes: (u32, u32),
+    /// Broadcast updates received via subscription streaming.
+    pub updates_received: u32,
 }
 
 impl OpStatsSnapshot {
@@ -296,6 +333,7 @@ impl OpStatsSnapshot {
             .saturating_add(sum(self.puts))
             .saturating_add(sum(self.updates))
             .saturating_add(sum(self.subscribes))
+            .saturating_add(self.updates_received)
     }
 }
 
@@ -359,6 +397,7 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
             is_gateway: p.is_gateway,
             location: p.location,
             connected_secs: now.duration_since(p.connected_since).as_secs(),
+            peer_key_location: p.peer_key_location.clone(),
         })
         .collect();
 
@@ -407,6 +446,7 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
             puts: s.op_stats.puts,
             updates: s.op_stats.updates,
             subscribes: s.op_stats.subscribes,
+            updates_received: s.op_stats.updates_received,
         },
         nat_stats: NatStatsSnapshot {
             attempts: s.nat_stats.attempts,
@@ -589,6 +629,7 @@ mod tests {
                 is_gateway: true,
                 location: Some(0.5),
                 connected_since: Instant::now(),
+                peer_key_location: None,
             });
         }
         let snap = get_snapshot().unwrap();
@@ -602,6 +643,7 @@ mod tests {
                 is_gateway: false,
                 location: Some(0.3),
                 connected_since: Instant::now(),
+                peer_key_location: None,
             });
         }
         let snap = get_snapshot().unwrap();
@@ -719,7 +761,7 @@ mod tests {
         }
 
         // Connect a non-gateway peer, then record a NAT failure to a different peer
-        record_peer_connected(peer_addr, Some(0.5));
+        record_peer_connected(peer_addr, Some(0.5), None);
         record_gateway_failure(fail_addr, FailureReason::NatTraversalFailed);
         let snap = get_snapshot().unwrap();
 
@@ -748,7 +790,7 @@ mod tests {
         }
 
         // Connect only a gateway peer, then record NAT failure
-        record_peer_connected(gw_addr, None);
+        record_peer_connected(gw_addr, None, None);
         record_gateway_failure(fail_addr, FailureReason::NatTraversalFailed);
         let snap = get_snapshot().unwrap();
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1075,6 +1075,7 @@ impl Operation for UpdateOp {
                                     "BroadcastToStreaming update produced no change"
                                 );
                             } else {
+                                crate::node::network_status::record_update_received();
                                 tracing::debug!(
                                     tx = %id,
                                     %key,

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -183,6 +183,7 @@ impl Ring {
         };
 
         let router = Arc::new(RwLock::new(Router::new(&[])));
+        crate::node::network_status::set_router(router.clone());
         task_monitor.register(
             "refresh_router",
             GlobalExecutor::spawn(Self::refresh_router(router.clone(), event_register.clone())),

--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -228,6 +228,20 @@ impl Adjustment {
     fn value(&self) -> f64 {
         self.sum / self.count as f64
     }
+
+    /// Mean adjustment value (sum / count).
+    pub(crate) fn mean(&self) -> f64 {
+        if self.count == 0 {
+            0.0
+        } else {
+            self.sum / self.count as f64
+        }
+    }
+
+    /// Number of events contributing to this adjustment.
+    pub(crate) fn event_count(&self) -> u64 {
+        self.count
+    }
 }
 
 // Tests

--- a/crates/core/src/router/mod.rs
+++ b/crates/core/src/router/mod.rs
@@ -86,6 +86,18 @@ pub(crate) struct RouterSnapshotInfo {
     pub connect_forward_peer_adjustments: Option<usize>,
 }
 
+/// Per-peer routing data for the dashboard detail page.
+pub(crate) struct PeerRoutingSnapshot {
+    /// (mean_adjustment, event_count) for the failure estimator.
+    pub failure_adjustment: Option<(f64, u64)>,
+    /// (mean_adjustment, event_count) for the response-time estimator.
+    pub response_time_adjustment: Option<(f64, u64)>,
+    /// (mean_adjustment, event_count) for the transfer-rate estimator.
+    pub transfer_rate_adjustment: Option<(f64, u64)>,
+    /// Prediction at the peer's own location (distance ≈ 0).
+    pub prediction_at_own_location: Option<RoutingPredictionInfo>,
+}
+
 /// # Usage
 /// Important when using this type:
 /// Need to periodically rebuild the Router using `history` for better predictions.
@@ -482,6 +494,38 @@ impl Router {
             connect_forward_curve: None,
             connect_forward_events: None,
             connect_forward_peer_adjustments: None,
+        }
+    }
+
+    /// Produce a per-peer routing snapshot for the dashboard detail page.
+    pub(crate) fn peer_snapshot(&self, peer: &PeerKeyLocation) -> PeerRoutingSnapshot {
+        let failure_adj = self
+            .failure_estimator
+            .peer_adjustments
+            .get(peer)
+            .map(|a| (a.mean(), a.event_count()));
+        let response_time_adj = self
+            .response_start_time_estimator
+            .peer_adjustments
+            .get(peer)
+            .map(|a| (a.mean(), a.event_count()));
+        let transfer_rate_adj = self
+            .transfer_rate_estimator
+            .peer_adjustments
+            .get(peer)
+            .map(|a| (a.mean(), a.event_count()));
+
+        // Compute a sample prediction at the peer's own location (distance=0)
+        let prediction = peer
+            .location()
+            .and_then(|loc| self.predict_routing_outcome(peer, loc).ok())
+            .map(RoutingPredictionInfo::from);
+
+        PeerRoutingSnapshot {
+            failure_adjustment: failure_adj,
+            response_time_adjustment: response_time_adj,
+            transfer_rate_adjustment: transfer_rate_adj,
+            prediction_at_own_location: prediction,
         }
     }
 

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -105,6 +105,10 @@ impl HttpClientApi {
 
         let router = Router::new()
             .route("/", axum::routing::get(home_page::homepage))
+            .route(
+                "/peer/{address}",
+                axum::routing::get(home_page::peer_detail),
+            )
             .merge(v1::routes(config.clone()))
             .merge(v2::routes(config))
             .layer(Extension(attested_contracts.clone()))

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -5,6 +5,7 @@
 
 use std::fmt::Write;
 
+use axum::extract::Path;
 use axum::response::{Html, IntoResponse};
 
 use crate::node::network_status::{self, format_ago, format_duration, html_escape};
@@ -12,6 +13,11 @@ use crate::node::network_status::{self, format_ago, format_duration, html_escape
 /// Handler for `GET /` — returns a self-contained HTML dashboard.
 pub(super) async fn homepage() -> impl IntoResponse {
     Html(homepage_html())
+}
+
+/// Handler for `GET /peer/{address}` — returns a detail page for a single peer.
+pub(super) async fn peer_detail(Path(address): Path<String>) -> impl IntoResponse {
+    Html(peer_detail_html(&address))
 }
 
 fn homepage_html() -> String {
@@ -336,7 +342,8 @@ fn build_peers_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> Str
             .map(|l| format!("{:.4}", l))
             .unwrap_or_else(|| "—".to_string());
         rows.push_str(&format!(
-            r#"<tr><td><code>{addr}</code></td><td>{loc}</td><td>{ptype}</td><td>{connected}</td></tr>"#,
+            r#"<tr class="peer-row" onclick="window.location='/peer/{addr_enc}'""><td><code>{addr}</code></td><td>{loc}</td><td>{ptype}</td><td>{connected}</td></tr>"#,
+            addr_enc = html_escape(&p.address.to_string()),
             addr = p.address,
             loc = loc,
             ptype = peer_type,
@@ -511,6 +518,36 @@ fn build_ops_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> Strin
         )
     }
 
+    // UPDATE cell: show received broadcast count (single number) since
+    // subscription-streamed updates are push-based and don't have success/failure.
+    // If there are also routed updates (with success/fail), show both.
+    let update_cell = {
+        let routed = ops.updates.0 + ops.updates.1;
+        let received = ops.updates_received;
+        if routed > 0 {
+            // Both routed and received
+            format!(
+                r#"<div class="op-cell">
+                    <div class="op-name">UPDATE</div>
+                    <div><span class="op-ok">{ok}</span> <span class="op-fail">{fail}</span></div>
+                    <div class="op-received">{recv} received</div>
+                </div>"#,
+                ok = ops.updates.0,
+                fail = ops.updates.1,
+                recv = received,
+            )
+        } else {
+            // Only received (common for subscriber nodes)
+            format!(
+                r#"<div class="op-cell">
+                    <div class="op-name">UPDATE</div>
+                    <div class="op-count">{recv}</div>
+                </div>"#,
+                recv = received,
+            )
+        }
+    };
+
     format!(
         r#"<div class="card">
             <h2>Operations</h2>
@@ -520,7 +557,7 @@ fn build_ops_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> Strin
         </div>"#,
         get = op_cell("GET", ops.gets.0, ops.gets.1),
         put = op_cell("PUT", ops.puts.0, ops.puts.1),
-        update = op_cell("UPDATE", ops.updates.0, ops.updates.1),
+        update = update_cell,
         subscribe = op_cell("SUBSCRIBE", ops.subscribes.0, ops.subscribes.1),
     )
 }
@@ -790,6 +827,8 @@ code {
     font-size: 0.85em;
     font-family: var(--font-mono);
 }
+.peer-row { cursor: pointer; transition: background 0.15s; }
+.peer-row:hover { background: var(--bg-tertiary); }
 .empty {
     color: var(--text-muted);
     font-size: 0.9rem;
@@ -821,6 +860,8 @@ code {
 .op-fail::before { content: "\2717 "; }
 [data-theme="light"] .op-ok { color: #059669; }
 [data-theme="light"] .op-fail { color: #dc2626; }
+.op-count { color: var(--text-primary); font-weight: 600; font-size: 1.1rem; }
+.op-received { color: var(--text-secondary); font-size: 0.7rem; margin-top: 0.15rem; }
 .app-list, .link-list {
     list-style: none;
     padding: 0;
@@ -925,6 +966,524 @@ document.addEventListener('DOMContentLoaded', function() {
         icon.textContent = '\uD83C\uDF19'; /* moon = click to switch to dark */
     }
 });
+"##;
+
+// ─── Peer detail page ────────────────────────────────────────────────────────
+
+fn peer_detail_html(address_str: &str) -> String {
+    let snap = network_status::get_snapshot();
+
+    let peer = snap.as_ref().and_then(|s| {
+        s.peers
+            .iter()
+            .find(|p| p.address.to_string() == address_str)
+    });
+
+    let Some(peer) = peer else {
+        return format!(
+            r##"<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Peer Not Found — Freenet</title>
+<style>{CSS}{PEER_CSS}</style><script>{JS}</script>
+</head><body>
+<header>
+    <div class="header-left">
+        <a href="/" class="logo-link"><img src="https://freenet.org/freenet_logo.svg" alt="Freenet" class="logo"></a>
+        <a href="/" class="header-title">FREENET</a>
+        <span class="header-sep">/</span>
+        <span class="header-scope">Peer</span>
+    </div>
+    <div class="header-right">
+        <button class="theme-btn" id="theme-btn" onclick="toggleTheme()" title="Toggle dark/light mode">
+            <span id="theme-icon">☀️</span>
+        </button>
+    </div>
+</header>
+<main>
+    <div class="card"><h2>Peer Not Found</h2><p class="empty">No connected peer with address <code>{addr}</code>. The peer may have disconnected.</p>
+    <p style="margin-top:0.75rem"><a href="/" style="color:var(--accent-light);font-family:var(--font-mono);font-size:0.85rem">&larr; Back to dashboard</a></p></div>
+</main></body></html>"##,
+            CSS = CSS,
+            PEER_CSS = PEER_CSS,
+            JS = JS,
+            addr = html_escape(address_str),
+        );
+    };
+
+    let peer_type = if peer.is_gateway { "Gateway" } else { "Peer" };
+    let loc_str = peer
+        .location
+        .map(|l| format!("{:.6}", l))
+        .unwrap_or_else(|| "—".to_string());
+
+    // Try to get router data
+    let router_lock = network_status::get_router();
+    let router_guard = router_lock.as_ref().map(|r| r.read());
+
+    let (router_snapshot, peer_routing) = match (&router_guard, &peer.peer_key_location) {
+        (Some(router), Some(pkl)) => (Some(router.snapshot()), Some(router.peer_snapshot(pkl))),
+        (Some(router), None) => (Some(router.snapshot()), None),
+        _ => (None, None),
+    };
+
+    // Build info card
+    let info_card = format!(
+        r#"<div class="card">
+            <h2>Peer Info</h2>
+            <div class="info-grid">
+                <div class="info-label">Address</div><div class="info-value"><code>{addr}</code></div>
+                <div class="info-label">Location</div><div class="info-value">{loc}</div>
+                <div class="info-label">Type</div><div class="info-value">{ptype}</div>
+                <div class="info-label">Connected</div><div class="info-value">{connected}</div>
+            </div>
+        </div>"#,
+        addr = html_escape(&peer.address.to_string()),
+        loc = loc_str,
+        ptype = peer_type,
+        connected = format_duration(peer.connected_secs),
+    );
+
+    // Build routing model status card
+    let model_card = if let Some(ref rs) = router_snapshot {
+        let total_events = rs.failure_events + rs.success_events;
+        let peer_failure_events = peer_routing
+            .as_ref()
+            .and_then(|pr| pr.failure_adjustment.map(|(_, c)| c))
+            .unwrap_or(0);
+        let peer_response_events = peer_routing
+            .as_ref()
+            .and_then(|pr| pr.response_time_adjustment.map(|(_, c)| c))
+            .unwrap_or(0);
+        let peer_transfer_events = peer_routing
+            .as_ref()
+            .and_then(|pr| pr.transfer_rate_adjustment.map(|(_, c)| c))
+            .unwrap_or(0);
+        format!(
+            r#"<div class="card">
+                <h2>Routing Model</h2>
+                <div class="info-grid">
+                    <div class="info-label">Prediction active</div><div class="info-value">{active}</div>
+                    <div class="info-label">Global events</div><div class="info-value">{total}</div>
+                    <div class="info-label">This peer: failure</div><div class="info-value">{pf} events</div>
+                    <div class="info-label">This peer: response time</div><div class="info-value">{pr} events</div>
+                    <div class="info-label">This peer: transfer rate</div><div class="info-value">{pt} events</div>
+                </div>
+            </div>"#,
+            active = if rs.prediction_active { "Yes" } else { "No" },
+            total = total_events,
+            pf = peer_failure_events,
+            pr = peer_response_events,
+            pt = peer_transfer_events,
+        )
+    } else {
+        r#"<div class="card"><h2>Routing Model</h2><p class="empty">Router data not available</p></div>"#.to_string()
+    };
+
+    // Build SVG charts
+    let charts = if let Some(ref rs) = router_snapshot {
+        let failure_chart = build_estimator_chart(
+            "Failure Probability",
+            &rs.failure_curve,
+            peer_routing
+                .as_ref()
+                .and_then(|pr| pr.failure_adjustment.map(|(m, _)| m)),
+            peer.location,
+            "0.0",
+            "1.0",
+        );
+        let response_chart = build_estimator_chart(
+            "Response Time (s)",
+            &rs.response_time_curve,
+            peer_routing
+                .as_ref()
+                .and_then(|pr| pr.response_time_adjustment.map(|(m, _)| m)),
+            peer.location,
+            "0",
+            "auto",
+        );
+        let transfer_chart = build_estimator_chart(
+            "Transfer Rate (B/s)",
+            &rs.transfer_rate_curve,
+            peer_routing
+                .as_ref()
+                .and_then(|pr| pr.transfer_rate_adjustment.map(|(m, _)| m)),
+            peer.location,
+            "auto",
+            "0",
+        );
+        format!(
+            r#"<div class="card">
+                <h2>PAV Regression Curves</h2>
+                <p class="chart-legend">
+                    <span class="chart-key"><span class="chart-dot chart-dot-global"></span> Global curve</span>
+                    <span class="chart-key"><span class="chart-dot chart-dot-peer"></span> Peer-adjusted curve</span>
+                    <span class="chart-key"><span class="chart-dot chart-dot-loc"></span> Peer location</span>
+                </p>
+                {failure_chart}
+                {response_chart}
+                {transfer_chart}
+            </div>"#,
+            failure_chart = failure_chart,
+            response_chart = response_chart,
+            transfer_chart = transfer_chart,
+        )
+    } else {
+        String::new()
+    };
+
+    // Build prediction summary card
+    let prediction_card = if let Some(ref pr) = peer_routing {
+        if let Some(ref pred) = pr.prediction_at_own_location {
+            format!(
+                r#"<div class="card">
+                    <h2>Prediction at Peer Location</h2>
+                    <div class="info-grid">
+                        <div class="info-label">Failure probability</div><div class="info-value">{fp:.4}</div>
+                        <div class="info-label">Response time</div><div class="info-value">{rt:.3}s</div>
+                        <div class="info-label">Expected total time</div><div class="info-value">{ett:.3}s</div>
+                        <div class="info-label">Transfer speed</div><div class="info-value">{ts:.0} B/s</div>
+                    </div>
+                </div>"#,
+                fp = pred.failure_probability,
+                rt = pred.time_to_response_start,
+                ett = pred.expected_total_time,
+                ts = pred.transfer_speed_bps,
+            )
+        } else {
+            r#"<div class="card"><h2>Prediction</h2><p class="empty">Insufficient data for prediction at this peer's location</p></div>"#.to_string()
+        }
+    } else {
+        String::new()
+    };
+
+    let snap_ref = snap.as_ref();
+    let version = snap_ref.map(|s| s.version.as_str()).unwrap_or("?");
+
+    format!(
+        r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="refresh" content="5">
+    <title>Peer {addr} — Freenet</title>
+    <style>{CSS}{PEER_CSS}</style>
+    <script>{JS}</script>
+</head>
+<body>
+    <header>
+        <div class="header-left">
+            <a href="/" class="logo-link"><img src="https://freenet.org/freenet_logo.svg" alt="Freenet" class="logo"></a>
+            <a href="/" class="header-title">FREENET</a>
+            <span class="header-sep">/</span>
+            <span class="header-scope">Peer</span>
+            <span class="header-addr">{addr}</span>
+            <span class="badge">v{version}</span>
+        </div>
+        <div class="header-right">
+            <button class="theme-btn" id="theme-btn" onclick="toggleTheme()" title="Toggle dark/light mode">
+                <span id="theme-icon">☀️</span>
+            </button>
+        </div>
+    </header>
+    <main>
+        {info_card}
+        {model_card}
+        {charts}
+        {prediction_card}
+    </main>
+</body>
+</html>"##,
+        addr = html_escape(&peer.address.to_string()),
+        CSS = CSS,
+        PEER_CSS = PEER_CSS,
+        JS = JS,
+        version = html_escape(version),
+        info_card = info_card,
+        model_card = model_card,
+        charts = charts,
+        prediction_card = prediction_card,
+    )
+}
+
+/// Build an SVG chart showing a PAV regression curve with optional per-peer adjustment.
+fn build_estimator_chart(
+    title: &str,
+    curve_points: &[(f64, f64)],
+    peer_adjustment: Option<f64>,
+    peer_location: Option<f64>,
+    _y_min_label: &str,
+    _y_max_label: &str,
+) -> String {
+    if curve_points.is_empty() {
+        return format!(
+            r#"<div class="chart-section"><h3>{title}</h3><div class="empty-chart">Awaiting routing events</div></div>"#,
+            title = title,
+        );
+    }
+
+    let w: f64 = 560.0;
+    let h: f64 = 200.0;
+    let pad_l: f64 = 50.0;
+    let pad_r: f64 = 10.0;
+    let pad_t: f64 = 10.0;
+    let pad_b: f64 = 30.0;
+    let plot_w = w - pad_l - pad_r;
+    let plot_h = h - pad_t - pad_b;
+
+    // Determine Y range from data
+    let y_vals: Vec<f64> = curve_points.iter().map(|(_, y)| *y).collect();
+    let mut y_min = y_vals.iter().cloned().fold(f64::INFINITY, f64::min);
+    let mut y_max = y_vals.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+
+    // Include peer-adjusted values in range if present
+    if let Some(adj) = peer_adjustment {
+        for (_, y) in curve_points {
+            let adjusted = y + adj;
+            y_min = y_min.min(adjusted);
+            y_max = y_max.max(adjusted);
+        }
+    }
+
+    // Add 10% padding and avoid zero-range
+    let range = y_max - y_min;
+    if range < 1e-10 {
+        y_min -= 0.5;
+        y_max += 0.5;
+    } else {
+        y_min -= range * 0.1;
+        y_max += range * 0.1;
+    }
+    let y_range = y_max - y_min;
+
+    // X is always distance [0.0, 0.5]
+    let x_min: f64 = 0.0;
+    let x_max: f64 = 0.5;
+    let x_range = x_max - x_min;
+
+    let to_svg_x = |x: f64| -> f64 { pad_l + ((x - x_min) / x_range) * plot_w };
+    let to_svg_y = |y: f64| -> f64 { pad_t + plot_h - ((y - y_min) / y_range) * plot_h };
+
+    let mut svg = format!(
+        r#"<div class="chart-section"><h3>{title}</h3>
+        <svg viewBox="0 0 {w} {h}" width="{w}" height="{h}" class="chart-svg">"#,
+        title = title,
+        w = w as u32,
+        h = h as u32,
+    );
+
+    // Axes
+    write!(
+        svg,
+        r#"<line x1="{lx}" y1="{ty}" x2="{lx}" y2="{by}" stroke="var(--text-muted)" stroke-width="1"/>"#,
+        lx = pad_l,
+        ty = pad_t,
+        by = pad_t + plot_h,
+    )
+    .ok();
+    write!(
+        svg,
+        r#"<line x1="{lx}" y1="{by}" x2="{rx}" y2="{by}" stroke="var(--text-muted)" stroke-width="1"/>"#,
+        lx = pad_l,
+        by = pad_t + plot_h,
+        rx = pad_l + plot_w,
+    )
+    .ok();
+
+    // X-axis labels
+    for &x_tick in &[0.0, 0.1, 0.2, 0.3, 0.4, 0.5] {
+        let sx = to_svg_x(x_tick);
+        write!(
+            svg,
+            r#"<text x="{sx:.0}" y="{y}" text-anchor="middle" class="axis-label">{v:.1}</text>"#,
+            sx = sx,
+            y = pad_t + plot_h + 18.0,
+            v = x_tick,
+        )
+        .ok();
+    }
+
+    // Y-axis labels (3 ticks)
+    for i in 0..=2 {
+        let frac = i as f64 / 2.0;
+        let y_val = y_min + frac * y_range;
+        let sy = to_svg_y(y_val);
+        let label = if y_val.abs() < 1e-3 && y_range < 10.0 {
+            format!("{:.3}", y_val)
+        } else if y_range < 1.0 {
+            format!("{:.2}", y_val)
+        } else {
+            format!("{:.0}", y_val)
+        };
+        write!(
+            svg,
+            r#"<text x="{x}" y="{sy:.0}" text-anchor="end" class="axis-label">{label}</text>"#,
+            x = pad_l - 4.0,
+            sy = sy,
+            label = label,
+        )
+        .ok();
+    }
+
+    // Global curve (blue stepped line)
+    if curve_points.len() >= 2 {
+        let mut path = String::new();
+        for (i, (x, y)) in curve_points.iter().enumerate() {
+            let sx = to_svg_x(*x);
+            let sy = to_svg_y(*y);
+            if i == 0 {
+                write!(path, "M{sx:.1},{sy:.1}").ok();
+            } else {
+                // Stepped: horizontal then vertical
+                let prev_y = to_svg_y(curve_points[i - 1].1);
+                write!(path, " L{sx:.1},{prev_y:.1} L{sx:.1},{sy:.1}").ok();
+            }
+        }
+        write!(
+            svg,
+            r#"<path d="{path}" fill="none" stroke="var(--accent-primary)" stroke-width="2" opacity="0.8"/>"#,
+            path = path,
+        )
+        .ok();
+    }
+
+    // Peer-adjusted curve (green stepped line)
+    if let Some(adj) = peer_adjustment {
+        if curve_points.len() >= 2 {
+            let mut path = String::new();
+            for (i, (x, y)) in curve_points.iter().enumerate() {
+                let sx = to_svg_x(*x);
+                let sy = to_svg_y(y + adj);
+                if i == 0 {
+                    write!(path, "M{sx:.1},{sy:.1}").ok();
+                } else {
+                    let prev_y = to_svg_y(curve_points[i - 1].1 + adj);
+                    write!(path, " L{sx:.1},{prev_y:.1} L{sx:.1},{sy:.1}").ok();
+                }
+            }
+            write!(
+                svg,
+                "<path d=\"{path}\" fill=\"none\" stroke=\"#34d399\" stroke-width=\"2\" opacity=\"0.8\"/>",
+                path = path,
+            )
+            .ok();
+        }
+    }
+
+    // Peer location marker (vertical dashed line)
+    if let Some(loc) = peer_location {
+        // Distance from peer to itself is 0, but contracts near the peer have small distances.
+        // Mark the peer's ring location on the x-axis as distance=0 (leftmost).
+        let _ = loc; // The peer itself is at distance 0 from contracts at its own location
+        let sx = to_svg_x(0.0);
+        write!(
+            svg,
+            "<line x1=\"{sx:.1}\" y1=\"{ty}\" x2=\"{sx:.1}\" y2=\"{by}\" stroke=\"#fbbf24\" stroke-width=\"1.5\" stroke-dasharray=\"4,3\" opacity=\"0.7\"/>",
+            sx = sx,
+            ty = pad_t,
+            by = pad_t + plot_h,
+        )
+        .ok();
+    }
+
+    svg.push_str("</svg></div>");
+    svg
+}
+
+const PEER_CSS: &str = r##"
+.logo-link, .header-title { text-decoration: none; }
+.logo-link:hover, a.header-title:hover { opacity: 0.8; }
+a.header-title {
+    background: linear-gradient(135deg, var(--accent-light) 0%, var(--accent-primary) 50%, var(--accent-dark) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    font-family: var(--font-mono);
+    font-weight: 600;
+    font-size: 1.1rem;
+    letter-spacing: -0.02em;
+}
+.header-sep {
+    color: var(--text-muted);
+    font-size: 1rem;
+    margin: 0 0.15rem;
+}
+.header-addr {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    background: var(--bg-tertiary);
+    padding: 0.1rem 0.45rem;
+    border-radius: 4px;
+}
+.info-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.4rem 1.25rem;
+    font-size: 0.85rem;
+}
+.info-label {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    align-self: center;
+}
+.info-value { font-family: var(--font-mono); }
+.chart-section { margin: 1rem 0; }
+.chart-section h3 {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-weight: 500;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+}
+.chart-svg {
+    display: block;
+    width: 100%;
+    max-width: 600px;
+}
+.chart-svg .axis-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    fill: var(--text-muted);
+}
+.chart-legend {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+.chart-key {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+.chart-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+.chart-dot-global { background: var(--accent-primary); }
+.chart-dot-peer { background: #34d399; }
+.chart-dot-loc { background: #fbbf24; }
+.empty-chart {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 80px;
+    background: var(--bg-secondary);
+    border: 1px dashed var(--border-color);
+    border-radius: 6px;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    font-family: var(--font-mono);
+}
 "##;
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

The local peer dashboard (`GET /`) shows a Network Peers table with basic info (address, location, type, connected duration) but none of the rich routing model data that the Router maintains. The Router has PAV isotonic regression models tracking failure probability, response time, and transfer rate per-peer, but this data was invisible.

Additionally, broadcast updates received via subscription streaming (BroadcastToStreaming) were not counted anywhere on the dashboard — they bypass the normal `report_result` path since they complete via `OperationResult::Completed`.

## Approach

**Peer detail page:**
- New route `GET /peer/{address}` with clickable peer rows on the homepage
- Exposes the Router's per-peer PAV isotonic regression data via a new `ROUTER` OnceLock (same pattern as `NETWORK_STATUS`)
- SVG charts show global PAV curves with per-peer adjusted overlays
- Graceful empty states ("Awaiting routing events") when insufficient data
- Reuses existing dashboard CSS with breadcrumb navigation header

**UPDATE counter:**
- Added `updates_received` counter to `OperationStats` incremented when `BroadcastToStreaming` successfully changes contract state
- Displayed as a single count (no success/fail) since broadcast updates can't fail in the same way routed operations can

**Key files:**
- `home_page.rs` — Main rendering (+563 lines for detail page, charts, UI improvements)
- `network_status.rs` — Router OnceLock, PeerKeyLocation tracking, updates_received counter
- `router/mod.rs` — `PeerRoutingSnapshot` type and `peer_snapshot()` method
- `isotonic_estimator.rs` — Public accessors for `Adjustment` (mean, event_count)

## Testing

- Deployed and manually verified on a live node (technic) with real network traffic
- Verified peer detail pages render correctly for both gateway and non-gateway peers
- Verified empty chart states display properly before routing events accumulate
- Verified UPDATE counter increments on broadcast updates
- `cargo fmt`, `cargo clippy --all-targets --all-features` clean
- This is a read-only dashboard feature with no impact on protocol behavior

[AI-assisted - Claude]