### PR TITLE
refactor: use fixed-size array for combinator slot_names

### DIFF
--- a/crates/core/src/client_events/combinator.rs
+++ b/crates/core/src/client_events/combinator.rs
@@ -43,7 +43,7 @@ pub struct ClientEventsCombinator<const N: usize> {
     /// tracks which client slots have disconnected so we don't re-poll dead channels
     dead_clients: [bool; N],
     /// human-readable names for each slot (e.g., "http", "websocket") for diagnostics
-    slot_names: Vec<&'static str>,
+    slot_names: [&'static str; N],
 }
 
 impl<const N: usize> ClientEventsCombinator<N> {
@@ -82,14 +82,18 @@ impl<const N: usize> ClientEventsCombinator<N> {
             internal_clients: HashMap::new(),
             pending_futs,
             dead_clients: [false; N],
-            slot_names: vec!["unknown"; N],
+            slot_names: ["unknown"; N],
         }
     }
 
     /// Set human-readable names for each slot for diagnostic logging.
+    ///
+    /// Panics if `names.len() != N` (programmer error).
     pub fn with_slot_names(mut self, names: &[&'static str]) -> Self {
         assert_eq!(names.len(), N, "slot names length must match client count");
-        self.slot_names = names.to_vec();
+        for (i, name) in names.iter().enumerate() {
+            self.slot_names[i] = name;
+        }
         self
     }
 }

--- a/crates/core/src/topology.rs
+++ b/crates/core/src/topology.rs
@@ -2022,7 +2022,9 @@ mod tests {
                     "Should not prune topology-critical peer (isolated at long distance)"
                 );
             }
-            other => {
+            other @ TopologyAdjustment::AddConnections(_)
+            | other @ TopologyAdjustment::SwapConnection { .. }
+            | other @ TopologyAdjustment::NoChange => {
                 panic!("Expected RemoveConnections under resource pressure, got {other:?}");
             }
         }


### PR DESCRIPTION
## Problem

`ClientEventsCombinator<N>` stores `slot_names` as `Vec<&'static str>` despite having a compile-time constant `N`. This is inconsistent with the other N-sized fields (`clients`, `external_clients`, `dead_clients`) which all use `[T; N]`, and causes an unnecessary heap allocation.

Raised in https://github.com/freenet/freenet-core/pull/3481#issuecomment-4022146401.

## Solution

Change the field from `Vec<&'static str>` to `[&'static str; N]`. The `with_slot_names()` method keeps its `&[&'static str]` parameter (with a runtime `assert_eq!` on length) because the call site in `p2p_impl.rs` uses a separate const generic `CLIENTS` that the compiler can't unify with `N`.

Also fixes a pre-existing `clippy::wildcard_enum_match_arm` warning in `topology.rs`.

## Testing

All 10 combinator unit tests pass.