### PR TITLE
fix: correct Y-axis tick formatting in PAV regression charts

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -1584,7 +1584,7 @@ fn build_estimator_chart(
         let sy = to_svg_y(y_val);
         let label = if y_val.abs() < 1e-3 && y_range < 10.0 {
             format!("{:.3}", y_val)
-        } else if y_range < 1.0 {
+        } else if y_range <= 1.0 {
             format!("{:.2}", y_val)
         } else {
             format!("{:.0}", y_val)


### PR DESCRIPTION
## Problem

The PAV regression curves panel in the local peer dashboard shows incorrect Y-axis ticks. For probability values (0.0–1.0 range), the ticks display as "1", "0", "0.000" — the middle tick shows "0" instead of "0.5".

## Approach

The formatting logic checks `y_range < 1.0` to decide between 2-decimal and 0-decimal format. For probability charts, `y_range` is exactly 1.0, so the strict `<` comparison misses this case. The middle tick value (0.5) falls through to `format!("{:.0}")`, which rounds it to "0".

Changed to `y_range <= 1.0` so the 2-decimal format applies. Ticks now show "1.00", "0.50", "0.000".

## Testing

Visual — one-character change to a comparison operator in display-only code.

[AI-assisted - Claude]