### PR TITLE
fix: use inline SVG favicon in shell page to avoid CORS errors

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -108,7 +108,7 @@ fn homepage_html() -> String {
 /// Freenet rabbit silhouette SVG path, derived from freenet_logo.svg.
 /// Used for the favicon with a solid color fill (no gradient) so the
 /// connection status color is immediately visible at favicon size.
-const RABBIT_SVG_PATH: &str = concat!(
+pub(super) const RABBIT_SVG_PATH: &str = concat!(
     "M358.864 40.470C358.605 40.728 354.143 42.467 348.947 44.334",
     "C284.621 67.446 232.573 113.729 201.443 175.500",
     "C193.895 190.478 184.375 213.708 185.375 214.708",

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -325,6 +325,14 @@ fn shell_page(
 
     // auth_token is base58 (alphanumeric only), safe for unescaped interpolation.
     let auth_token = auth_token.as_str();
+    // Use an inline SVG data URI for the default favicon to avoid CORS errors
+    // from cross-origin requests. Contracts can override this via the
+    // __freenet_shell__ postMessage bridge (type: 'favicon').
+    let favicon = format!(
+        "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 471'>\
+         <path d='{}' fill='%23007FFF' fill-rule='evenodd'/></svg>",
+        super::home_page::RABBIT_SVG_PATH,
+    );
     let html = format!(
         r##"<!DOCTYPE html>
 <html lang="en">
@@ -332,7 +340,7 @@ fn shell_page(
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Freenet</title>
-<link rel="icon" href="https://freenet.org/freenet_logo.svg">
+<link rel="icon" type="image/svg+xml" href="{favicon}">
 <style>*{{margin:0;padding:0}}html,body{{width:100%;height:100%;overflow:hidden}}iframe{{width:100%;height:100%;border:none}}</style>
 </head>
 <body>
@@ -854,8 +862,12 @@ mod tests {
             "shell page title mismatch"
         );
         assert!(
-            html.contains(r#"<link rel="icon" href="https://freenet.org/freenet_logo.svg">"#),
-            "favicon link missing"
+            html.contains(r#"<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,"#),
+            "favicon should use inline data URI, not external URL"
+        );
+        assert!(
+            !html.contains("freenet.org"),
+            "shell page must not reference external origins (CORS)"
         );
         // Shell message handler must be present in bridge JS
         assert!(


### PR DESCRIPTION
## Problem

The contract shell page's `<link rel="icon">` pointed to `https://freenet.org/freenet_logo.svg`, which triggers CORS errors since the shell serves from the gateway's origin. This means every contract tab shows no favicon and logs console errors.

## Solution

Replace the external URL with an inline SVG data URI using the same Freenet rabbit silhouette already used by the local peer dashboard. Made `RABBIT_SVG_PATH` in `home_page.rs` accessible as `pub(super)` to reuse in `path_handlers.rs`.

Contracts can still override the favicon via the existing `__freenet_shell__` postMessage bridge (`type: 'favicon'`). A companion PR in the River repo will send River's logo to the shell on startup.

## Testing

- All 4 `shell_page_*` tests pass with updated assertions
- Added assertion that shell page does not reference `freenet.org` (no external origins)

## Fixes

Closes #3354

[AI-assisted - Claude]