### PR TITLE
feat: add state_size to telemetry events

### DIFF
--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -512,6 +512,7 @@ impl Operation for PutOp {
                             // hop_count is 0 since we stored locally
                             let own_location = op_manager.ring.connection_manager.own_location();
                             let hash = Some(state_hash_full(&merged_value));
+                            let size = Some(merged_value.len());
                             if let Some(event) = NetEventLog::put_success(
                                 &id,
                                 &op_manager.ring,
@@ -519,6 +520,7 @@ impl Operation for PutOp {
                                 own_location,
                                 Some(0), // Stored locally, 0 hops
                                 hash,
+                                size,
                             ) {
                                 op_manager.ring.register_events(Either::Left(event)).await;
                             }
@@ -547,6 +549,7 @@ impl Operation for PutOp {
                             // across multiple peers). See issue #2680.
                             let own_location = op_manager.ring.connection_manager.own_location();
                             let hash = Some(state_hash_full(&merged_value));
+                            let size = Some(merged_value.len());
                             if let Some(event) = NetEventLog::put_success(
                                 &id,
                                 &op_manager.ring,
@@ -554,6 +557,7 @@ impl Operation for PutOp {
                                 own_location,
                                 None, // hop_count unknown without initial HTL
                                 hash,
+                                size,
                             ) {
                                 op_manager.ring.register_events(Either::Left(event)).await;
                             }
@@ -609,6 +613,7 @@ impl Operation for PutOp {
                                 sender,
                                 hop_count,
                                 None, // State not available in response
+                                None, // Size not available in response
                             ) {
                                 op_manager.ring.register_events(Either::Left(event)).await;
                             }
@@ -1042,6 +1047,7 @@ impl Operation for PutOp {
                         if is_originator {
                             let own_location = op_manager.ring.connection_manager.own_location();
                             let hash = Some(state_hash_full(&merged_value));
+                            let size = Some(merged_value.len());
                             if let Some(event) = NetEventLog::put_success(
                                 &id,
                                 &op_manager.ring,
@@ -1049,6 +1055,7 @@ impl Operation for PutOp {
                                 own_location,
                                 Some(0),
                                 hash,
+                                size,
                             ) {
                                 op_manager.ring.register_events(Either::Left(event)).await;
                             }
@@ -1073,6 +1080,7 @@ impl Operation for PutOp {
                             // Send ResponseStreaming back to upstream
                             let own_location = op_manager.ring.connection_manager.own_location();
                             let hash = Some(state_hash_full(&merged_value));
+                            let size = Some(merged_value.len());
                             if let Some(event) = NetEventLog::put_success(
                                 &id,
                                 &op_manager.ring,
@@ -1080,6 +1088,7 @@ impl Operation for PutOp {
                                 own_location,
                                 None,
                                 hash,
+                                size,
                             ) {
                                 op_manager.ring.register_events(Either::Left(event)).await;
                             }
@@ -1134,6 +1143,7 @@ impl Operation for PutOp {
                             op_manager.ring.connection_manager.own_location(),
                             hop_count,
                             None, // No hash available in streaming response
+                            None, // No size available in streaming response
                         ) {
                             op_manager.ring.register_events(Either::Left(event)).await;
                         }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -429,6 +429,7 @@ impl Operation for UpdateOp {
                                     requester_pkl,
                                     hash_before,
                                     hash_after.clone(),
+                                    Some(updated_value.len()),
                                 ) {
                                     op_manager.ring.register_events(Either::Left(event)).await;
                                 }
@@ -968,6 +969,7 @@ impl Operation for UpdateOp {
                                 requester_pkl,
                                 None, // No before hash for streaming
                                 hash_after.clone(),
+                                Some(updated_value.len()),
                             ) {
                                 op_manager.ring.register_events(Either::Left(event)).await;
                             }

--- a/crates/core/src/tracing/mod.rs
+++ b/crates/core/src/tracing/mod.rs
@@ -503,6 +503,7 @@ impl<'a> NetEventLog<'a> {
         target: PeerKeyLocation,
         hop_count: Option<usize>,
         state_hash: Option<String>,
+        state_size: Option<usize>,
     ) -> Option<Self> {
         let peer_id = Self::get_own_peer_id(ring)?;
         let own_loc = ring.connection_manager.own_location();
@@ -518,6 +519,7 @@ impl<'a> NetEventLog<'a> {
                 elapsed_ms: tx.elapsed().as_millis() as u64,
                 timestamp: chrono::Utc::now().timestamp() as u64,
                 state_hash,
+                state_size,
             }),
         })
     }
@@ -767,6 +769,7 @@ impl<'a> NetEventLog<'a> {
         target: PeerKeyLocation,
         state_hash_before: Option<String>,
         state_hash_after: Option<String>,
+        state_size: Option<usize>,
     ) -> Option<Self> {
         let peer_id = Self::get_own_peer_id(ring)?;
         let own_loc = ring.connection_manager.own_location();
@@ -781,6 +784,7 @@ impl<'a> NetEventLog<'a> {
                 timestamp: chrono::Utc::now().timestamp() as u64,
                 state_hash_before,
                 state_hash_after,
+                state_size,
             }),
         })
     }
@@ -836,6 +840,7 @@ impl<'a> NetEventLog<'a> {
                 state_hash_before: Some(state_hash_full(state_before)),
                 state_hash_after: Some(state_hash_full(state_after)),
                 changed,
+                state_size: state_after.len(),
             }),
         })
     }
