### PR TITLE
fix: add telemetry and logging for GET operation failures

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -188,6 +188,18 @@ pub(crate) async fn request_get(
                 phase = "error",
                 "GET: Contract not found locally and no peers available"
             );
+
+            // Emit failure telemetry so this case is visible in production metrics
+            if let Some(event) = NetEventLog::get_failure(
+                id,
+                &op_manager.ring,
+                *instance_id,
+                OperationFailure::NoPeersAvailable,
+                None,
+            ) {
+                op_manager.ring.register_events(Either::Left(event)).await;
+            }
+
             return Err(RingError::EmptyRing.into());
         }
 
@@ -1055,7 +1067,8 @@ impl Operation for GetOp {
                                         tx = %id,
                                         %instance_id,
                                         %this_peer,
-                                        "GET: state available locally but contract code missing; continuing search"
+                                        fetch_contract,
+                                        "GET: state available locally but contract code missing; forwarding GET"
                                     );
                                     None
                                 } else {

--- a/crates/core/src/ring/mod.rs
+++ b/crates/core/src/ring/mod.rs
@@ -1407,6 +1407,7 @@ impl Ring {
 
         let mut seen = HashSet::new();
         let mut candidates: Vec<PeerKeyLocation> = Vec::new();
+        let mut skipped_not_ready: usize = 0;
 
         let connections = self.connection_manager.get_connections_by_location();
         // Sort keys for deterministic iteration order (HashMap iteration is non-deterministic)
@@ -1425,6 +1426,12 @@ impl Ring {
                     }
                     // Skip peers that haven't advertised readiness
                     if !self.connection_manager.is_peer_ready(addr) {
+                        tracing::debug!(
+                            %addr,
+                            target_location = %target_location.as_f64(),
+                            "k_closest: skipping peer not yet ready"
+                        );
+                        skipped_not_ready += 1;
                         continue;
                     }
                 }
@@ -1451,6 +1458,13 @@ impl Ring {
             total_routing_events = decision.total_routing_events,
             selected_count = selected.len(),
             "routing_decision"
+        );
+
+        tracing::debug!(
+            target_location = %target_location.as_f64(),
+            candidates_found = selected.len(),
+            skipped_not_ready,
+            "k_closest_potentially_caching result"
         );
 
         selected.into_iter().cloned().collect()


### PR DESCRIPTION
## Problem

Issue #3356 documents that GET operations fail 94% of the time. The failures are currently invisible:

- **~55% case**: `k_closest_potentially_caching` returns empty → GET fails at originating peer with `RingError::EmptyRing`. This emits **zero telemetry** — completely invisible in production metrics.
- **~45% case**: GET forwarded 1-2 hops and dies because `fetch_contract=true` but WASM code is missing. The existing log was already `info!` but lacked the `fetch_contract` field needed to confirm the root cause.

Without visibility we can't confirm whether the fixes we'd write are actually addressing the right root causes.

## Solution

Phase 1 visibility fixes — **logging and telemetry changes only, no behavior changes**:

1. **Emit `get_failure` telemetry when `EmptyRing`** (`get.rs` `request_get` path): Before returning `Err(RingError::EmptyRing)`, call `NetEventLog::get_failure` with `OperationFailure::NoPeersAvailable`. Uses the same pattern already present at line ~761 for the connection-aborted path.

2. **Add `fetch_contract` field to "contract code missing" log** (`get.rs` relay handler): The `tracing::info!` at ~line 1066 already existed but lacked the `fetch_contract` field. Adding it makes the cause machine-readable in production logs. Also updated the message to say "forwarding GET" (more precise than "continuing search").

3. **Add `debug!` logs in `k_closest_potentially_caching`** (`ring/mod.rs`): Log each peer skipped because `is_peer_ready` returned false (with peer addr and target location), and add a per-call summary log showing `candidates_found` vs `skipped_not_ready`. This makes it possible to see from logs whether the function is returning empty due to readiness filtering.

## Testing

No behavior changes — existing tests continue to pass. The new telemetry and log lines fire only on existing code paths.

## Fixes

Closes  3356 (Phase 1 — visibility only; Phase 2 will address root causes once confirmed from telemetry)