### PR TITLE
feat: require acknowledgment of Critical/Warning rule-review findings before merge

### DIFF
--- a/.github/workflows/claude-pr-review-gate.yml
+++ b/.github/workflows/claude-pr-review-gate.yml
@@ -1,0 +1,89 @@
+name: Rule Review Gate
+
+# Updates the rule-review/findings commit status when:
+# - A maintainer checks/unchecks a finding checkbox in the review comment
+# - A maintainer posts /ack to dismiss all findings
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  update-gate:
+    name: Update acknowledgment status
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request != null &&
+      (contains(github.event.comment.body, '<!-- claude-rule-review -->') ||
+       startsWith(github.event.comment.body, '/ack'))
+    permissions:
+      statuses: write
+      pull-requests: read
+
+    steps:
+      - name: Update commit status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body;
+            const isAck = body.trim().startsWith('/ack');
+
+            // Get PR head SHA
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const sha = pr.data.head.sha;
+
+            if (isAck) {
+              // Verify commenter has write/admin access
+              let perm;
+              try {
+                const resp = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: context.payload.comment.user.login,
+                });
+                perm = resp.data.permission;
+              } catch (_) {
+                perm = 'none';
+              }
+              if (!['admin', 'write'].includes(perm)) {
+                console.log(`Ignoring /ack from ${context.payload.comment.user.login} (permission: ${perm})`);
+                return;
+              }
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'success',
+                context: 'rule-review/findings',
+                description: `Acknowledged by @${context.payload.comment.user.login}`,
+              });
+              return;
+            }
+
+            // Checkbox edit — recount unchecked Critical/Warning items
+            function countUnchecked(text) {
+              const lines = text.split('\n');
+              let inSection = false, unchecked = 0;
+              for (const line of lines) {
+                if (/^####\s*(Critical|Warning)/i.test(line)) inSection = true;
+                else if (/^####/.test(line)) inSection = false;
+                if (inSection && /^- \[ \]/.test(line)) unchecked++;
+              }
+              return unchecked;
+            }
+
+            const unchecked = countUnchecked(body);
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: unchecked > 0 ? 'failure' : 'success',
+              context: 'rule-review/findings',
+              description: unchecked > 0
+                ? `${unchecked} finding(s) need acknowledgment — check boxes or comment /ack`
+                : 'All findings acknowledged',
+            });

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -46,6 +46,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      statuses: write
 
     steps:
       - name: Checkout repository
@@ -231,6 +232,10 @@ jobs:
             #### Info
             - [ ] `file:line` — description (rule: X)
 
+            > **To acknowledge findings:** Check each box above once addressed (or a tracking issue opened),
+            > or post `/ack` to dismiss all findings for this revision.
+            > Merge is blocked until Critical and Warning findings are acknowledged.
+
             If there are no findings at any severity level, output:
 
             ### ✅ Rule Review: No issues found
@@ -238,7 +243,7 @@ jobs:
             **Rules checked:** [list]
             **Files reviewed:** [count]
 
-            No rule violations detected in this PR.
+            No rule violations detected — merge is not blocked by this check.
 
       - name: Post review comment
         if: steps.rules.outputs.skip != 'true'
@@ -255,7 +260,7 @@ jobs:
                 '### ⚠️ Claude Rule Review: Failed to run\n\n' +
                 'The Claude rule review step failed (likely an authentication or API issue). ' +
                 'Check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.\n\n' +
-                '---\n*Automated review against `.claude/rules/`. Advisory only — does not block merge.*';
+                '---\n*Automated review against `.claude/rules/`. Critical and Warning findings block merge — check boxes or post `/ack` to acknowledge.*';
 
               const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
@@ -313,7 +318,7 @@ jobs:
               return;
             }
 
-            const body = report + '\n\n---\n*Automated review against `.claude/rules/`. Advisory only — does not block merge.*';
+            const body = report + '\n\n---\n*Automated review against `.claude/rules/`. Critical and Warning findings block merge — check boxes or post `/ack` to acknowledge.*';
 
             // Find and update existing sticky comment, or create new one
             const { data: comments } = await github.rest.issues.listComments({
@@ -343,3 +348,46 @@ jobs:
               });
               console.log('Created new review comment');
             }
+
+      - name: Set acknowledgment status
+        if: steps.rules.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- claude-rule-review -->';
+
+            // Read the already-posted comment body
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            const body = existing ? existing.body : '';
+
+            function countUnchecked(text) {
+              const lines = text.split('\n');
+              let inSection = false, unchecked = 0;
+              for (const line of lines) {
+                if (/^####\s*(Critical|Warning)/i.test(line)) inSection = true;
+                else if (/^####/.test(line)) inSection = false;
+                if (inSection && /^- \[ \]/.test(line)) unchecked++;
+              }
+              return unchecked;
+            }
+
+            const unchecked = countUnchecked(body);
+            const noFindings = !body.includes('- [ ]') && !body.includes('- [x]');
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.pull_request.head.sha }}',
+              state: unchecked > 0 ? 'failure' : 'success',
+              context: 'rule-review/findings',
+              description: unchecked > 0
+                ? `${unchecked} finding(s) need acknowledgment — check boxes or comment /ack`
+                : noFindings ? 'No critical/warning findings' : 'All findings acknowledged',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}`,
+            });


### PR DESCRIPTION
## Problem

The `claude-pr-review` workflow posts advisory comments with Critical/Warning/Info findings as
markdown checkboxes, but these were routinely ignored — PRs merged with unacknowledged findings
(e.g., #3363, #3378, #3380). The \"advisory only\" footer gave no incentive to act on them.

## Solution

Add a commit status gate (`rule-review/findings`) backed by two new mechanisms:

**`claude-pr-review.yml` changes:**
- Adds `statuses: write` permission to the job
- Updates the prompt output format to include an acknowledgment block explaining how to clear the status
- Adds a \"Set acknowledgment status\" step that reads the freshly-posted review comment, counts unchecked Critical/Warning items (Info is excluded), and sets the commit status to `failure` or `success`

**New `claude-pr-review-gate.yml` workflow:**
- Triggers on `issue_comment` created/edited events
- **Checkbox path**: when the review comment body is edited (box checked/unchecked), recounts unchecked Critical/Warning items and updates the commit status
- **`/ack` path**: when a write/admin collaborator posts `/ack`, immediately sets status to `success` — useful when findings are intentional or already tracked elsewhere; non-collaborators are silently ignored

Info-level findings are not counted and never block merge.

## Edge Cases

| Situation | Outcome |
|-----------|---------|
| No Critical/Warning findings | Status → success immediately |
| All findings are Info | Status → success |
| PR updated (new push) | Review re-runs → status reset to reflect new findings |
| `/ack` from non-collaborator | Ignored, logged, status unchanged |
| Review API error | Warning comment posted, status set to failure |

## Testing

1. Open a test PR that triggers Critical or Warning findings
2. Confirm `rule-review/findings` appears as **failed** in the PR checks
3. Check one of the boxes → status updates to reflect remaining count
4. Check all boxes → status turns green
5. Open another test PR, post `/ack` as a maintainer → status turns green immediately
6. Post `/ack` as a non-collaborator → status stays red, logged in Actions

## Required Follow-up (manual admin step)

After merging, a repo admin must add `rule-review/findings` as a **required status check** in:
Settings → Branches → Branch protection rules → main

Without this, the status is visible but doesn't gate merge.

[AI-assisted - Claude]