### PR TITLE
fix: remove distracting NAT verdict badges from local peer dashboard

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -304,21 +304,19 @@ fn build_status_card(snap: &Option<network_status::NetworkStatusSnapshot>) -> St
             String::new()
         };
 
-        // Rolling trend: recent window stats and verdict badge
+        // Rolling trend: recent window stats; only show verdict when truly blocked
         let (recent, verdict) = if snap.nat_stats.recent_attempts > 0 {
             let rs = snap.nat_stats.recent_successes;
             let ra = snap.nat_stats.recent_attempts;
-            let recent_rate = rs as f64 / ra as f64;
-            let (verdict_text, verdict_class) = if recent_rate > 0.5 {
-                ("Port appears open", "nat-verdict-good")
-            } else if rs == 0 {
-                ("Port may be blocked", "nat-verdict-bad")
+            let verdict = if rs == 0 && snap.nat_stats.successes == 0 {
+                r#" <span class="nat-verdict nat-verdict-bad">Port may be blocked</span>"#
+                    .to_string()
             } else {
-                ("Intermittent", "nat-verdict-warn")
+                String::new()
             };
             (
                 format!(r#" <span class="nat-recent">({rs}/{ra} recent)</span>"#),
-                format!(r#"<span class="nat-verdict {verdict_class}">{verdict_text}</span>"#),
+                verdict,
             )
         } else {
             (String::new(), String::new())


### PR DESCRIPTION
## Problem

The local peer dashboard shows colored verdict badges ("Port appears open", "Intermittent", "Port may be blocked") based on the recent NAT success window. This causes false alarms on healthy nodes — e.g., a node with 9 ring peers and 49/357 overall NAT successes shows a red "Port may be blocked" badge just because the most recent 20 attempts had 0 successes. The badges are distracting and unnecessarily alarming.

## Approach

Remove the "Port appears open" and "Intermittent" badges entirely — the raw stats (e.g., `49/357 successful (0/20 recent)`) already convey this information without colored noise. Only show the "Port may be blocked" badge when there are zero successes both recently AND overall, indicating the port is genuinely unreachable.

## Testing

Visual change only — verified clippy passes. The existing NAT stats rendering logic and CSS remain intact.

[AI-assisted - Claude]