### PR TITLE
fix: transient connection display and lifecycle issues

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2592,6 +2592,42 @@ impl P2pConnManager {
             return Ok(());
         }
 
+        // Check if this peer is in backoff due to previous connection failures.
+        // This check is done AFTER the existing connection check above, so that:
+        // 1. If we already have a connection (possibly from inbound), we reuse it
+        // 2. Backoff only blocks NEW outbound connection attempts
+        // NOTE: Backoff must run BEFORE the early admission check because
+        // should_accept() has a side effect (inserts pending_reservation on
+        // acceptance). If backoff rejects after should_accept passes, the
+        // reservation leaks until TTL.
+        if !peer_addr.ip().is_unspecified() && state.peer_backoff.is_in_backoff(peer_addr) {
+            let remaining = state
+                .peer_backoff
+                .remaining_backoff(peer_addr)
+                .unwrap_or(Duration::ZERO);
+            tracing::debug!(
+                tx = %tx,
+                peer = %peer,
+                peer_addr = %peer_addr,
+                remaining_secs = remaining.as_secs(),
+                transient,
+                phase = "connect",
+                "Skipping connection attempt - peer in backoff"
+            );
+            callback
+                .send_result(Err(()))
+                .await
+                .inspect_err(|error| {
+                    tracing::debug!(
+                        remote = %peer_addr,
+                        ?error,
+                        "Failed to notify caller about backoff-delayed connection"
+                    );
+                })
+                .ok();
+            return Ok(());
+        }
+
         // Early admission check: avoid expensive NAT hole-punching for connections
         // that would be rejected by should_accept() after establishment. Only applies
         // to non-transient (ring-bound) connections — transient gateway connections
@@ -2622,38 +2658,6 @@ impl P2pConnManager {
                     .ok();
                 return Ok(());
             }
-        }
-
-        // Check if this peer is in backoff due to previous connection failures.
-        // This check is done AFTER the existing connection check above, so that:
-        // 1. If we already have a connection (possibly from inbound), we reuse it
-        // 2. Backoff only blocks NEW outbound connection attempts
-        if !peer_addr.ip().is_unspecified() && state.peer_backoff.is_in_backoff(peer_addr) {
-            let remaining = state
-                .peer_backoff
-                .remaining_backoff(peer_addr)
-                .unwrap_or(Duration::ZERO);
-            tracing::debug!(
-                tx = %tx,
-                peer = %peer,
-                peer_addr = %peer_addr,
-                remaining_secs = remaining.as_secs(),
-                transient,
-                phase = "connect",
-                "Skipping connection attempt - peer in backoff"
-            );
-            callback
-                .send_result(Err(()))
-                .await
-                .inspect_err(|error| {
-                    tracing::debug!(
-                        remote = %peer_addr,
-                        ?error,
-                        "Failed to notify caller about backoff-delayed connection"
-                    );
-                })
-                .ok();
-            return Ok(());
         }
 
         match state.awaiting_connection.entry(peer_addr) {

--- a/crates/core/src/node/network_status.rs
+++ b/crates/core/src/node/network_status.rs
@@ -933,6 +933,28 @@ mod tests {
     }
 
     #[test]
+    fn test_record_peer_connected_updates_location() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 9999);
+        init(31339, HashSet::new(), "0.1.148".to_string());
+
+        // First call with no location (as handle_successful_connection does initially)
+        record_peer_connected(peer_addr, None, None);
+        let snap = get_snapshot().unwrap();
+        let peer = snap.peers.iter().find(|p| p.address == peer_addr).unwrap();
+        assert_eq!(peer.location, None);
+
+        // Second call with location (as connect_peer promotion path now does)
+        record_peer_connected(peer_addr, Some(0.42), None);
+        let snap = get_snapshot().unwrap();
+        let peer = snap.peers.iter().find(|p| p.address == peer_addr).unwrap();
+        assert_eq!(peer.location, Some(0.42));
+
+        // Cleanup
+        record_peer_disconnected(peer_addr);
+    }
+
+    #[test]
     fn test_nat_stats_rolling_window_all_failures() {
         let mut nat = NatStats::default();
         for _ in 0..25 {


### PR DESCRIPTION
## Problem

Users report peers with no location ("—") on the peer dashboard even after their node is well-established. On technic.locut.us, 6 of 15 connections showed no location. Investigation revealed three distinct issues:

1. **Dashboard display bug**: Peers promoted to ring via `connect_peer`'s "reusing existing transport" path show "—" because `network_status` is never updated with their location. The initial `record_peer_connected(addr, None, None)` from transport establishment is the only record.

2. **Wasted NAT traversal**: When a CONNECT acceptor initiates hole-punching, the expensive NAT traversal completes successfully, only for `handle_successful_connection` to reject the connection via `should_accept()`. This wastes bandwidth and creates zombie transports.

3. **Zombie transport limbo**: After admission rejection, `handle_successful_connection` returns `Ok(())` without dropping the transport. The connection lingers for up to 5 minutes (zombie cleanup threshold) as a locationless entry on the dashboard.

## Approach

**Fix 1** — Add `record_peer_connected(peer_addr, Some(loc), Some(pkl))` to the `connect_peer` promotion path (after `ring.add_connection()`), matching what `handle_successful_connection` already does.

**Fix 2** — Add an early `should_accept()` check in `handle_connect_peer` before initiating the handshake for non-transient connections. This avoids the expensive NAT hole-punching when the connection would be rejected anyway. The check is skipped for transient (gateway) connections since those don't go through admission.

**Fix 3** — In `handle_successful_connection`, when admission logic or capacity cap rejects a connection, actively call `drop_connection_by_addr()` and `record_peer_disconnected()` instead of returning silently. This eliminates the 5-minute zombie window.

## Testing

- `cargo fmt` — clean
- `cargo clippy --all-targets` — no warnings
- `cargo test -p freenet` — 1836 passed, 1 failed (pre-existing `test_deadlock_is_detected` which requires `--test-threads=1`), 10 ignored

The changes are in connection lifecycle code paths that are exercised by the existing integration and simulation tests. The fixes are straightforward additions (recording state, early rejection, immediate cleanup) that don't change the happy-path behavior.

Validated by log analysis on technic.locut.us:
- `98.183.148.44:49269` — confirmed in ring (loc 0.396) but dashboard showed "—" → Fix 1
- `74.140.146.45:52317` — confirmed admission-rejected, lingered 5 min as zombie → Fix 2 + 3
- `212.112.135.6:53608`, `146.60.153.153:56448` — confirmed zombie-cleaned after 5 min → Fix 2 + 3

[AI-assisted - Claude]