### PR TITLE
feat: show peer's external address and UDP port on local dashboard

### DIFF
--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -44,6 +44,8 @@ pub struct NetworkStatus {
     pub version: String,
     /// This node's ring location.
     pub own_location: Option<f64>,
+    /// This node's externally observed address (as seen by peers).
+    pub external_address: Option<SocketAddr>,
     /// Operation counters.
     pub op_stats: OperationStats,
     /// NAT traversal counters.
@@ -153,6 +155,7 @@ pub fn init(listening_port: u16, gateway_addrs: HashSet<SocketAddr>, version: St
         subscribed_contracts: HashMap::new(),
         version,
         own_location: None,
+        external_address: None,
         op_stats: OperationStats::default(),
         nat_stats: NatStats::default(),
     };
@@ -300,6 +303,15 @@ pub fn set_own_location(location: f64) {
     }
 }
 
+/// Set this node's externally observed address (as reported by peers).
+pub fn set_external_address(addr: SocketAddr) {
+    if let Some(status) = NETWORK_STATUS.get() {
+        if let Ok(mut s) = status.write() {
+            s.external_address = Some(addr);
+        }
+    }
+}
+
 // --- Snapshot types for rendering ---
 
 /// Snapshot of the current network status for rendering.
@@ -311,6 +323,8 @@ pub struct NetworkStatusSnapshot {
     pub listening_port: u16,
     pub version: String,
     pub own_location: Option<f64>,
+    /// This node's externally observed address (as seen by peers).
+    pub external_address: Option<SocketAddr>,
     pub peers: Vec<PeerSnapshot>,
     pub contracts: Vec<ContractSnapshot>,
     pub op_stats: OpStatsSnapshot,
@@ -526,6 +540,7 @@ pub fn get_snapshot() -> Option<NetworkStatusSnapshot> {
         listening_port: s.listening_port,
         version: s.version.clone(),
         own_location: s.own_location,
+        external_address: s.external_address,
         peers,
         contracts,
         op_stats: OpStatsSnapshot {

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -851,6 +851,7 @@ impl ConnectionManager {
         let mut own_addr = self.own_addr.lock();
         if own_addr.is_none() {
             *own_addr = Some(addr);
+            crate::node::network_status::set_external_address(addr);
             tracing::info!(
                 addr = %addr,
                 "try_set_own_addr: initialized own address"
@@ -872,6 +873,7 @@ impl ConnectionManager {
         let mut own_addr = self.own_addr.lock();
         let old_addr = *own_addr;
         *own_addr = Some(addr);
+        crate::node::network_status::set_external_address(addr);
         tracing::debug!(
             old_addr = ?old_addr,
             new_addr = %addr,

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -256,6 +256,19 @@ fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> St
         }
     };
 
+    // External address info (shown once discovered via NAT traversal)
+    let external_addr_html = if let Some(addr) = snap.external_address {
+        format!(
+            r#"<p class="external-addr">External address: <code>{ip}</code> &mdash; UDP port: <code>{port}</code></p>"#,
+            ip = addr.ip(),
+            port = addr.port(),
+        )
+    } else if snap.open_connections > 0 {
+        r#"<p class="external-addr muted">External address: discovering...</p>"#.to_string()
+    } else {
+        String::new()
+    };
+
     let spinner = if snap.open_connections == 0 {
         r#"<div class="spinner"></div>"#
     } else {
@@ -372,12 +385,14 @@ fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> St
         r#"<div class="card">
             <h2>Connection Status</h2>
             {health_banner}
+            {external_addr_html}
             {spinner}
             {gateway_warning}
             {nat_html}
             {failures_html}
         </div>"#,
         health_banner = health_banner,
+        external_addr_html = external_addr_html,
         spinner = spinner,
         gateway_warning = gateway_warning,
         nat_html = nat_html,
@@ -882,6 +897,12 @@ main {
     font-size: 0.85rem;
 }
 .warning li { margin-bottom: 0.25rem; }
+.external-addr {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-top: 0.5rem;
+}
+.external-addr.muted { opacity: 0.6; font-style: italic; }
 .nat-stat {
     font-size: 0.85rem;
     color: var(--text-secondary);
@@ -1752,6 +1773,7 @@ mod tests {
             listening_port: 31337,
             version: "0.1.0".to_string(),
             own_location: None,
+            external_address: None,
             peers: Vec::new(),
             contracts: Vec::new(),
             op_stats: OpStatsSnapshot::default(),


### PR DESCRIPTION
## Problem
Users have no way to see their node's externally observed address (public IP and UDP port) on the local peer dashboard. This information is useful for verifying NAT traversal is working and understanding the node's public-facing identity.

## Approach
- Added `external_address: Option<SocketAddr>` to `NetworkStatus` and `NetworkStatusSnapshot`
- Added `set_external_address()` to the network status module
- Hooked into `set_own_addr()` and `try_set_own_addr()` in `ConnectionManager` — these are the single points where the externally observed address is learned (via ObservedAddress messages during NAT traversal)
- Display the external IP and UDP port in the Connection Status card, right below the health banner
- Shows "discovering..." while connected but address not yet learned
- Hidden when not connected (no connections = no way to discover external address)

## Testing
- All 33 existing `network_status` and `home_page` tests pass
- Build compiles cleanly with no new warnings
- No behavioral changes to existing logic — purely additive display feature

[AI-assisted - Claude]