### PR TITLE
docs: add rules from connection growth stall RCA

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -143,6 +143,26 @@ CORRECT:
 
 **Audit targets:** `grep -r "biased;" crates/core/src/` — verify each site has per-iteration caps and cancellation-safety documentation.
 
+### WHEN introducing numeric thresholds or limits
+
+```
+Does this threshold relate to a configurable value (min_connections, max_connections, etc.)?
+  → YES: Derive from that config value, NEVER hardcode a number
+  → NO: Define as a named constant with a comment explaining the choice
+
+WRONG:
+  const BOOTSTRAP_THRESHOLD: usize = 4;  // Magic number, breaks when config changes
+
+CORRECT:
+  let threshold = connection_manager.min_connections;  // Tied to config
+
+WHY: Hardcoded thresholds silently break when the related configuration
+changes. A hardcoded 4 caused nodes to plateau far below min_connections=10+
+for 9 months because the threshold didn't scale with the config.
+
+See: issue #3414 — BOOTSTRAP_THRESHOLD=4 vs min_connections
+```
+
 ### WHEN spawning tasks with `GlobalExecutor::spawn`
 
 **No fire-and-forget spawns for critical tasks.**

--- a/.claude/rules/ring.md
+++ b/.claude/rules/ring.md
@@ -24,16 +24,61 @@ WHEN calculating contract location:
 ### Connection Management
 
 ```
-WHEN accepting a new connection:
+WHEN accepting a new connection (should_accept):
   1. CHECK: Is this a self-connection? → REJECT
-  2. CHECK: Are we below min_connections (25)? → ACCEPT
-  3. CHECK: Are we at max_connections (200)? → REJECT
+  2. CHECK: Are we below min_connections? → ACCEPT
+     → Use ACTUAL open connection count, NOT speculative totals
+     → Pending reservations are speculative (many fail to complete);
+       counting them pushes nodes into the topology evaluator prematurely
+  3. CHECK: Are we at max_connections? → REJECT
+     → Use total_conn (open + pending) here to prevent over-commitment
   4. OTHERWISE: Evaluate via TopologyManager
 
 WHEN closing a connection:
   → MUST remove from connections_by_location
   → MUST remove from location_for_peer
   → MUST update connection count atomically
+```
+
+### Speculative State vs Actual State
+
+```
+Speculative state (pending reservations, in-flight operations) MUST be
+treated differently from actual state (open connections, completed ops):
+
+  - "Do I need more?" checks → use ACTUAL state only
+    (e.g., open < min_connections)
+  - "Am I over-committed?" checks → use speculative state
+    (e.g., total_conn >= max_connections)
+
+WHY: Speculative state inflates counts. A node with 8 open connections
+and 2 pending reservations appears to have 11 connections, but only 8
+are real. Using the inflated count for "need more?" decisions prevents
+the node from reaching min_connections.
+
+See: connection_manager.rs should_accept(), issue #3414
+```
+
+### Backoff Target Must Match Failure Cause
+
+```
+WHEN recording connection backoff:
+  → The backoff target MUST reflect what actually failed
+
+WRONG:
+  // acquire_new returns None because WE have no routing candidates
+  self.record_connection_failure(target_location, RoutingFailed);
+  // This backs off the TARGET, but the target isn't at fault
+
+CORRECT:
+  // Only back off the target when the TARGET caused the failure
+  // (timeout, rejection, NAT punch failed)
+  // If the failure is local (no routing candidates), don't record backoff
+
+WHY: Backing off a target for a local problem prevents connecting to it
+later when local conditions improve (e.g., more connections acquired).
+
+See: ring/mod.rs connection_maintenance, issue #3414
 ```
 
 ### Routing Decisions
@@ -181,12 +226,32 @@ DON'T: Accept connections without checking should_accept()
 WHY: Breaks topology optimization, may cause resource exhaustion
 ```
 
+### Thresholds Must Derive From Configuration
+
+```
+WHEN introducing a connection count threshold or limit:
+  → MUST derive from min_connections / max_connections, NOT hardcode a number
+  → Hardcoded thresholds silently break when configuration changes
+
+WRONG:
+  const BOOTSTRAP_THRESHOLD: usize = 4;  // Assumes min_connections is small
+
+CORRECT:
+  let bootstrap_threshold = connection_manager.min_connections;
+
+WHY: A hardcoded threshold of 4 caused a 9-month latent bug where nodes
+plateaued far below min_connections=10+ because gateway-directed CONNECTs
+stopped too early.
+
+See: operations/connect.rs initial_join_procedure, issue #3414
+```
+
 ## Testing Checklist
 
 ```
 □ Test with 0 connections (cold start)
-□ Test at min_connections boundary (25)
-□ Test at max_connections boundary (200)
+□ Test at min_connections boundary
+□ Test at max_connections boundary
 □ Test self-connection rejection
 □ Test location calculation determinism
 □ Test routing with visited peer filtering

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -139,6 +139,33 @@ event signal count and per-peer generation budget).
 See: `crates/core/tests/simulation_integration.rs` — `test_partition_heal_convergence`,
 `test_crash_recover_convergence`, `test_multi_step_churn`
 
+## Simulation Test Realism
+
+```
+WHEN writing a simulation test for connection/topology behavior:
+  → Use realistic parameters, not minimal ones
+
+WRONG:
+  5 nodes, min_connections=3, 5 virtual minutes
+  // Too small to detect growth ceilings or compounding bugs
+
+CORRECT:
+  50 nodes, min_connections=10, 1 virtual hour
+  // Exercises realistic topology formation and exposes plateau behavior
+
+WHEN asserting on connection counts:
+  → Assert against min_connections, not arbitrary low thresholds
+  → Assert a high percentage (>=90%) of nodes reach min_connections
+  → Include a fault injection phase to verify no death spiral
+
+WHY: Small topologies with low thresholds masked a 9-month bug where
+nodes plateaued at 4-9 connections. The stall only manifests clearly
+with min_connections significantly above hardcoded internal thresholds
+and enough nodes + time for the growth ceiling to appear.
+
+See: test_connection_growth_stall_regression in simulation_integration.rs
+```
+
 ## Anomaly Detection
 
 After any simulation test, use `StateVerifier` to check for consistency anomalies:


### PR DESCRIPTION
## Problem

The connection growth stall (nodes plateauing at 4-9 connections) was caused by three compounding design flaws that went undetected for 9 months. The fixes are in PR #3413, but the learnings should be codified in rules so automated reviews catch these patterns in future code.

## Solution

Add rules to three files based on the RCA in #3414:

### `.claude/rules/ring.md`
- **Speculative vs actual state**: `should_accept` must use actual open connections for `min_connections` check, not inflated `total_conn` (open + pending). Pending reservations are speculative — use them only for `max_connections` (over-commitment prevention).
- **Backoff target must match failure cause**: Don't back off a target location when the failure is local (no routing candidates). Only back off when the target itself failed (timeout, rejection, NAT failure).
- **Thresholds must derive from config**: Connection thresholds must come from `min_connections`/`max_connections`, not hardcoded magic numbers.
- Fix stale hardcoded values (25, 200) in the connection management docs.

### `.claude/rules/code-style.md`
- **General rule**: Numeric thresholds that relate to configurable values must derive from those config values, never be hardcoded.

### `.claude/rules/testing.md`
- **Simulation test realism**: Topology/connection tests must use realistic parameters (50+ nodes, min_connections=10+, 1+ virtual hour). Small topologies mask growth ceiling bugs.

## Testing

Documentation-only change — no code changes.

## Fixes

Closes #3414