### PR TITLE
fix: prevent div-by-zero in Adjustment::value()

### DIFF
--- a/crates/core/src/router/isotonic_estimator.rs
+++ b/crates/core/src/router/isotonic_estimator.rs
@@ -226,7 +226,7 @@ impl Adjustment {
     }
 
     fn value(&self) -> f64 {
-        self.sum / self.count as f64
+        self.mean()
     }
 
     /// Mean adjustment value (sum / count).


### PR DESCRIPTION
## Problem

The private `Adjustment::value()` method in `isotonic_estimator.rs` divides `self.sum / self.count as f64` without guarding against `count == 0`. While the caller currently checks `count >= MIN_POINTS_FOR_REGRESSION`, the method itself is unsafe and a near-duplicate of the already-safe `mean()` method.

The stray double-quote in `home_page.rs` (Issue 1 of #3385) was already fixed in #3402.

## Solution

Delegate `value()` to `mean()`, which correctly returns `0.0` when `count == 0`.

## Testing

- `cargo clippy --all-targets` passes
- `cargo test -p freenet` passes

## Fixes

Closes #3385