### PR TITLE
fix: don't wipe peer interest/proximity on connection blip

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -40,7 +40,7 @@ use crate::{
     },
     ring::{
         ConnectionFailureReason, ConnectionManager, LiveTransactionTracker, PeerConnectionBackoff,
-        PeerKey, PeerKeyLocation, Ring,
+        PeerKeyLocation, Ring,
     },
     transport::TransportPublicKey,
     util::time_source::InstantTimeSrc,

--- a/crates/core/src/node/proximity_cache.rs
+++ b/crates/core/src/node/proximity_cache.rs
@@ -365,6 +365,7 @@ impl ProximityCacheManager {
     }
 
     /// Handle peer disconnection by removing their cache state.
+    #[cfg(test)]
     pub fn on_peer_disconnected(&self, pub_key: &TransportPublicKey) {
         if let Some((_, removed_cache)) = self.neighbor_caches.remove(pub_key) {
             let count = removed_cache.len();

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -3551,7 +3551,12 @@ mod tests {
                 assert_eq!(value.state, Some(state));
                 assert!(value.contract.is_none());
             }
-            other => panic!("Expected Found response, got {other:?}"),
+            other @ GetMsg::Response { .. }
+            | other @ GetMsg::Request { .. }
+            | other @ GetMsg::ResponseStreaming { .. }
+            | other @ GetMsg::ResponseStreamingAck { .. } => {
+                panic!("Expected Found response, got {other:?}")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Stop eagerly removing interest and proximity cache entries in `on_ring_connection_lost()`
- Interest entries are already TTL-managed (20 min expiry) and refreshed via the Interests/Summaries heartbeat exchange on reconnection
- Proximity cache entries are replaced via `CacheAnnounce` on reconnection
- Between disconnect and reconnect, stale entries are harmless — `get_peer_by_pub_key()` only resolves peers in `connections_by_location`, so broadcasts skip disconnected peers automatically

## Problem

Peers with unstable connections (e.g. stale pending reservations causing ~60s disconnect/reconnect cycles) permanently lose all registered interests on every connection blip. This means subsequent contract updates see `NO_TARGETS` for those peers and don't propagate updates to them, even though subscriptions were successfully established.

The heartbeat-based interest re-registration on reconnect exists, but there's a timing gap — if the connection drops again before the exchange completes, interests are lost again.

## Test plan

- Tested on a 7-node local Freenet network where node-3 (port 3004) has unstable connections
- Before fix: `rapid_fire_updates` and `subscription_fanout` stress tests consistently failed on port 3004 due to interest loss
- After fix: both tests pass consistently (verified across 4 consecutive runs)
- No regressions in other stress tests (`concurrent_product_additions`, `cross_node_propagation_all_nodes`)

## Risk: proximity cache memory growth

The proximity cache `neighbor_caches` is a `DashMap<TransportPublicKey, HashSet<ContractKey>>`. If a peer permanently disconnects (network churn in production), their entry persists until the process restarts. For small networks this is irrelevant. For production, a periodic sweep or TTL could be added as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)