@@ -1238,6 +1243,7 @@ impl<'a> NetEventLog<'a> {
                     elapsed_ms: id.elapsed().as_millis() as u64,
                     timestamp: chrono::Utc::now().timestamp() as u64,
                     state_hash: None, // Hash not available from message
+                    state_size: None, // Size not available from message
                 })
             }
             NetMessageV1::Get(GetMsg::Request {
@@ -2984,6 +2990,8 @@ pub(crate) enum PutEvent {
         timestamp: u64,
         /// Short hash of the stored state (first 4 bytes of Blake3, 8 hex chars).
         state_hash: Option<String>,
+        /// Size of the stored state in bytes.
+        state_size: Option<usize>,
     },
     /// Put operation failed.
     PutFailure {
@@ -3104,6 +3112,8 @@ pub(crate) enum UpdateEvent {
         state_hash_before: Option<String>,
         /// Short hash of state after update (first 4 bytes of Blake3, 8 hex chars).
         state_hash_after: Option<String>,
+        /// Size of the state after update in bytes.
+        state_size: Option<usize>,
     },
     BroadcastEmitted {
         id: Transaction,
@@ -3166,6 +3176,8 @@ pub(crate) enum UpdateEvent {
         state_hash_after: Option<String>,
         /// Whether the local state actually changed after applying the update.
         changed: bool,
+        /// Size of the state after applying the update in bytes.
+        state_size: usize,
     },
     /// Emitted after handle_broadcast_state_change() completes with a full
     /// breakdown of why each potential peer was or was not sent the broadcast.

--- a/crates/core/src/tracing/state_verifier/tests.rs
+++ b/crates/core/src/tracing/state_verifier/tests.rs
@@ -67,6 +67,7 @@ fn test_clean_convergence() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("aabb0011".to_string()),
+                state_size: None,
             }),
         },
         // Peer 2 receives broadcast and stores same state
@@ -120,6 +121,7 @@ fn test_detects_final_divergence() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("aaaa0000".to_string()),
+                state_size: None,
             }),
         },
         // Peer 2 stores DIFFERENT state "bbbb"
@@ -136,6 +138,7 @@ fn test_detects_final_divergence() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("bbbb0000".to_string()),
+                state_size: None,
             }),
         },
     ];
@@ -176,6 +179,7 @@ fn test_detects_missing_broadcast() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("aaaa0000".to_string()),
+                state_size: None,
             }),
         },
         // Peer 1 emits broadcast to peer 2
@@ -243,6 +247,7 @@ fn test_detects_unapplied_update_broadcast() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("aaaa0000".to_string()),
+                state_size: None,
             }),
         },
         // Peer 1 updates
@@ -258,6 +263,7 @@ fn test_detects_unapplied_update_broadcast() {
                 timestamp: 200,
                 state_hash_before: Some("aaaa0000".to_string()),
                 state_hash_after: Some("cccc0000".to_string()),
+                state_size: None,
             }),
         },
         // Peer 1 emits broadcast to peer 2
@@ -330,6 +336,7 @@ fn test_full_update_cycle_clean() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("aaaa0000".to_string()),
+                state_size: None,
             }),
         },
         NetLogMessage {
@@ -359,6 +366,7 @@ fn test_full_update_cycle_clean() {
                 timestamp: 200,
                 state_hash_before: Some("aaaa0000".to_string()),
                 state_hash_after: Some("cccc0000".to_string()),
+                state_size: None,
             }),
         },
         // Peer 1 broadcasts to peer 2
