### PR TITLE
fix: prevent 404 during release by using draft releases

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -345,3 +345,11 @@ jobs:
           gh release upload "$TAG_NAME" $ASSETS \
             --repo ${{ github.repository }} \
             --clobber
+
+          # Publish the release now that binaries are attached.
+          # The release is created as a draft by release.sh/release.yml to
+          # prevent the installer from seeing a version before binaries exist.
+          gh release edit "$TAG_NAME" \
+            --repo ${{ github.repository }} \
+            --draft=false
+          echo "✅ Release $TAG_NAME published with all binaries attached"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,8 +304,9 @@ jobs:
           VERSION="${{ needs.validate.outputs.version }}"
           gh release create "v$VERSION" \
             --title "v$VERSION" \
-            --notes-file "${{ steps.release_notes.outputs.notes_file }}"
-          echo "✅ Created GitHub release v$VERSION"
+            --notes-file "${{ steps.release_notes.outputs.notes_file }}" \
+            --draft
+          echo "✅ Created draft GitHub release v$VERSION (will be published after binaries are attached)"
 
       - name: Dry run summary
         if: ${{ inputs.dry_run }}


### PR DESCRIPTION
## Problem

Users running `install.sh` during a release get a 404 error because the GitHub release is visible (via `/releases/latest` API) before the cross-compile workflow has finished uploading binaries. This was reported by Xonticus during the v0.1.177 release — there was a ~14 minute window between release creation and binary upload.

**Root cause:** The release agent was creating GitHub releases without `--draft`, despite `release.sh` using `--draft` correctly. The cross-compile workflow had no step to publish a draft after uploading binaries.

## Approach

Two-layer fix:

1. **`cross-compile.yml`** (critical): After uploading binaries, publish the draft release with `gh release edit --draft=false`. This is the safety net that ensures releases only become visible after binaries exist, regardless of how the release was created.

2. **`release.yml`** (defense in depth): Add `--draft` to `gh release create` in case this workflow is ever used again.

3. **Release skill** (already pushed to freenet-agent-skills): Added explicit instructions that `release.sh` MUST be run as a single command, not decomposed into manual steps by the agent.

## Testing

- Verified v0.1.175, v0.1.176, v0.1.177 all had `published_at` ~5s after `created_at` (confirming non-draft creation)
- Verified `release.sh` already has correct `--draft` + `publish_draft_release` flow
- The `gh release edit --draft=false` is idempotent (no-op if already published)

Closes #3483

[AI-assisted - Claude]