### PR TITLE
fix: make ping integration tests robust instead of timeout-dependent

### DIFF
--- a/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
+++ b/apps/freenet-ping/app/tests/run_app_blocked_peers.rs
@@ -17,13 +17,11 @@ use std::{
 
 use anyhow::anyhow;
 use common::{
-    base_node_test_config_with_ip, get_all_ping_states, gw_config_from_path_with_ip,
-    test_node_config, wait_for_node_connected, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
+    allocate_test_node_block, base_node_test_config_with_ip, connect_ws_with_retry,
+    get_all_ping_states, gw_config_from_path_with_ip, test_ip_for_node, test_node_config,
+    wait_for_node_connected, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
 };
-use freenet::{
-    server::serve_client_api,
-    test_utils::{allocate_test_node_block, test_ip_for_node},
-};
+use freenet::server::serve_client_api;
 use freenet_ping_app::ping_client::{
     wait_for_get_response, wait_for_put_response, wait_for_subscribe_response,
 };
@@ -35,8 +33,6 @@ use freenet_stdlib::{
 use futures::FutureExt;
 use tokio::{select, time::sleep};
 use tracing::{span, Instrument, Level};
-
-use common::{connect_async_with_config, ws_config};
 
 /// Maximum number of retries when port allocation fails
 const MAX_PORT_RETRY_ATTEMPTS: usize = 5;
@@ -94,9 +90,11 @@ async fn run_blocked_peers_test(attempt: usize) -> anyhow::Result<()> {
     let network_socket_gw = TcpListener::bind(SocketAddr::new(gw_ip.into(), 0))?;
     let gw_network_port = network_socket_gw.local_addr()?.port();
 
-    let ws_api_port_socket_gw = TcpListener::bind("127.0.0.1:0")?;
-    let ws_api_port_socket_node1 = TcpListener::bind("127.0.0.1:0")?;
-    let ws_api_port_socket_node2 = TcpListener::bind("127.0.0.1:0")?;
+    // Bind WS ports on unique node IPs (not 127.0.0.1) to avoid port collisions
+    // with parallel tests and match the IP that serve_client_api will bind to
+    let ws_api_port_socket_gw = TcpListener::bind(SocketAddr::new(gw_ip.into(), 0))?;
+    let ws_api_port_socket_node1 = TcpListener::bind(SocketAddr::new(node1_ip.into(), 0))?;
+    let ws_api_port_socket_node2 = TcpListener::bind(SocketAddr::new(node2_ip.into(), 0))?;
 
     let network_socket_node1 = TcpListener::bind(SocketAddr::new(node1_ip.into(), 0))?;
     let node1_network_port = network_socket_node1.local_addr()?.port();
@@ -210,10 +208,7 @@ async fn run_blocked_peers_test(attempt: usize) -> anyhow::Result<()> {
     let span = span!(Level::INFO, "test_ping_blocked_peers");
 
     let test = tokio::time::timeout(Duration::from_secs(420), async {
-        tracing::info!("Waiting 25s for nodes to start up...");
-        sleep(Duration::from_secs(25)).await;
-
-        // Connect WebSocket clients
+        // Connect to nodes with retry (replaces blind 25s sleep + raw connect)
         let uri_gw =
             format!("ws://{gw_ip}:{ws_api_port_gw}/v1/contract/command?encodingProtocol=native");
         let uri_node1 = format!(
@@ -223,19 +218,9 @@ async fn run_blocked_peers_test(attempt: usize) -> anyhow::Result<()> {
             "ws://{node2_ip}:{ws_api_port_node2}/v1/contract/command?encodingProtocol=native"
         );
 
-        tracing::info!("Connecting to Gateway at {}", uri_gw);
-        let (stream_gw, _) = connect_async_with_config(&uri_gw, Some(ws_config()), false).await?;
-        let mut client_gw = WebApi::start(stream_gw);
-
-        tracing::info!("Connecting to Node1 at {}", uri_node1);
-        let (stream_node1, _) =
-            connect_async_with_config(&uri_node1, Some(ws_config()), false).await?;
-        let mut client_node1 = WebApi::start(stream_node1);
-
-        tracing::info!("Connecting to Node2 at {}", uri_node2);
-        let (stream_node2, _) =
-            connect_async_with_config(&uri_node2, Some(ws_config()), false).await?;
-        let mut client_node2 = WebApi::start(stream_node2);
+        let mut client_gw = connect_ws_with_retry(&uri_gw, "Gateway", 60).await?;
+        let mut client_node1 = connect_ws_with_retry(&uri_node1, "Node1", 60).await?;
+        let mut client_node2 = connect_ws_with_retry(&uri_node2, "Node2", 60).await?;
 
         // Wait for ring connections (180s for slow CI runners)
         tracing::info!("Waiting for nodes to join the ring...");
@@ -344,7 +329,7 @@ async fn run_blocked_peers_test(attempt: usize) -> anyhow::Result<()> {
         // fails (subscribe.rs:705-716 - peer_key lookup can return None if the
         // peer isn't fully registered yet).
         let poll_interval = Duration::from_secs(5);
-        let max_polls: u32 = 48; // 240s total (accommodates OPERATION_TTL=120s)
+        let max_polls: u32 = 48; // 240s total (accommodates OPERATION_TTL=60s with retries)
 
         for poll in 1..=max_polls {
             // Send an update from each node

--- a/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
+++ b/apps/freenet-ping/app/tests/run_app_partially_connected_network.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use anyhow::anyhow;
-use freenet::{server::serve_client_api, test_utils::test_ip_for_node};
+use freenet::server::serve_client_api;
 use freenet_ping_app::ping_client::wait_for_put_response;
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
@@ -33,8 +33,9 @@ use tokio::{select, time::timeout};
 use tracing::{span, Instrument, Level};
 
 use common::{
-    base_node_test_config_with_ip, connect_ws_with_retry, gw_config_from_path_with_ip,
-    test_node_config, wait_for_node_connected, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
+    allocate_test_node_block, base_node_test_config_with_ip, connect_ws_with_retry,
+    gw_config_from_path_with_ip, test_ip_for_node, test_node_config, wait_for_node_connected,
+    APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
 };
 
 /// Test for subscription propagation in a partially connected network.
@@ -67,12 +68,13 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
         NUM_GATEWAYS, NUM_REGULAR_NODES, CONNECTIVITY_RATIO
     );
 
-    // Use varied loopback IPs for unique ring locations
-    // This is essential because ring locations are derived from IP addresses.
-    // Gateways use indices 0..NUM_GATEWAYS, nodes use NUM_GATEWAYS..NUM_GATEWAYS+NUM_REGULAR_NODES
-    let gateway_ips: Vec<_> = (0..NUM_GATEWAYS).map(test_ip_for_node).collect();
+    // Use globally unique loopback IPs to avoid collisions with parallel tests
+    let base_idx = allocate_test_node_block(NUM_GATEWAYS + NUM_REGULAR_NODES);
+    let gateway_ips: Vec<_> = (0..NUM_GATEWAYS)
+        .map(|i| test_ip_for_node(base_idx + i))
+        .collect();
     let node_ips: Vec<_> = (0..NUM_REGULAR_NODES)
-        .map(|i| test_ip_for_node(NUM_GATEWAYS + i))
+        .map(|i| test_ip_for_node(base_idx + NUM_GATEWAYS + i))
         .collect();
 
     // Reserve network ports for gateways on their varied IPs
@@ -85,8 +87,8 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
         let port = network_socket.local_addr()?.port();
         gateway_network_ports.push(port);
         gateway_network_sockets.push(network_socket);
-        // WebSocket always uses localhost
-        ws_api_gateway_sockets.push(TcpListener::bind("127.0.0.1:0")?);
+        // Bind WS on node IP to avoid port collisions with parallel tests
+        ws_api_gateway_sockets.push(TcpListener::bind(SocketAddr::new(ip.into(), 0))?);
         println!("Gateway {} will use {}:{}", i, ip, port);
     }
 
@@ -104,8 +106,8 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
         node_network_ports.push(port);
         node_network_addrs.push(addr);
         node_network_sockets.push(network_socket);
-        // WebSocket always uses localhost
-        ws_api_node_sockets.push(TcpListener::bind("127.0.0.1:0")?);
+        // Bind WS on node IP to avoid port collisions with parallel tests
+        ws_api_node_sockets.push(TcpListener::bind(SocketAddr::new(ip.into(), 0))?);
         println!("Node {} will use {} ({})", i, addr, ip);
     }
 
@@ -261,12 +263,9 @@ async fn test_ping_partially_connected_network() -> anyhow::Result<()> {
         regular_node_futures.push(regular_node_future);
     }
 
-    // 420s: 20s gateway startup + 5s port binding + 180s node connection + operations + buffer
+    // 420s: 20s gateway startup + 180s node connection + operations + buffer
     let test = tokio::time::timeout(Duration::from_secs(420), async {
-        // Small initial wait for nodes to start binding ports
-        tokio::time::sleep(Duration::from_secs(5)).await;
-
-        // Connect to all nodes with retry logic
+        // Connect to all nodes with retry logic (handles waiting for WS servers)
         // Use the correct IPs for each node (WebSocket servers bind to node IPs, not 127.0.0.1)
         let mut gateway_clients = Vec::with_capacity(NUM_GATEWAYS);
         for (i, port) in ws_api_ports_gw.iter().enumerate() {

--- a/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
+++ b/apps/freenet-ping/app/tests/test_small_network_get_issue.rs
@@ -6,10 +6,10 @@ use std::{
     time::Duration,
 };
 
-use freenet::{server::serve_client_api, test_utils::test_ip_for_node};
+use freenet::server::serve_client_api;
 use freenet_ping_types::{Ping, PingContractOptions};
 use freenet_stdlib::{
-    client_api::{ClientRequest, ContractRequest, ContractResponse, HostResponse, WebApi},
+    client_api::{ClientRequest, ContractRequest, ContractResponse, HostResponse},
     prelude::*,
 };
 use futures::FutureExt;
@@ -17,8 +17,9 @@ use tokio::{select, time::timeout};
 use tracing::{span, Instrument, Level};
 
 use common::{
-    base_node_test_config_with_ip, connect_async_with_config, gw_config_from_path_with_ip,
-    test_node_config, wait_for_node_connected, ws_config, APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
+    allocate_test_node_block, base_node_test_config_with_ip, connect_ws_with_retry,
+    gw_config_from_path_with_ip, test_ip_for_node, test_node_config, wait_for_node_connected,
+    APP_TAG, PACKAGE_DIR, PATH_TO_CONTRACT,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
@@ -32,10 +33,11 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
         NUM_GATEWAYS + NUM_NODES
     );
 
-    // Use unique IPs for each node
-    let gw_ip = test_ip_for_node(0);
-    let node1_ip = test_ip_for_node(1);
-    let node2_ip = test_ip_for_node(2);
+    // Use globally unique IPs to avoid collisions with parallel tests
+    let base_node_idx = allocate_test_node_block(3);
+    let gw_ip = test_ip_for_node(base_node_idx);
+    let node1_ip = test_ip_for_node(base_node_idx + 1);
+    let node2_ip = test_ip_for_node(base_node_idx + 2);
 
     let network_socket_gw = TcpListener::bind(SocketAddr::new(gw_ip.into(), 0))?;
     let ws_api_port_socket_gw = TcpListener::bind(SocketAddr::new(gw_ip.into(), 0))?;
@@ -136,27 +138,19 @@ async fn test_small_network_get_failure() -> anyhow::Result<()> {
     .boxed_local();
 
     let test = timeout(Duration::from_secs(300), async {
-        // Wait for nodes to start their WebSocket servers
-        tokio::time::sleep(Duration::from_secs(10)).await;
-
+        // Connect to nodes with retry (replaces blind sleep + raw connect)
         let uri_gw =
             format!("ws://{gw_ip}:{ws_api_port_gw}/v1/contract/command?encodingProtocol=native");
-        let (stream_gw, _) = connect_async_with_config(&uri_gw, Some(ws_config()), false).await?;
-        let mut client_gw = WebApi::start(stream_gw);
-
         let uri_node1 = format!(
             "ws://{node1_ip}:{ws_api_port_node1}/v1/contract/command?encodingProtocol=native"
         );
-        let (stream_node1, _) =
-            connect_async_with_config(&uri_node1, Some(ws_config()), false).await?;
-        let mut client_node1 = WebApi::start(stream_node1);
-
         let uri_node2 = format!(
             "ws://{node2_ip}:{ws_api_port_node2}/v1/contract/command?encodingProtocol=native"
         );
-        let (stream_node2, _) =
-            connect_async_with_config(&uri_node2, Some(ws_config()), false).await?;
-        let mut client_node2 = WebApi::start(stream_node2);
+
+        let mut client_gw = connect_ws_with_retry(&uri_gw, "Gateway", 60).await?;
+        let mut client_node1 = connect_ws_with_retry(&uri_node1, "Node1", 60).await?;
+        let mut client_node2 = connect_ws_with_retry(&uri_node2, "Node2", 60).await?;
 
         // Verify nodes have joined the ring before starting operations
         println!("Waiting for nodes to join the ring...");


### PR DESCRIPTION
## Problem

Ping integration tests (`test_small_network_get_failure`, `test_ping_blocked_peers`, `test_ping_partially_connected_network`) fail intermittently on CI with operation timeouts due to:

1. **Hardcoded IP indices** in `test_small_network_get_failure` and `partially_connected_network` — causes address collisions when tests run in parallel
2. **Blind 10-25s sleeps** before WS connections — too short on slow CI, wasted time on fast machines
3. **WS ports bound on shared `127.0.0.1`** — port collisions between parallel tests
4. **Stale comment** claiming OPERATION_TTL=120s when actual value is 60s

## Approach

- Replace hardcoded `test_ip_for_node(0/1/2)` with `allocate_test_node_block()` for globally unique IPs
- Replace `sleep(N) + raw WS connect` with `connect_ws_with_retry()` which polls until the WS server is ready (already existed in common utils but wasn't used consistently)
- Bind WS ports on per-node unique IPs instead of shared `127.0.0.1:0`
- Fix stale OPERATION_TTL comment

**Note:** This addresses fixes #1 and #2 from #3490. Fixes #3 (client-side operation retry) and #4 (shared WASM compilation fixture) are deferred for follow-up.

## Testing

- `cargo clippy -p freenet-ping-app --tests` — clean
- These are test-infrastructure changes; the tests themselves validate the fix by no longer having the flaky patterns

Partially addresses #3490

[AI-assisted - Claude]