@@ -406,6 +414,7 @@ fn test_full_update_cycle_clean() {
                 state_hash_before: Some("aaaa0000".to_string()),
                 state_hash_after: Some("cccc0000".to_string()),
                 changed: true,
+                state_size: 1024,
             }),
         },
     ];
@@ -453,6 +462,7 @@ fn test_report_display() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("aaaa0000".to_string()),
+                state_size: None,
             }),
         },
         NetLogMessage {
@@ -468,6 +478,7 @@ fn test_report_display() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("bbbb0000".to_string()),
+                state_size: None,
             }),
         },
     ];
@@ -599,6 +610,7 @@ fn test_stale_peer_detected() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("aaa".into()),
+                state_size: None,
             }),
         },
         NetLogMessage {
@@ -642,6 +654,7 @@ fn test_stale_peer_detected() {
                 timestamp: 200,
                 state_hash_before: Some("aaa".into()),
                 state_hash_after: Some("bbb".into()),
+                state_size: None,
             }),
         },
         NetLogMessage {
@@ -656,6 +669,7 @@ fn test_stale_peer_detected() {
                 state_hash_before: Some("aaa".into()),
                 state_hash_after: Some("bbb".into()),
                 changed: true,
+                state_size: 1024,
             }),
         },
         NetLogMessage {
@@ -670,6 +684,7 @@ fn test_stale_peer_detected() {
                 timestamp: 300,
                 state_hash_before: Some("bbb".into()),
                 state_hash_after: Some("ccc".into()),
+                state_size: None,
             }),
         },
     ];
@@ -702,6 +717,7 @@ fn test_state_oscillation_detected() {
             elapsed_ms: 10,
             timestamp: 100,
             state_hash: Some("aaa".into()),
+            state_size: None,
         }),
     }];
 
@@ -719,6 +735,7 @@ fn test_state_oscillation_detected() {
                 state_hash_before: Some(if i % 2 == 0 { "aaa" } else { "bbb" }.into()),
                 state_hash_after: Some(hash.to_string()),
                 changed: true,
+                state_size: 1024,
             }),
         });
     }
@@ -797,6 +814,7 @@ fn test_zombie_not_flagged_on_completion() {
                 elapsed_ms: 10,
                 timestamp: 110,
                 state_hash: Some("aaaa".into()),
+                state_size: None,
             }),
         },
     ];
@@ -829,6 +847,7 @@ fn test_broadcast_storm_detected() {
             elapsed_ms: 10,
             timestamp: 100,
             state_hash: Some("aaa".into()),
+            state_size: None,
         }),
     }];
 
@@ -949,6 +968,7 @@ fn test_update_ordering_anomaly() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("init".into()),
+                state_size: None,
             }),
         },
         NetLogMessage {
@@ -964,6 +984,7 @@ fn test_update_ordering_anomaly() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("init".into()),
+                state_size: None,
             }),
         },
         // Peer1 applies A then B -> hash "ab_result"
@@ -979,6 +1000,7 @@ fn test_update_ordering_anomaly() {
                 state_hash_before: Some("init".into()),
                 state_hash_after: Some("after_a".into()),
                 changed: true,
+                state_size: 1024,
             }),
         },
         NetLogMessage {
@@ -993,6 +1015,7 @@ fn test_update_ordering_anomaly() {
                 state_hash_before: Some("after_a".into()),
                 state_hash_after: Some("ab_result".into()),
                 changed: true,
+                state_size: 1024,
             }),
         },
         // Peer2 applies B then A -> hash "ba_result" (different!)
@@ -1008,6 +1031,7 @@ fn test_update_ordering_anomaly() {
                 state_hash_before: Some("init".into()),
                 state_hash_after: Some("after_b".into()),
                 changed: true,
+                state_size: 1024,
             }),
         },
         NetLogMessage {
@@ -1022,6 +1046,7 @@ fn test_update_ordering_anomaly() {
                 state_hash_before: Some("after_b".into()),
                 state_hash_after: Some("ba_result".into()),
                 changed: true,
+                state_size: 1024,
             }),
         },
     ];
@@ -1061,6 +1086,7 @@ fn test_no_ordering_anomaly_when_commutative() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("init".into()),
+                state_size: None,
             }),
         },
         NetLogMessage {
@@ -1076,6 +1102,7 @@ fn test_no_ordering_anomaly_when_commutative() {
                 elapsed_ms: 10,
                 timestamp: 100,
                 state_hash: Some("init".into()),
+                state_size: None,
             }),
         },
         // Peer1: A then B -> "same_result"
