### PR TITLE
ci: skip expensive tests for release PRs in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,13 +128,12 @@ jobs:
 
   test_unit:
     name: Unit & Integration
-    runs-on: ubicloud-standard-16
+    runs-on: "${{ (github.event_name == 'merge_group' && startsWith(github.event.merge_group.head_commit.message, 'build: release')) && 'ubuntu-latest' || 'ubicloud-standard-16' }}"
     timeout-minutes: 30
     needs: fmt_check
-    # Skip on:
-    # - push to main: PR already validated code before merge (saves ~$0.08/push)
-    # - release PRs: only bump versions, main already passed CI
-    # Note: merge_group MUST run — required status checks apply to merge queue entries
+    # Skip on push to main (PR already validated) and release PRs (only version bumps).
+    # For release merge_group entries: required checks can't be skipped (would block merge),
+    # so we run on a cheap runner and skip expensive steps via is_release output.
     if: |
       (github.event_name == 'pull_request' || github.event_name == 'merge_group') &&
       !startsWith(github.head_ref, 'release/v')
@@ -148,27 +147,42 @@ jobs:
       RUST_MIN_STACK: 268435456
 
     steps:
+      - name: Detect release merge queue
+        id: release_check
+        run: |
+          if [[ "${{ github.event_name }}" == "merge_group" && "${{ github.event.merge_group.head_commit.message }}" == build:\ release* ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping tests — release PRs only bump versions (main CI already validated)"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v6
+        if: steps.release_check.outputs.is_release != 'true'
 
       - name: Install mold linker
+        if: steps.release_check.outputs.is_release != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y mold
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.release_check.outputs.is_release != 'true'
         with:
           toolchain: 1.93.0
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
-        if: success() || steps.test.conclusion == 'failure'
+        if: (success() || steps.test.conclusion == 'failure') && steps.release_check.outputs.is_release != 'true'
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
+        if: steps.release_check.outputs.is_release != 'true'
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Build
+        if: steps.release_check.outputs.is_release != 'true'
         env:
           # Use mold linker to avoid rust-lld crashes (see issue #2519)
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
@@ -179,12 +193,14 @@ jobs:
           make -C apps/freenet-ping -f run-ping.mk build
 
       - name: Clean test directories
+        if: steps.release_check.outputs.is_release != 'true'
         run: |
           # Remove freenet test directories from /tmp to avoid permission issues
           # when tests create directories with different user ownership
           rm -rf /tmp/freenet /tmp/freenet-* 2>/dev/null || true
 
       - name: Test
+        if: steps.release_check.outputs.is_release != 'true'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
@@ -210,7 +226,7 @@ jobs:
             --profile ci -E 'not test(blocked_peers)'
 
       - name: Test blocked-peers (serial)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.release_check.outputs.is_release != 'true' }}
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
@@ -223,17 +239,17 @@ jobs:
             -E 'test(blocked_peers)' -j 1
 
       - name: Test ping-types
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.release_check.outputs.is_release != 'true' }}
         # freenet-ping-types tests need the std feature (default).
         # Run separately since the main step uses --no-default-features.
         run: cargo nextest run -p freenet-ping-types --profile ci
 
   test_simulation:
     name: Simulation
-    runs-on: ubicloud-standard-16
+    runs-on: "${{ (github.event_name == 'merge_group' && startsWith(github.event.merge_group.head_commit.message, 'build: release')) && 'ubuntu-latest' || 'ubicloud-standard-16' }}"
     timeout-minutes: 30
     needs: fmt_check
-    # Same skip conditions as test_unit
+    # Same skip conditions as test_unit (see test_unit comment for details)
     if: |
       (github.event_name == 'pull_request' || github.event_name == 'merge_group') &&
       !startsWith(github.head_ref, 'release/v')
@@ -243,23 +259,39 @@ jobs:
       RUST_MIN_STACK: 268435456
 
     steps:
