### PR TITLE
fix: break subscribe routing death spiral and connection growth stall

### DIFF
--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -237,10 +237,24 @@ impl PeerHealthTracker {
 
         // Partition: never-succeeded peers are always evictable (they block routing
         // and connection growth), other unhealthy peers are protected by min_connections.
+        // Note: never-succeeded peers must still pass criterion 2's HEALTH_NO_SUCCESS_TIMEOUT
+        // (600s) + at least 1 failure, so freshly connected peers are not affected.
         let (never_succeeded, degraded): (Vec<_>, Vec<_>) = candidates
             .into_iter()
             .partition(|(_, zero_success)| *zero_success);
-        let mut result: Vec<SocketAddr> = never_succeeded.into_iter().map(|(a, _)| a).collect();
+        // Safety floor: always retain at least 1 connection to avoid total isolation.
+        // The gateway bootstrap recovery path has a 120s delay; keeping one connection
+        // gives the node a chance to route while waiting for fresh connections.
+        let max_never_succeeded = if current_count > 1 {
+            never_succeeded.len().min(current_count - 1)
+        } else {
+            0
+        };
+        let mut result: Vec<SocketAddr> = never_succeeded
+            .into_iter()
+            .take(max_never_succeeded)
+            .map(|(a, _)| a)
+            .collect();
         let remaining = current_count.saturating_sub(result.len());
         if remaining > min_connections {
             let budget = remaining.saturating_sub(min_connections);
@@ -3692,6 +3706,38 @@ mod tests {
         assert!(
             !unhealthy.contains(&has_ok),
             "Degraded peer with successes should be protected by min_connections"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_peer_health_tracker_safety_floor_retains_one_connection() {
+        let mut tracker = PeerHealthTracker::new();
+        let addr_a = make_addr(9012);
+        let addr_b = make_addr(9013);
+        let addr_c = make_addr(9014);
+
+        tracker.init_peer(addr_a);
+        tracker.init_peer(addr_b);
+        tracker.init_peer(addr_c);
+
+        // Advance past no-success timeout
+        tokio::time::advance(Duration::from_secs(660)).await;
+
+        // All 3 peers: 0 successes, failures only
+        for addr in [addr_a, addr_b, addr_c] {
+            for _ in 0..5 {
+                tracker.record_failure(addr);
+            }
+        }
+
+        // current_count=3, min_connections=3, all never-succeeded.
+        // Safety floor: should evict at most 2, retaining 1 connection.
+        let unhealthy = tracker.unhealthy_peers(3, 3);
+        assert_eq!(
+            unhealthy.len(),
+            2,
+            "Should evict at most current_count-1 never-succeeded peers, got {}",
+            unhealthy.len()
         );
     }
 

--- a/crates/core/src/router/mod.rs
+++ b/crates/core/src/router/mod.rs
@@ -390,10 +390,13 @@ impl Router {
                 .collect();
 
             GlobalRng::shuffle(&mut peer_distances);
-            // Deprioritize peers that have failure data in the estimator.
-            // Untried peers get priority — within each group, sort by distance.
-            // This breaks routing death spirals where the closest peer always
-            // times out but distance-based sorting always picks it again.
+            // Prefer untried peers over peers with any routing history.
+            // `peer_adjustments` is populated for ALL peers once the global regression
+            // has >= ADJUSTMENT_PRIOR_SIZE (10) events, regardless of success/failure.
+            // In this sub-50-event regime, preferring untried peers is the right
+            // exploration strategy: it breaks death spirals where the closest peer
+            // always times out, and helps the router accumulate diverse data toward
+            // the prediction threshold. Within each group, closest peer wins.
             peer_distances.sort_by(|(pa, da), (pb, db)| {
                 let fa = self.failure_estimator.peer_adjustments.contains_key(pa);
                 let fb = self.failure_estimator.peer_adjustments.contains_key(pb);
@@ -2115,5 +2118,45 @@ mod tests {
             *selected[0], untried_peer,
             "Should prefer untried peer over peer with failure history"
         );
+    }
+
+    /// With k > 1 and a mix of tried/untried peers, untried peers fill first,
+    /// then tried peers fill remaining slots by distance.
+    #[test]
+    fn test_distance_fallback_k_greater_than_untried_count() {
+        let _guard = crate::config::GlobalRng::seed_guard(0xBEEF_CAFE);
+
+        let tried_peer = PeerKeyLocation::random();
+        let untried_a = PeerKeyLocation::random();
+        let untried_b = PeerKeyLocation::random();
+        let target = tried_peer.location().unwrap();
+
+        // 30 failures for the tried peer (above ADJUSTMENT_PRIOR_SIZE=10, below threshold=50)
+        let events: Vec<RouteEvent> = (0..30)
+            .map(|_| RouteEvent {
+                peer: tried_peer.clone(),
+                contract_location: target,
+                outcome: RouteOutcome::Failure,
+            })
+            .collect();
+
+        let router = Router::new(&events);
+        assert!(!router.has_sufficient_routing_events());
+
+        // Select k=3 from 3 peers: 2 untried should come first, tried peer last
+        let peers = vec![tried_peer.clone(), untried_a.clone(), untried_b.clone()];
+        let (selected, _) = router.select_k_best_peers_with_telemetry(&peers, target, 3);
+
+        assert_eq!(selected.len(), 3);
+        // The tried peer should be last (deprioritized)
+        assert_eq!(
+            *selected[2], tried_peer,
+            "Tried peer should be last when untried peers are available"
+        );
+        // First two should be the untried peers (order depends on distance)
+        let untried_set: std::collections::HashSet<PeerKeyLocation> =
+            [untried_a, untried_b].into_iter().collect();
+        assert!(untried_set.contains(selected[0]));
+        assert!(untried_set.contains(selected[1]));
     }
 }


### PR DESCRIPTION
## Problem

Nacho's node (v0.1.162, macOS) is stuck with 5 ring connections despite `min-number-of-connections = 10`. Subscribe operations consistently timeout through the same two peers. The node cannot use River because all subscription attempts fail.

**Root cause chain:**
1. Router has 30 failures, 0 successes — below the 50-event prediction threshold
2. Falls back to pure distance-based routing, which ignores all failure data
3. Distance-based sorting deterministically picks the same closest peer for each contract location
4. Those peers timeout → more failures → router still can't learn (still below threshold)
5. Health eviction can't fire: `current(5) - candidates < min(10)` → `max_evictable = 0`
6. CONNECTs also route through the same failing peers → can't grow past 5

## Approach

Two minimal, targeted changes that break the death spiral using data the system already collects:

### 1. Distance-based fallback uses failure estimator data (`router/mod.rs`)

The isotonic regression failure estimator already tracks per-peer adjustment data via `peer_adjustments: HashMap<PeerKeyLocation, Adjustment>`. The distance-based fallback path (when `!has_sufficient_routing_events()`) completely ignores this data. 

**Fix:** Sort peers by `(has_failure_history, distance)` instead of just `distance`. Untried peers get priority over tried-and-failed peers. Within each group, closest peer wins. As untried peers succeed, the router accumulates success data toward the 50-event prediction threshold, breaking the learning deadlock.

### 2. Never-succeeded peers evictable below min_connections (`connection_manager.rs`)

The min_connections guard previously prevented ALL evictions when below min. But a peer with 0 successes is actively harmful — it blocks routing and connection growth.

**Fix:** Partition eviction candidates into never-succeeded (always evictable) vs degraded (protected by min). This breaks the connection growth deadlock: unhealthy peers get evicted → gateway bootstrap fires → fresh connections through different peers.

## Testing

- **Unit test:** `test_distance_fallback_deprioritizes_failed_peers` — verifies untried peers are preferred over peers with failure history in the distance-based fallback path
- **Unit test:** `test_peer_health_tracker_never_succeeded_evicted_below_min` — verifies never-succeeded peers are evicted even at min_connections while degraded peers with some successes remain protected
- **Updated existing test:** `test_peer_health_tracker_spares_degraded_peer_at_min_connections` — now tests with a degraded peer (has successes) to verify min_connections guard still protects peers that have worked before
- All 9 health tracker tests pass
- All router tests pass
- `cargo fmt`, `cargo clippy --all-targets` clean

## Fixes

Closes #3392

[AI-assisted - Claude]