### PR TITLE
fix: serve GET state without contract code instead of forwarding into death spiral

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -1063,17 +1063,21 @@ impl Operation for GetOp {
                                     }),
                             }) => {
                                 if fetch_contract && contract.is_none() {
+                                    // Serve state even without contract code rather than
+                                    // forwarding. UPDATE broadcasts propagate state but not
+                                    // WASM code, so most peers have state without code.
+                                    // Forwarding causes a death spiral where the GET bounces
+                                    // between peers that all have state but no code, eventually
+                                    // exhausting retries and dying silently (#3356 45% case).
                                     tracing::info!(
                                         tx = %id,
                                         %instance_id,
                                         %this_peer,
                                         fetch_contract,
-                                        "GET: state available locally but contract code missing; forwarding GET"
+                                        "GET: serving state without contract code (code not available locally)"
                                     );
-                                    None
-                                } else {
-                                    Some((key, state, contract))
                                 }
+                                Some((key, state, contract))
                             }
                             _ => None,
                         };

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -6720,3 +6720,138 @@ fn test_get_succeeds_despite_readiness_gating() {
         report.total_events
     );
 }
+
+/// Validates GET with `fetch_contract=true` works in a PUT→UPDATE→GET flow.
+///
+/// Related to #3356 (45% case): peers that receive state via UPDATE but not
+/// WASM code should still serve the state rather than forwarding into a death
+/// spiral. In this small topology the GET may reach the gateway (which has
+/// code), so this test primarily validates the end-to-end flow rather than
+/// specifically proving the forwarding fix. The forwarding fix is a defensive
+/// change for larger topologies where GETs may not reach the PUT originator.
+///
+/// Scenario:
+///   1. Gateway PUTs contract with subscribe=true
+///   2. Nodes 1-2 subscribe (triggering state propagation)
+///   3. Gateway sends UPDATE (propagates state to subscribers)
+///   4. Node 3 (not subscribed) GETs with `return_contract_code=true`
+///   5. Assert node 3's storage has the contract state
+#[test_log::test]
+fn test_get_fetch_contract_serves_state_without_code() {
+    use freenet::dev_tool::{register_crdt_contract, NodeLabel, ScheduledOperation, SimOperation};
+
+    const SEED: u64 = 0xDE7A_5F10_0001;
+    const NETWORK_NAME: &str = "get-fetch-contract-no-code";
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+
+    let rt = create_runtime();
+
+    let (sim, logs_handle) = rt.block_on(async {
+        let sim = SimNetwork::new(
+            NETWORK_NAME,
+            1,  // gateways
+            3,  // nodes
+            7,  // ring_max_htl
+            3,  // rnd_if_htl_above
+            10, // max_connections
+            2,  // min_connections
+            SEED,
+        )
+        .await;
+        let logs_handle = sim.event_logs_handle();
+        (sim, logs_handle)
+    });
+
+    let contract = SimOperation::create_test_contract(0xDE);
+    let contract_id = *contract.key().id();
+    let contract_key = contract.key();
+    register_crdt_contract(contract_id);
+
+    let operations = vec![
+        // 1. Gateway PUTs contract with subscribe
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: SimOperation::create_crdt_state(1, 0xDE),
+                subscribe: true,
+            },
+        ),
+        // 2. Nodes 1-2 subscribe (state propagation targets)
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 1),
+            SimOperation::Subscribe { contract_id },
+        ),
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 2),
+            SimOperation::Subscribe { contract_id },
+        ),
+        // 3. Gateway updates — propagates state (not code) to subscribers
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Update {
+                key: contract_key,
+                data: SimOperation::create_crdt_state(10, 0xDE),
+            },
+        ),
+        // 4. Node 3 GETs with fetch_contract=true (not a subscriber, must route)
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 3),
+            SimOperation::Get {
+                contract_id,
+                return_contract_code: true,
+                subscribe: false,
+            },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(180),
+        Duration::from_secs(60),
+    );
+
+    assert!(
+        result.turmoil_result.is_ok(),
+        "GET fetch_contract simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    // Verify that node 3 has the contract state despite peers only having
+    // state (not code) from UPDATE broadcasts.
+    let node3_label = NodeLabel::node(NETWORK_NAME, 3);
+    let node3_storage = result
+        .node_storages
+        .get(&node3_label)
+        .expect("node 3 should have a storage handle");
+    let node3_state = node3_storage.get_stored_state(&contract_key);
+
+    assert!(
+        node3_state.is_some(),
+        "Node 3 should have contract state after GET with fetch_contract=true, \
+         but storage is empty. This indicates the GET died in a forwarding \
+         death spiral because relay peers had state but no WASM code (#3356)."
+    );
+
+    // Run StateVerifier for anomaly detection (per testing.md)
+    let rt = create_runtime();
+    let report = rt.block_on(async {
+        let logs = logs_handle.lock().await;
+        let verifier = freenet::tracing::StateVerifier::from_events(logs.clone());
+        verifier.verify()
+    });
+    tracing::info!(
+        "Anomaly report: {} anomalies across {} contracts",
+        report.anomalies.len(),
+        report.contracts_analyzed
+    );
+
+    tracing::info!(
+        "test_get_fetch_contract_serves_state_without_code PASSED: \
+         node 3 has contract state, {} events analyzed",
+        report.total_events
+    );
+}


### PR DESCRIPTION
## Problem

When a relay peer has contract state (received via UPDATE broadcast) but not the WASM code, and a GET arrives with `fetch_contract=true`, the peer treated it as "not found" and forwarded the GET to the next peer.

Since UPDATE broadcasts propagate state but **never** WASM code, most peers in the network have state without code. The GET bounces between these peers until retries are exhausted, dying silently. This is the **45% failure case** from #3356 — GETs that find peers with state but no code die after 1-2 hops.

The 55% failure case (EmptyRing from readiness gating) was fixed in #3425.

## Solution

At `get.rs:1065`, instead of returning `None` (forwarding) when `fetch_contract && contract.is_none()`, serve the state the peer has. The `GetResult.contract` field is already `Option<ContractContainer>`, so the client already handles `None` contract code gracefully.

This is a one-line behavioral change (removing the `None` return and always returning `Some((key, state, contract))`). A `tracing::info!` log is emitted when state is served without code for observability.

## Testing

- Test `test_get_fetch_contract_serves_state_without_code` validates the PUT→UPDATE→GET flow with `fetch_contract=true`. In the small test topology the GET may reach the gateway (which has code), so the test validates the end-to-end flow. The forwarding fix is a defensive change for larger production topologies.
- StateVerifier anomaly detection included per testing.md

## Refs

Refs #3356, #3423