+      - name: Detect release merge queue
+        id: release_check
+        run: |
+          if [[ "${{ github.event_name }}" == "merge_group" && "${{ github.event.merge_group.head_commit.message }}" == build:\ release* ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping tests — release PRs only bump versions (main CI already validated)"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v6
+        if: steps.release_check.outputs.is_release != 'true'
 
       - name: Install mold linker
+        if: steps.release_check.outputs.is_release != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y mold
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.release_check.outputs.is_release != 'true'
         with:
           toolchain: 1.93.0
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.release_check.outputs.is_release != 'true'
 
       - name: Install nextest
+        if: steps.release_check.outputs.is_release != 'true'
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Run simulation tests
+        if: steps.release_check.outputs.is_release != 'true'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
@@ -276,13 +308,13 @@ jobs:
   nat_validation:
     name: NAT Validation
     needs: fmt_check
-    runs-on: ubicloud-standard-16
+    runs-on: "${{ (github.event_name == 'merge_group' && startsWith(github.event.merge_group.head_commit.message, 'build: release')) && 'ubuntu-latest' || 'ubicloud-standard-16' }}"
     timeout-minutes: 30
     # Skip on:
     # - push to main: PR already validated code before merge
     # - release PRs: only bump versions
     # - dependabot PRs: just version bumps, Test job is sufficient
-    # Note: merge_group MUST run — required status checks apply to merge queue entries
+    # For release merge_group entries: run on cheap runner and skip expensive steps
     if: |
       (github.event_name == 'pull_request' || github.event_name == 'merge_group') &&
       !startsWith(github.head_ref, 'release/v') &&
@@ -293,27 +325,44 @@ jobs:
       RUST_MIN_STACK: 268435456
 
     steps:
+      - name: Detect release merge queue
+        id: release_check
+        run: |
+          if [[ "${{ github.event_name }}" == "merge_group" && "${{ github.event.merge_group.head_commit.message }}" == build:\ release* ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping tests — release PRs only bump versions (main CI already validated)"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v6
+        if: steps.release_check.outputs.is_release != 'true'
 
       - name: Install dependencies
+        if: steps.release_check.outputs.is_release != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y mold liblzma-dev
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.release_check.outputs.is_release != 'true'
         with:
           toolchain: 1.93.0
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.release_check.outputs.is_release != 'true'
 
       - name: Pull Docker images for NAT simulation
+        if: steps.release_check.outputs.is_release != 'true'
         run: docker pull alpine:latest
 
       - name: Install nextest
+        if: steps.release_check.outputs.is_release != 'true'
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Build
+        if: steps.release_check.outputs.is_release != 'true'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
@@ -323,6 +372,7 @@ jobs:
           make -C apps/freenet-ping -f run-ping.mk build
 
       - name: Run Docker NAT test
+        if: steps.release_check.outputs.is_release != 'true'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,6 +12,19 @@ if ! PROJECT_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)
     exit 1
 fi
 
+# Save original branch so we can restore it on exit (avoids leaving user on release branch)
+ORIGINAL_BRANCH="$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || echo "")"
+restore_branch() {
+    local current
+    current="$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || echo "")"
+    if [[ -n "$ORIGINAL_BRANCH" && "$current" != "$ORIGINAL_BRANCH" ]]; then
+        echo ""
+        echo "Restoring original branch ($ORIGINAL_BRANCH)..."
+        git -C "$PROJECT_ROOT" checkout "$ORIGINAL_BRANCH" 2>/dev/null || true
+    fi
+}
+trap restore_branch EXIT
+
 # Parse arguments
 VERSION=""
 MIN_COMPATIBLE=""
@@ -488,35 +501,47 @@ check_prerequisites() {
     # Check if main branch CI is green (required before skipping tests on release PR)
     # Note: GitHub Actions uses Check Runs API, not the legacy Status API
     if [[ "$DRY_RUN" == "false" ]]; then
-        echo -n "  Checking main branch CI status... "
-        local check_runs_json
-        check_runs_json=$(gh api repos/freenet/freenet-core/commits/main/check-runs 2>/dev/null || echo "{}")
+        local ci_max_wait=600  # 10 minutes max wait for pending CI
+        local ci_elapsed=0
+        local ci_interval=30
 
-        local total_checks in_progress_count failed_count
-        total_checks=$(echo "$check_runs_json" | jq '.total_count // 0')
-        in_progress_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status != "completed" and (.name | startswith("Build for") | not) and .name != "claude")] | length')
-        failed_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .name != "Dependabot" and (.name | startswith("Build for") | not) and .name != "claude")] | length')
+        while true; do
+            echo -n "  Checking main branch CI status... "
+            local check_runs_json
+            check_runs_json=$(gh api repos/freenet/freenet-core/commits/main/check-runs 2>/dev/null || echo "{}")
 
