### PR TITLE
test: rule-review gate verification (do not merge)

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -3551,7 +3551,12 @@ mod tests {
                 assert_eq!(value.state, Some(state));
                 assert!(value.contract.is_none());
             }
-            other => panic!("Expected Found response, got {other:?}"),
+            other @ GetMsg::Request { .. }
+            | other @ GetMsg::Response { .. }
+            | other @ GetMsg::ResponseStreaming { .. }
+            | other @ GetMsg::ResponseStreamingAck { .. } => {
+                panic!("Expected Found response, got {other:?}")
+            }
         }
     }
 }

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -300,3 +300,8 @@ pub(crate) mod tests {
         dir
     }
 }
+
+// TEST: intentional .unwrap() to verify rule-review gate — remove before merge
+pub fn parse_test_addr(s: &str) -> std::net::SocketAddr {
+    s.parse().unwrap()
+}


### PR DESCRIPTION
## Purpose

Test PR to verify the `rule-review/findings` commit status gate introduced in #3387.

This PR intentionally includes a `.unwrap()` in production code (`crates/core/src/util/mod.rs`)
to trigger a Warning finding from the rule reviewer.

## Expected behavior

1. `claude-pr-review` posts a comment with a Warning checkbox for the `.unwrap()`
2. `rule-review/findings` status appears as **failed** in the checks
3. Checking the Warning box → status updates to success
4. Or: posting `/ack` → status turns green immediately

**Do not merge.**

[AI-assisted - Claude]