### PR TITLE
docs: amended documentation to remove overloading of 'gateway'

### DIFF
--- a/crates/core/src/client_events/mod.rs
+++ b/crates/core/src/client_events/mod.rs
@@ -1,4 +1,4 @@
-//! Clients events related logic and type definitions. For example, receival of client events from applications throught the HTTP gateway.
+//! Clients events related logic and type definitions. For example, receival of client events from applications throught the HTTP API.
 
 use either::Either;
 use freenet_stdlib::{

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -165,16 +165,17 @@ async fn web_home(
         add_sandbox_cors_headers(&mut response);
         // CSP for sandbox content: the iframe has an opaque origin (null) because the
         // sandbox attribute omits allow-same-origin. This means CSP 'self' won't match
-        // the gateway's actual origin, so we must use the explicit gateway origin derived
-        // from the Host header. This allows the iframe to load scripts, styles, images,
-        // and WASM from the gateway while blocking access to other origins.
-        let gateway_origin = req_headers
+        // the local API server's actual origin, so we must use the explicit local API
+        // origin derived from the Host header. This allows the iframe to load scripts,
+        // styles, images, and WASM from the local API server while blocking access
+        // to other origins.
+        let local_api_origin = req_headers
             .get(axum::http::header::HOST)
             .and_then(|h| h.to_str().ok())
             .map(|host| format!("http://{host}"))
             .unwrap_or_else(|| "'self'".to_string());
         let csp = format!(
-            "default-src {gateway_origin} 'unsafe-inline' 'unsafe-eval' blob: data:; connect-src {gateway_origin} blob: data:"
+            "default-src {local_api_origin} 'unsafe-inline' 'unsafe-eval' blob: data:; connect-src {local_api_origin} blob: data:"
         );
         if let Ok(csp_value) = axum::http::HeaderValue::from_str(&csp) {
             response

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1,8 +1,8 @@
 //! Handle the `web` part of the bundles.
 //!
 //! Contract web apps are served inside sandboxed iframes to provide origin isolation.
-//! The gateway returns a "shell" page that holds the auth token and proxies WebSocket
-//! connections via postMessage, while the contract runs in an
+//! The local API server returns a "shell" page that holds the auth token and
+//! proxies WebSocket connections via postMessage, while the contract runs in an
 //! `<iframe sandbox="allow-scripts allow-forms">` with an opaque origin that cannot
 //! access other contracts' data.
 
@@ -423,12 +423,12 @@ async fn sandbox_content_body(
 /// The bridge listens for WebSocket requests from the sandboxed iframe,
 /// creates real WebSocket connections with the auth token injected, and
 /// forwards messages in both directions. Only allows connections to the
-/// gateway itself (same origin) to prevent the contract from using the
+/// local API server itself (same origin) to prevent the contract from using the
 /// bridge as an open proxy to other localhost services.
 const SHELL_BRIDGE_JS: &str = r#"
 function freenetBridge(authToken) {
   'use strict';
-  var GATEWAY_ORIGIN = location.origin;
+  var LOCAL_API_ORIGIN = location.origin;
   var MAX_CONNECTIONS = 32;
   var iframe = document.getElementById('app');
   var connections = new Map();
@@ -468,7 +468,7 @@ function freenetBridge(authToken) {
           sendToIframe({ __freenet_ws__: true, type: 'error', id: msg.id });
           return;
         }
-        // Security: only allow WebSocket connections to the gateway itself.
+        // Security: only allow WebSocket connections to the local API server itself.
         // Validate protocol explicitly and compare origin.
         try {
           var u = new URL(msg.url);
@@ -477,7 +477,7 @@ function freenetBridge(authToken) {
             return;
           }
           var httpProto = u.protocol === 'wss:' ? 'https:' : 'http:';
-          if (httpProto + '//' + u.host !== GATEWAY_ORIGIN) {
+          if (httpProto + '//' + u.host !== LOCAL_API_ORIGIN) {
             sendToIframe({ __freenet_ws__: true, type: 'error', id: msg.id });
             return;
           }
@@ -1020,7 +1020,7 @@ mod tests {
     #[test]
     fn bridge_js_contains_origin_check() {
         assert!(
-            SHELL_BRIDGE_JS.contains("GATEWAY_ORIGIN"),
+            SHELL_BRIDGE_JS.contains("LOCAL_API_ORIGIN"),
             "bridge JS must validate WebSocket origin"
         );
         assert!(

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -14,7 +14,7 @@ Freenet Core is a peer-to-peer runtime that enables decentralized applications. 
 ```mermaid
 flowchart TB
     subgraph Client["Client Applications"]
-        ClientAPI["WebSocket API / HTTP Gateway"]
+        ClientAPI["WebSocket API / HTTP API"]
     end
 
     subgraph NodeLoop["Node Event Loop (Central Coordinator)"]
@@ -137,7 +137,7 @@ See [ring/README.md](ring/README.md) for detailed documentation.
 Client-facing APIs:
 
 - **WebSocket API** – Primary client interface (`/v1/contract/command`)
-- **HTTP Gateway** – REST endpoints for management
+- **HTTP API** – REST endpoints for management
 
 ### Simulation (`crates/core/src/simulation/`)
 


### PR DESCRIPTION
I have made the specified changes to the documentation as listed in issue #3395. I was uncertain how to exactly word `client_api.rs:168`, so I did my best guess.

I noticed a few more places where the there was a JS variable name to change, and changed the full scope of that variable.