-        if [[ "$total_checks" == "0" ]]; then
-            echo "⚠️  (no checks found)"
-            echo "  ⚠️  Could not find any CI checks for main branch"
-            echo "     Proceeding anyway - verify CI manually if needed"
-        elif [[ "$in_progress_count" -gt 0 ]]; then
-            echo "⚠️  (pending: $in_progress_count checks running)"
-            echo "  ⚠️  Main branch CI is still running"
-            echo "     Release PRs skip slow tests, so main must be green first"
-            echo "     Wait for CI to complete or run with tests enabled"
-            exit 1
-        elif [[ "$failed_count" -gt 0 ]]; then
-            echo "✗ ($failed_count checks failed)"
-            local failed_names
-            failed_names=$(echo "$check_runs_json" | jq -r '[.check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped")] | .[].name' | head -5)
-            echo "  ✗ Main branch CI is failing - cannot release"
-            echo "     Failed checks: $failed_names"
-            exit 1
-        else
-            echo "✓ (green - $total_checks checks passed)"
-        fi
+            local total_checks in_progress_count failed_count
+            total_checks=$(echo "$check_runs_json" | jq '.total_count // 0')
+            in_progress_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status != "completed" and (.name | startswith("Build for") | not) and .name != "claude")] | length')
+            failed_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .name != "Dependabot" and (.name | startswith("Build for") | not) and .name != "claude")] | length')
+
+            if [[ "$total_checks" == "0" ]]; then
+                echo "⚠️  (no checks found)"
+                echo "  ⚠️  Could not find any CI checks for main branch"
+                echo "     Proceeding anyway - verify CI manually if needed"
+                break
+            elif [[ "$in_progress_count" -gt 0 ]]; then
+                if [[ $ci_elapsed -ge $ci_max_wait ]]; then
+                    echo "⚠️  (still pending after ${ci_max_wait}s)"
+                    echo "  ⚠️  Main branch CI is still running after ${ci_max_wait}s"
+                    echo "     Release PRs skip slow tests, so main must be green first"
+                    exit 1
+                fi
+                echo "⏳ ($in_progress_count checks running, waiting... ${ci_elapsed}s/${ci_max_wait}s)"
+                sleep $ci_interval
+                ci_elapsed=$((ci_elapsed + ci_interval))
+            elif [[ "$failed_count" -gt 0 ]]; then
+                echo "✗ ($failed_count checks failed)"
+                local failed_names
+                failed_names=$(echo "$check_runs_json" | jq -r '[.check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped")] | .[].name' | head -5)
+                echo "  ✗ Main branch CI is failing - cannot release"
+                echo "     Failed checks: $failed_names"
+                exit 1
+            else
+                echo "✓ (green - $total_checks checks passed)"
+                break
+            fi
+        done
     fi
 
     # Check required tools


### PR DESCRIPTION
## Problem

Release PRs (version bump only) were triggering full CI in the merge queue (~6 min for Unit & Integration, Simulation, NAT Validation), even though:
1. Main branch CI already validated the code before the release
2. Release PRs only change version numbers in `Cargo.toml`

The existing skip condition `!startsWith(github.head_ref, 'release/v')` didn't work for `merge_group` events because GitHub sets `head_ref` to a queue branch (`gh-readonly-queue/main/pr-XXXX-...`), not the original PR branch.

Additionally, the release script had two UX issues:
- Exited immediately when main CI was still pending, requiring manual re-runs
- Left the user on the `release/v*` branch if interrupted or on failure

## Approach

**CI (`.github/workflows/ci.yml`):**
- Detect release merge queue entries via commit message pattern (`build: release*`) using `github.event.merge_group.head_commit.message`
- Since required status checks can't be skipped (would block the merge), the jobs still run but on `ubuntu-latest` (cheap runner) and skip all expensive steps via `is_release` output
- This satisfies required checks while reducing merge queue time from ~6 min to ~30 sec

**Release script (`scripts/release.sh`):**
- Add `EXIT` trap to restore the original git branch on any exit
- Replace immediate exit on pending main CI with polling loop (30s intervals, 10 min max)

## Testing

- Validated YAML parses correctly with Python yaml.safe_load
- Validated release script syntax with `bash -n`
- Verified merge queue commit message format matches `build: release*` by checking actual GitHub API data for past release runs

Fixes the bottlenecks identified in the v0.1.170 release post-mortem.

[AI-assisted - Claude]