### PR TITLE
fix: add slot names to combinator for better dead-slot diagnostics

### DIFF
--- a/crates/core/src/client_events/combinator.rs
+++ b/crates/core/src/client_events/combinator.rs
@@ -42,6 +42,8 @@ pub struct ClientEventsCombinator<const N: usize> {
     internal_clients: HashMap<ClientId, (usize, ClientId)>,
     /// tracks which client slots have disconnected so we don't re-poll dead channels
     dead_clients: [bool; N],
+    /// human-readable names for each slot (e.g., "http", "websocket") for diagnostics
+    slot_names: Vec<&'static str>,
 }
 
 impl<const N: usize> ClientEventsCombinator<N> {
@@ -80,7 +82,15 @@ impl<const N: usize> ClientEventsCombinator<N> {
             internal_clients: HashMap::new(),
             pending_futs,
             dead_clients: [false; N],
+            slot_names: vec!["unknown"; N],
         }
+    }
+
+    /// Set human-readable names for each slot for diagnostic logging.
+    pub fn with_slot_names(mut self, names: &[&'static str]) -> Self {
+        assert_eq!(names.len(), N, "slot names length must match client count");
+        self.slot_names = names.to_vec();
+        self
     }
 }
 
@@ -146,10 +156,7 @@ impl<const N: usize> super::ClientEventsProxy for ClientEventsCombinator<N> {
                     None => {
                         // Channel closed — client_fn exited. Mark slot as dead and clean up
                         // mappings. Do NOT re-push into pending_futs (avoids infinite spin).
-                        tracing::warn!(
-                            proxy_idx = idx,
-                            "Client transport disconnected, cleaning up client slot"
-                        );
+                        let slot_name = self.slot_names[idx];
                         self.dead_clients[idx] = true;
 
                         // Remove internal→external mappings for this slot
@@ -163,6 +170,16 @@ impl<const N: usize> super::ClientEventsProxy for ClientEventsCombinator<N> {
                             self.internal_clients.remove(id);
                         }
                         self.external_clients[idx].clear();
+
+                        // Log at error level so operators notice degraded state.
+                        // If this is the WebSocket slot, the node can't accept new
+                        // client connections — a restart is recommended (#3479).
+                        tracing::error!(
+                            slot_name,
+                            proxy_idx = idx,
+                            "Client API '{slot_name}' died — node is in degraded state, \
+                             restart recommended"
+                        );
 
                         // Loop back to poll remaining live clients
                         continue;
@@ -805,5 +822,41 @@ mod test {
             result.is_ok(),
             "proxy should still be alive after multiple transient errors"
         );
+    }
+
+    /// Test that with_slot_names works and dead slots still allow live ones to continue.
+    #[tokio::test]
+    async fn test_slot_names_and_dead_slot_continues() {
+        let (proxies, mut senders, _receivers) = setup_proxies();
+        let mut combinator =
+            ClientEventsCombinator::new(proxies).with_slot_names(&["http", "websocket", "extra"]);
+
+        for (idx, sender) in senders.iter_mut().enumerate() {
+            sender.send(idx).await.unwrap();
+            combinator.recv().await.unwrap();
+        }
+
+        // Kill slot 1 ("websocket")
+        drop(senders.remove(1));
+
+        // Send data from a live proxy
+        senders[0].send(0).await.unwrap();
+
+        // Should eventually get a successful request from a live proxy
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                match combinator.recv().await {
+                    Ok(req) => return Ok(req),
+                    Err(e) if matches!(e.kind(), ErrorKind::ChannelClosed) => continue,
+                    Err(e) if matches!(e.kind(), ErrorKind::TransportProtocolDisconnect) => {
+                        continue
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        })
+        .await
+        .expect("recv timed out — combinator should continue with live slots");
+        assert!(result.is_ok(), "dead slot should not kill combinator");
     }
 }

--- a/crates/core/src/node/p2p_impl.rs
+++ b/crates/core/src/node/p2p_impl.rs
@@ -398,7 +398,8 @@ impl NodeP2P {
             Err(e) => anyhow::anyhow!(e),
         })
         .boxed();
-        let clients = ClientEventsCombinator::new(clients);
+        // Slot 0 = HTTP client API, Slot 1 = WebSocket proxy (from serve_client_api).
+        let clients = ClientEventsCombinator::new(clients).with_slot_names(&["http", "websocket"]);
         // Create node controller channel with capacity for shutdown signal
         // We clone the sender to return it for external shutdown triggering
         let (node_controller_tx, node_controller_rx) = tokio::sync::mpsc::channel(1);


### PR DESCRIPTION
## Problem

When a client_fn slot in the `ClientEventsCombinator` dies, the only signal was a `warn!`-level log with a numeric `proxy_idx`. This made it hard to diagnose the zombie state from #3479 — operators had to know that "proxy_idx=1" means "WebSocket API is dead" and the node needs a restart.

## Approach

- Added `slot_names` field to `ClientEventsCombinator` with a `with_slot_names()` builder method
- Changed dead-slot logging from `warn!` to `error!` with the human-readable slot name
- Production construction in `p2p_impl.rs` labels slots as `["http", "websocket"]`
- Log now reads: `Client API 'websocket' died — node is in degraded state, restart recommended`

This is defense-in-depth for #3479. The primary fix (PR #3480) already prevents `client_fn` from dying on transient errors, so this should rarely fire. But when it does, the message is clear and actionable.

## Testing

- Added `test_slot_names_and_dead_slot_continues`: verifies slot names work and a dead slot doesn't kill the combinator
- All 10 existing combinator tests pass unchanged

Closes #3479

[AI-assisted - Claude]