### PR TITLE
fix: relay peers serve hosted contracts immediately on GET

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -1089,18 +1089,33 @@ impl Operation for GetOp {
                         };
 
                         // Relay peers in ReceivedRequest: prefer fresh network state,
-                        // local cache is fallback only. Store local value and forward.
+                        // local cache is fallback only. EXCEPTION: if this node is
+                        // hosting the contract, serve immediately — we're an
+                        // authoritative source and deferring wastes the full
+                        // OPERATION_TTL routing toward peers that may not have
+                        // the contract, causing ~94% GET failure rate (#3356).
                         let local_value = if self.upstream_addr.is_some()
                             && matches!(self.state, Some(GetState::ReceivedRequest))
                         {
                             if let Some(lv) = local_value {
-                                tracing::debug!(
-                                    tx = %id,
-                                    "Relay peer deferring local cache, forwarding GET for fresh state"
-                                );
-                                local_fallback = Some(lv);
+                                if op_manager.ring.is_hosting_contract(&lv.0) {
+                                    tracing::debug!(
+                                        tx = %id,
+                                        contract = %lv.0,
+                                        "Relay peer hosting contract, serving immediately"
+                                    );
+                                    Some(lv)
+                                } else {
+                                    tracing::debug!(
+                                        tx = %id,
+                                        "Relay peer deferring local cache, forwarding GET for fresh state"
+                                    );
+                                    local_fallback = Some(lv);
+                                    None
+                                }
+                            } else {
+                                None
                             }
-                            None
                         } else {
                             local_value
                         };


### PR DESCRIPTION
## Problem

When a relay peer receives a forwarded GET request and has the contract locally, the "network first" strategy unconditionally defers the local copy and forwards toward the contract's ring location. For contracts that exist only on hosting nodes far from their ring location — like the River container contract (location 0.050, gateway at 0.924) — this wastes the full 60s OPERATION_TTL routing toward peers that don't have the contract, causing ~94% GET failure rates (#3356).

**User impact**: New River users cannot load the app because the container contract GET fails. Only users whose peers happen to already have the contract cached can use River.

## Solution

When a relay peer is **hosting** the contract (i.e., it's an authoritative source tracked in the hosting cache), serve it immediately instead of deferring to network routing. Non-hosted cached contracts retain the existing "network first, local fallback" strategy for freshness.

The key insight: hosting peers are authoritative sources — there's no "fresher" copy to find on the network. Deferring only wastes time routing toward the contract's ring location where no peers have the contract.

**Change**: `get.rs:1091-1121` — added `is_hosting_contract()` check before deferring local cache.

## Testing

- `cargo fmt` — clean
- `cargo clippy --all-targets` — clean  
- `cargo test -p freenet` — all tests pass

This is a targeted behavioral change in the GET relay path. The fix only affects the code path where:
1. A relay peer receives a forwarded GET (has `upstream_addr`)
2. The peer has the contract locally
3. The peer is hosting the contract (`is_hosting_contract` returns true)

Non-hosting relay peers are unaffected.

## Related

- Fixes the GET failure component of #3356
- Related: #3445 (subscribe timeout telemetry gap)
- Related: #3446 (subscribe lacks retry/breadth)

[AI-assisted - Claude]