### PR TITLE
test: rule-review gate info-only verification (do not merge)

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -3551,7 +3551,12 @@ mod tests {
                 assert_eq!(value.state, Some(state));
                 assert!(value.contract.is_none());
             }
-            other => panic!("Expected Found response, got {other:?}"),
+            other @ GetMsg::Request { .. }
+            | other @ GetMsg::Response { .. }
+            | other @ GetMsg::ResponseStreaming { .. }
+            | other @ GetMsg::ResponseStreamingAck { .. } => {
+                panic!("Expected Found response, got {other:?}")
+            }
         }
     }
 }

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -300,3 +300,11 @@ pub(crate) mod tests {
         dir
     }
 }
+
+pub fn format_peer_count(n: usize) -> String {
+    if n == 1 {
+        "1 peer".to_string()
+    } else {
+        format!("{n} peers")
+    }
+}


### PR DESCRIPTION
## Purpose

Test PR to verify that `rule-review/findings` status goes to **success** immediately
when a PR has only Info-level findings (or none at all).

Adds a public `format_peer_count` helper without a doc comment — intentionally Info-level only.
No Critical or Warning violations should be present.

## Expected behavior

1. `claude-pr-review` posts a comment with only an Info checkbox (no Critical/Warning)
2. `rule-review/findings` status appears as **success** immediately — no blocking

**Do not merge.**

[AI-assisted - Claude]