### PR TITLE
fix: remove Host header filter that blocks local hostname access

### DIFF
--- a/crates/core/src/server/mod.rs
+++ b/crates/core/src/server/mod.rs
@@ -386,18 +386,15 @@ async fn serve_client_api_in_impl(
     let (ws_proxy, ws_router) =
         WebSocketProxy::create_router_with_attested_contracts(gw_router, attested_contracts);
 
-    // When bound to a non-loopback address, add two security layers:
-    // 1. Reject connections from non-private source IPs
-    // 2. Reject requests with Host headers that don't match our bind address
-    //    (mitigates DNS rebinding attacks)
-    let needs_lan_filters = !config.address.is_loopback();
-    let router = if needs_lan_filters {
-        let allowed_hosts = build_allowed_hosts(config.address, config.port);
+    // When bound to a non-loopback address, reject connections from non-private
+    // source IPs. This is sufficient security: only LAN clients can connect.
+    // We intentionally do NOT filter on Host headers because users access their
+    // nodes via local hostnames, mDNS names, and Docker container names that
+    // we cannot enumerate.
+    let needs_lan_filter = !config.address.is_loopback();
+    let router = if needs_lan_filter {
         ws_router
             .layer(axum::middleware::from_fn(private_network_filter))
-            .layer(axum::middleware::from_fn(move |req, next| {
-                host_header_filter(req, next, allowed_hosts.clone())
-            }))
             .layer(TraceLayer::new_for_http())
     } else {
         ws_router.layer(TraceLayer::new_for_http())
@@ -405,69 +402,6 @@ async fn serve_client_api_in_impl(
 
     serve_with_listener(ws_socket, router, pre_bound).await?;
     Ok((gw, ws_proxy))
-}
-
-/// Build the set of Host header values we accept.
-///
-/// When bound to 0.0.0.0 we accept any private IP as host (since the client
-/// may connect via any local interface). When bound to a specific IP we only
-/// accept that IP. Localhost variants are always accepted.
-fn build_allowed_hosts(bind_addr: IpAddr, port: u16) -> Vec<String> {
-    let mut hosts = vec![
-        format!("localhost:{port}"),
-        format!("127.0.0.1:{port}"),
-        format!("[::1]:{port}"),
-    ];
-    if bind_addr.is_unspecified() {
-        // Accept any host that resolves to a private IP — the private_network_filter
-        // middleware already ensures the source IP is private, and the Host header
-        // will be the IP the client used to connect. We can't enumerate all local
-        // IPs portably, so we validate the Host is a private IP at request time.
-    } else {
-        hosts.push(format!("{bind_addr}:{port}"));
-    }
-    hosts
-}
-
-/// Middleware that rejects requests whose Host header doesn't match our bind address.
-/// This mitigates DNS rebinding attacks where a malicious page resolves to our LAN IP.
-async fn host_header_filter(
-    req: axum::http::Request<axum::body::Body>,
-    next: axum::middleware::Next,
-    static_hosts: Vec<String>,
-) -> axum::response::Response {
-    let host = req
-        .headers()
-        .get(axum::http::header::HOST)
-        .and_then(|h| h.to_str().ok())
-        .unwrap_or("");
-
-    // Check against static allowed hosts (localhost, specific bind IP)
-    if static_hosts.iter().any(|h| h.eq_ignore_ascii_case(host)) {
-        return next.run(req).await;
-    }
-
-    // For 0.0.0.0 bindings: accept if the Host header is a private IP
-    if let Some(colon_pos) = host.rfind(':') {
-        let host_ip = &host[..colon_pos];
-        // Strip brackets for IPv6
-        let host_ip = host_ip.trim_start_matches('[').trim_end_matches(']');
-        if let Ok(ip) = host_ip.parse::<IpAddr>() {
-            if is_private_ip(&ip) && !ip.is_unspecified() {
-                return next.run(req).await;
-            }
-        }
-    }
-
-    tracing::warn!(
-        host = host,
-        "Rejected request with non-matching Host header (possible DNS rebinding)"
-    );
-    (
-        axum::http::StatusCode::FORBIDDEN,
-        "Request host does not match server address",
-    )
-        .into_response()
 }
 
 /// Middleware that rejects requests from non-private IP addresses.
@@ -616,70 +550,5 @@ mod tests {
         assert!(!is_private_ip(&IpAddr::V6(Ipv6Addr::new(
             0x2607, 0xf8b0, 0, 0, 0, 0, 0, 1
         ))));
-    }
-
-    #[test]
-    fn test_build_allowed_hosts_specific_ip() {
-        let hosts = build_allowed_hosts(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)), 7509);
-        assert!(hosts.contains(&"localhost:7509".to_string()));
-        assert!(hosts.contains(&"127.0.0.1:7509".to_string()));
-        assert!(hosts.contains(&"[::1]:7509".to_string()));
-        assert!(hosts.contains(&"192.168.1.2:7509".to_string()));
-    }
-
-    #[test]
-    fn test_build_allowed_hosts_unspecified() {
-        // When bound to 0.0.0.0, we don't add a specific IP — the host_header_filter
-        // dynamically validates that the Host is a private IP.
-        let hosts = build_allowed_hosts(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 7509);
-        assert!(hosts.contains(&"localhost:7509".to_string()));
-        assert_eq!(hosts.len(), 3); // localhost, 127.0.0.1, [::1]
-    }
-
-    #[test]
-    fn test_host_header_filter_logic() {
-        // Test the Host header parsing logic used by host_header_filter.
-        // We test the parsing inline since the middleware requires an async runtime.
-
-        let check_host = |host: &str| -> bool {
-            let static_hosts = [
-                "localhost:7509".to_string(),
-                "127.0.0.1:7509".to_string(),
-                "[::1]:7509".to_string(),
-            ];
-
-            // Static match
-            if static_hosts.iter().any(|h| h.eq_ignore_ascii_case(host)) {
-                return true;
-            }
-
-            // Dynamic private-IP match
-            if let Some(colon_pos) = host.rfind(':') {
-                let host_ip = &host[..colon_pos];
-                let host_ip = host_ip.trim_start_matches('[').trim_end_matches(']');
-                if let Ok(ip) = host_ip.parse::<IpAddr>() {
-                    if is_private_ip(&ip) && !ip.is_unspecified() {
-                        return true;
-                    }
-                }
-            }
-
-            false
-        };
-
-        // Allowed
-        assert!(check_host("localhost:7509"));
-        assert!(check_host("127.0.0.1:7509"));
-        assert!(check_host("[::1]:7509"));
-        assert!(check_host("192.168.1.2:7509"));
-        assert!(check_host("10.0.0.5:7509"));
-        assert!(check_host("[fd00::1]:7509"));
-        assert!(check_host("[fe80::1]:7509"));
-
-        // Rejected (DNS rebinding, public IPs)
-        assert!(!check_host("evil.com:7509"));
-        assert!(!check_host("8.8.8.8:7509"));
-        assert!(!check_host("[2001:db8::1]:7509"));
-        assert!(!check_host("localhost.evil.com:7509"));
     }
 }