@@ -1091,6 +1118,7 @@ fn test_no_ordering_anomaly_when_commutative() {
                 state_hash_before: Some("init".into()),
                 state_hash_after: Some("mid".into()),
                 changed: true,
+                state_size: 1024,
             }),
         },
         NetLogMessage {
@@ -1105,6 +1133,7 @@ fn test_no_ordering_anomaly_when_commutative() {
                 state_hash_before: Some("mid".into()),
                 state_hash_after: Some("same_result".into()),
                 changed: true,
+                state_size: 1024,
             }),
         },
         // Peer2: B then A -> "same_result" (commutative, no anomaly)
@@ -1120,6 +1149,7 @@ fn test_no_ordering_anomaly_when_commutative() {
                 state_hash_before: Some("init".into()),
                 state_hash_after: Some("mid2".into()),
                 changed: true,
+                state_size: 1024,
             }),
         },
         NetLogMessage {
@@ -1134,6 +1164,7 @@ fn test_no_ordering_anomaly_when_commutative() {
                 state_hash_before: Some("mid2".into()),
                 state_hash_after: Some("same_result".into()),
                 changed: true,
+                state_size: 1024,
             }),
         },
     ];

--- a/crates/core/src/tracing/telemetry.rs
+++ b/crates/core/src/tracing/telemetry.rs
@@ -761,6 +761,7 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     elapsed_ms,
                     timestamp,
                     state_hash,
+                    state_size,
                 } => {
                     let mut json = serde_json::json!({
                         "type": "success",
@@ -774,6 +775,9 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     });
                     if let Some(hash) = state_hash {
                         json["state_hash"] = serde_json::Value::String(hash.clone());
+                    }
+                    if let Some(size) = state_size {
+                        json["state_size"] = serde_json::json!(size);
                     }
                     json
                 }
@@ -1133,6 +1137,7 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     timestamp,
                     state_hash_before,
                     state_hash_after,
+                    state_size,
                 } => {
                     let mut json = serde_json::json!({
                         "type": "success",
@@ -1147,6 +1152,9 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     }
                     if let Some(hash) = state_hash_after {
                         json["state_hash_after"] = serde_json::Value::String(hash.clone());
+                    }
+                    if let Some(size) = state_size {
+                        json["state_size"] = serde_json::json!(size);
                     }
                     json
                 }
@@ -1221,6 +1229,7 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                     state_hash_before,
                     state_hash_after,
                     changed,
+                    state_size,
                 } => {
                     let mut json = serde_json::json!({
                         "type": "broadcast_applied",
@@ -1229,6 +1238,7 @@ fn event_kind_to_json(kind: &EventKind) -> serde_json::Value {
                         "target": target.to_string(),
                         "timestamp": timestamp,
                         "changed": changed,
+                        "state_size": state_size,
                     });
                     if let Some(hash) = state_hash_before {
                         json["state_hash_before"] = serde_json::Value::String(hash.clone());


### PR DESCRIPTION
## Problem

The telemetry dashboard needs to display contract state sizes in the Contracts panel, but no telemetry events currently include `state_size`. The field exists in `BroadcastComplete` and `ResyncResponseSent` events, but those don't reach the OTLP collector on the running network. The events that DO reach it (`put_success`, `update_success`, `update_broadcast_applied`) lack size information.

## Approach

Add `state_size` to the three telemetry events where the full state is already available in memory:

- **`PutEvent::PutSuccess`** — `Option<usize>` from `merged_value.len()` (None when state not available in response path)
- **`UpdateEvent::UpdateSuccess`** — `Option<usize>` from `updated_value.len()` (None when state not available in streaming response)
- **`UpdateEvent::BroadcastApplied`** — `usize` from `state_after.len()` (always available since the helper receives `&WrappedState`)

The telemetry JSON serializer includes `state_size` in the event body when present, matching the existing pattern used by `ResyncResponseSent`.

## Testing

- `cargo fmt && cargo clippy --all-targets` — clean
- `cargo test -p freenet` — 1798 passed, 1 pre-existing flaky failure (`test_deadlock_is_detected`, timing-sensitive)
- Updated all 31 test constructions in `state_verifier/tests.rs`
- No new tests needed — this adds an optional field to existing events with no behavioral change

[AI-assisted - Claude]