### PR TITLE
fix: improve NAT failure feedback in CONNECT protocol

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -1894,6 +1894,8 @@ impl Operation for ConnectOp {
                         // Relay received ConnectFailed. Strategy: if we have a downstream
                         // peer that already forwarded a response, send ConnectFailed there
                         // first (closer relay has better local knowledge for re-routing).
+                        // Capture timestamp once for consistent use across this handler.
+                        let now = Instant::now();
                         if state.response_forwarded {
                             if let Some(ref fwd) = state.forwarded_to {
                                 if let Some(fwd_addr) = fwd.socket_addr() {
@@ -1903,7 +1905,7 @@ impl Operation for ConnectOp {
                                         .connection_manager
                                         .record_connect_acceptor_failure(
                                             *failed_acceptor_addr,
-                                            Instant::now(),
+                                            now,
                                         );
 
                                     let fwd_msg = ConnectMsg::ConnectFailed {
@@ -1933,8 +1935,6 @@ impl Operation for ConnectOp {
                         let upstream_addr = state.upstream_addr;
                         let failed_peer = state.forwarded_to.clone();
                         let desired_location = state.request.desired_location;
-                        // Capture now once to avoid multiple Instant::now() calls in this handler.
-                        let now = Instant::now();
 
                         // Record failure in exclusion tracker
                         op_manager

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -61,13 +61,24 @@ const FAILED_ADDR_BASE_TTL: Duration = Duration::from_secs(300);
 /// (e.g., symmetric NAT on both sides) caps at 1 hour between retries.
 const FAILED_ADDR_MAX_TTL: Duration = Duration::from_secs(3600);
 
-/// Compute the adaptive TTL for an address with `failure_count` repeated failures.
+/// Compute the base (un-jittered) adaptive TTL for an address with `failure_count` failures.
 /// First failure (count=1) uses the base TTL; each subsequent failure doubles it.
+/// This is a pure function used by tests; callers that need jitter should use
+/// [`failed_addr_ttl_jittered`] instead.
 fn failed_addr_ttl(failure_count: u32) -> Duration {
     let exponent = failure_count.saturating_sub(1);
     let multiplier = 1u64.checked_shl(exponent).unwrap_or(u64::MAX);
     let ttl_secs = FAILED_ADDR_BASE_TTL.as_secs().saturating_mul(multiplier);
     Duration::from_secs(ttl_secs.min(FAILED_ADDR_MAX_TTL.as_secs()))
+}
+
+/// Like [`failed_addr_ttl`] but applies ±20% random jitter to prevent
+/// multiple peers from retrying the same unreachable address in lockstep.
+fn failed_addr_ttl_jittered(failure_count: u32) -> Duration {
+    let base = failed_addr_ttl(failure_count);
+    // ±20% jitter: multiply by a factor in [0.8, 1.2]
+    let jitter_factor = 0.8 + (GlobalRng::random_u64() % 401) as f64 / 1000.0;
+    base.mul_f64(jitter_factor)
 }
 
 /// RAII guard that releases a connect admission slot when dropped.
@@ -1452,22 +1463,24 @@ impl ConnectionManager {
 
     /// Return addresses that failed NAT traversal within their adaptive TTL.
     /// Addresses with more repeated failures have longer TTLs (up to 1 hour).
+    /// Includes ±20% jitter to stagger retries across peers.
     pub fn recently_failed_addrs(&self) -> Vec<SocketAddr> {
         let now = Instant::now();
         self.recently_failed_addrs
             .read()
             .iter()
-            .filter(|(_, (ts, count))| now.duration_since(*ts) < failed_addr_ttl(*count))
+            .filter(|(_, (ts, count))| now.duration_since(*ts) < failed_addr_ttl_jittered(*count))
             .map(|(addr, _)| *addr)
             .collect()
     }
 
     /// Remove entries whose adaptive TTL has expired.
+    /// Uses jittered TTL so cleanup is naturally staggered.
     pub fn cleanup_stale_failed_addrs(&self) -> usize {
         let now = Instant::now();
         let mut map = self.recently_failed_addrs.write();
         let before = map.len();
-        map.retain(|_, (ts, count)| now.duration_since(*ts) < failed_addr_ttl(*count));
+        map.retain(|_, (ts, count)| now.duration_since(*ts) < failed_addr_ttl_jittered(*count));
         before - map.len()
     }
 


### PR DESCRIPTION
## Problem

A peer behind NAT (technic) loops 252+ times trying to connect to unreachable peers because two feedback mechanisms have gaps:

1. **`recently_failed_addrs` uses a fixed 5-min TTL** — permanent NAT incompatibility (symmetric NAT on both sides) is retried endlessly after each 5-min expiry
2. **ConnectFailed Phase 1 forwards downstream without recording the failure** on the forwarding relay. The terminus records its own address in its own exclusion map, which is meaningless

## Approach

### Fix 1: Adaptive `recently_failed_addrs` TTL

Store failure count alongside timestamp. Scale TTL exponentially with repeated failures:

```
Base: 5 min → 10 min → 20 min → 40 min → 1 hour (cap)
Formula: min(300s × 2^count, 3600s)
```

This means permanent NAT incompatibility is retried with increasing backoff up to 1 hour, while transient failures still get the original 5-min window.

### Fix 2: Record failure before forwarding downstream

In the ConnectFailed Phase 1 handler (the `response_forwarded` branch), add `record_connect_acceptor_failure()` before forwarding the message downstream. This way the relay that routed to the bad acceptor learns to exclude it in future CONNECTs (30-min exclusion after 3 failures via existing `connect_excluded_peers` mechanism).

Previously only the terminus recorded the failure — against its own address in its own exclusion map, which had no effect on routing decisions.

## Testing

- `cargo fmt && cargo clippy --all-targets --all-features` — clean
- `cargo test -p freenet --lib` — 1763 passed, 0 failed
- Production validation: deploy to technic and observe reduced retry loops

The changes are small and surgical — one new helper function, type change to an existing map, and one additional method call in an existing code path. The adaptive TTL logic uses the same exponential backoff pattern already established in `connect_excluded_peers`.

## Files Changed

| File | Change |
|------|--------|
| `crates/core/src/ring/connection_manager.rs` | Adaptive TTL for `recently_failed_addrs` (timestamp + failure count) |
| `crates/core/src/operations/connect.rs` | Record failure in Phase 1 before downstream forwarding |

[AI-assisted - Claude]