### PR TITLE
fix: downgrade keepalive timeout diagnostic from ERROR to DEBUG

### DIFF
--- a/crates/core/src/transport/peer_connection.rs
+++ b/crates/core/src/transport/peer_connection.rs
@@ -980,21 +980,19 @@ impl<S: super::Socket, T: TimeSource> PeerConnection<S, T> {
                             elapsed.as_secs_f64()
                         );
 
-                        // Check if keep-alive task is still alive
+                        // Diagnostic: check keepalive task state at timeout.
+                        // "still running" is the normal case — pings are being sent
+                        // but the remote isn't responding (NAT mapping expired, peer
+                        // crashed, etc.). "already finished" means the socket errored
+                        // before the idle timeout fired (rare).
                         if let Some(ref handle) = self.keep_alive_handle {
-                            if !handle.is_finished() {
-                                tracing::error!(
-                                    target: "freenet_core::transport::keepalive_timeout",
-                                    remote = ?self.remote_conn.remote_addr,
-                                    "Keep-alive task is STILL RUNNING despite timeout!"
-                                );
-                            } else {
-                                tracing::error!(
-                                    target: "freenet_core::transport::keepalive_timeout",
-                                    remote = ?self.remote_conn.remote_addr,
-                                    "Keep-alive task has ALREADY FINISHED before timeout!"
-                                );
-                            }
+                            let task_state = if handle.is_finished() { "finished" } else { "running" };
+                            tracing::debug!(
+                                target: "freenet_core::transport::keepalive_timeout",
+                                remote = ?self.remote_conn.remote_addr,
+                                keepalive_task = task_state,
+                                "Connection timed out, keepalive task was {task_state}"
+                            );
                         }
 
                         return Err(TransportError::ConnectionClosed(self.remote_addr()));


### PR DESCRIPTION
## Problem

The `Keep-alive task is STILL RUNNING despite timeout!` message fires at ERROR level on 100% of normal connection timeouts (~90/hr on nova gateway, ~7% of connections). This is expected behavior — the keepalive task sends pings while the remote doesn't respond (NAT mapping expired, peer crashed, etc.) — and the connection is properly cleaned up immediately after.

ERROR level for expected behavior causes:
- Log noise (~100-160 ERROR lines/hr that aren't actionable)
- Alarm fatigue (real errors get lost in the noise)
- Misleading diagnostics (suggests something is broken when it's working correctly)

## Solution

Downgrade the diagnostic from `tracing::error!` to `tracing::debug!` and consolidate the two branches ("still running" vs "already finished") into a single concise log message. The keepalive task state is included as a structured field for filtering.

The "already finished" branch (keepalive task exited before idle timeout) has never been observed in production logs — it would require a socket send error before the 120s idle timeout fires, which is rare. Both branches are now handled uniformly at DEBUG level.

## Testing

- `cargo fmt` — clean
- `cargo clippy --all-targets --all-features` — clean (no new warnings)
- `cargo test -p freenet` — passes
- This is a log-level-only change with no behavioral impact

[AI-assisted - Claude]