### PR DESCRIPTION
## Problem

PR #3459 added a `host_header_filter` middleware that validates the HTTP `Host` header when the WS API binds to a non-loopback address. The filter only accepts:
- `localhost`
- Loopback/private IP literals (e.g. `192.168.1.2`)

This **breaks access via local hostnames** — when a user accesses their node at `http://myserver.local:7509` or via a Docker container name, the `Host` header contains the hostname. The filter tries to parse it as an IP address, fails, and returns **403 Forbidden**.

Reported by user IvvorI on Matrix: *"the new Freenet release means I can't access my node remotely via a local hostname anymore, I have to use direct IP now."*

This also affects Docker deployments where containers are accessed by name.

## Approach

Remove the `host_header_filter` middleware entirely. The `private_network_filter` middleware (which checks the **source IP** of the TCP connection) already ensures only LAN clients can connect — this is the real security boundary.

The Host header filter provided marginal DNS rebinding protection, but:
1. It breaks legitimate, common LAN access patterns (hostnames, mDNS, Docker names)
2. Browsers are increasingly handling DNS rebinding natively via the [Private Network Access](https://wicg.github.io/private-network-access/) spec
3. The source-IP filter already prevents non-LAN access regardless of Host header

Also removes `build_allowed_hosts()` and associated tests that are now dead code.

## Testing

- `cargo fmt` ✓
- `cargo clippy --all-targets` ✓  
- `server::tests::test_is_private_ip_v4` and `test_is_private_ip_v6` pass ✓
- No simulation tests needed — this is a pure code removal in the HTTP middleware layer, not routing/topology/operations

[AI-assisted - Claude]