### PR TITLE
fix: use Kleinberg-optimal gap_target for bootstrap connections

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -2179,49 +2179,93 @@ pub(crate) async fn join_ring_request(
     }
 
     let own = op_manager.ring.connection_manager.own_location();
-    // Use the joiner's own location as the desired_location for the connect request.
-    //
-    // History: PR #2907 fixed a critical issue where using `gateway.location()` caused
-    // 99.7% of join requests to converge on a single acceptor. That PR intended to use
-    // the joiner's own location but implemented `Location::random()` instead, which
-    // broke simulation determinism for certain seeds (issues #3028, #3030).
-    //
-    // Using `own.location()` is correct because:
-    // - Each joiner has a unique location → requests spread across gateway neighbors
-    // - The gateway routes toward the joiner's ring neighborhood → better initial placement
-    // - Deterministic in simulation tests (same seed → same location → same topology)
-    // - Falls back to random only if own address is unknown (NAT before ObservedAddress)
     let base_location = own.location().unwrap_or_else(Location::random);
 
     // Capture now once so the jitter failure counter and any other time-sensitive
     // calls in this function share a consistent timestamp.
     let now = Instant::now();
 
-    // Apply location jitter on retry to explore different ring regions.
+    let current_connections = op_manager.ring.connection_manager.connection_count();
+
+    // Helper: apply jitter to base_location for NAT-compatible acceptor exploration.
     // After consecutive hole-punch failures, the same location routes to the same
-    // acceptors. Jittering the target location causes routing to converge on
-    // different ring peers, increasing the chance of finding a NAT-compatible acceptor.
-    let failures = op_manager
-        .ring
-        .connection_manager
-        .increment_connect_jitter_failures(now);
-    let desired_location = if failures > 1 {
-        // Jitter magnitude: 0.05 * 2^(failures-2), capped at 0.25
-        let magnitude = (0.05 * (1u32 << (failures - 2).min(3)) as f64).min(0.25);
-        // Generate uniform random offset in [-magnitude, +magnitude]
-        let uniform_01 = (GlobalRng::random_u64() as f64) / (u64::MAX as f64);
-        let offset = magnitude * (2.0 * uniform_01 - 1.0);
-        let jittered = (base_location.as_f64() + offset).rem_euclid(1.0);
-        tracing::info!(
-            failures,
-            magnitude,
-            base = %base_location,
-            jittered,
-            "connect: applying location jitter after consecutive failures"
-        );
-        Location::new(jittered)
+    // acceptors. Jittering explores different ring regions.
+    let apply_bootstrap_jitter = |base: Location| -> Location {
+        let failures = op_manager
+            .ring
+            .connection_manager
+            .increment_connect_jitter_failures(now);
+        if failures > 1 {
+            // Jitter magnitude: 0.05 * 2^(failures-2), capped at 0.25
+            let magnitude = (0.05 * (1u32 << (failures - 2).min(3)) as f64).min(0.25);
+            let uniform_01 = (GlobalRng::random_u64() as f64) / (u64::MAX as f64);
+            let offset = magnitude * (2.0 * uniform_01 - 1.0);
+            let jittered = (base.as_f64() + offset).rem_euclid(1.0);
+            tracing::info!(
+                failures,
+                magnitude,
+                base = %base,
+                jittered,
+                "connect: applying location jitter after consecutive failures"
+            );
+            Location::new(jittered)
+        } else {
+            base
+        }
+    };
+
+    // Choose desired_location based on whether we have enough connections for
+    // gap-based targeting (Kleinberg-optimal) or need bootstrap targeting.
+    //
+    // With connections: use gap_target to find the largest gap in our connection
+    // distribution in log-distance space and target its midpoint. This produces
+    // Kleinberg-optimal 1/d-distributed connections.
+    //
+    // Without connections (true bootstrap): target own location with jitter.
+    // Own-location targeting spreads requests across gateway neighbors (each
+    // joiner has a unique location). Jitter after failures explores different
+    // ring regions to find NAT-compatible acceptors.
+    // Minimum connections needed for meaningful gap analysis. Independent of
+    // min_connections because this is about statistical sample size for the 1/d
+    // distribution, not connection targets. 3 points are sufficient to identify
+    // the largest gap in log-distance space.
+    const GAP_TARGET_THRESHOLD: usize = 3;
+    let desired_location = if current_connections >= GAP_TARGET_THRESHOLD {
+        // Use gap_target: find the largest gap in our current connections
+        // and target its midpoint for Kleinberg-optimal placement.
+        if let Some(my_loc) = own.location() {
+            let neighbor_distances: Vec<f64> = op_manager
+                .ring
+                .connection_manager
+                .location_for_all_peers()
+                .into_iter()
+                .map(|peer_loc| my_loc.distance(peer_loc).as_f64())
+                .collect();
+            if neighbor_distances.len() >= GAP_TARGET_THRESHOLD {
+                let target = crate::topology::small_world_rand::gap_target(
+                    my_loc,
+                    neighbor_distances.into_iter(),
+                );
+                tracing::info!(
+                    current_connections,
+                    own_location = %my_loc,
+                    target = %target,
+                    distance = my_loc.distance(target).as_f64(),
+                    "connect: using gap_target for Kleinberg-optimal placement"
+                );
+                target
+            } else {
+                // Fewer unique neighbor locations than connections (e.g. sybil
+                // masking collapses peers to same ring location). Fall back to
+                // jitter-based exploration to avoid retrying the same acceptors.
+                apply_bootstrap_jitter(base_location)
+            }
+        } else {
+            apply_bootstrap_jitter(base_location)
+        }
     } else {
-        base_location
+        // Bootstrap mode: target own location with jitter after failures.
+        apply_bootstrap_jitter(base_location)
     };
     let ttl = op_manager
         .ring
@@ -4387,6 +4431,71 @@ mod tests {
         assert!(
             !visited.probably_visited(unconnected_peer),
             "unconnected peer should not be in the visited filter"
+        );
+    }
+
+    /// Verify that gap_target produces shorter connections than own-location+jitter.
+    ///
+    /// This is a regression test for the bootstrap topology bug: before the fix,
+    /// join_ring_request always targeted the joiner's own location with up to ±0.25
+    /// jitter, producing median connection distance ~0.12 instead of the Kleinberg-
+    /// optimal ~0.02. Now, with ≥3 existing connections, gap_target is used instead.
+    #[test]
+    fn test_gap_target_produces_shorter_connections_than_jitter() {
+        use crate::topology::small_world_rand::gap_target;
+
+        let _guard = GlobalRng::seed_guard(42);
+
+        let my_location = Location::new(0.5);
+
+        // Simulate a peer with 5 existing connections at various distances
+        let existing_connections = vec![
+            Location::new(0.501), // very close
+            Location::new(0.51),  // close
+            Location::new(0.55),  // nearby
+            Location::new(0.7),   // medium
+            Location::new(0.9),   // far
+        ];
+
+        let distances: Vec<f64> = existing_connections
+            .iter()
+            .map(|loc| my_location.distance(*loc).as_f64())
+            .collect();
+
+        // Generate 100 gap_target samples and 100 jitter samples
+        let mut gap_target_distances = Vec::new();
+        let mut jitter_distances = Vec::new();
+
+        for _ in 0..100 {
+            let target = gap_target(my_location, distances.iter().copied());
+            gap_target_distances.push(my_location.distance(target).as_f64());
+
+            // Simulate jitter with failures=3 (magnitude=0.10)
+            let magnitude = 0.10;
+            let uniform_01 = (GlobalRng::random_u64() as f64) / (u64::MAX as f64);
+            let offset = magnitude * (2.0 * uniform_01 - 1.0);
+            let jittered = (my_location.as_f64() + offset).rem_euclid(1.0);
+            jitter_distances.push(my_location.distance(Location::new(jittered)).as_f64());
+        }
+
+        gap_target_distances.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        jitter_distances.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        let gap_median = gap_target_distances[50];
+        let jitter_median = jitter_distances[50];
+
+        // gap_target should produce significantly shorter median distances
+        // because it targets gaps in the 1/d distribution (Kleinberg-optimal),
+        // while jitter produces roughly uniform distances around the peer.
+        assert!(
+            gap_median < jitter_median,
+            "gap_target median ({gap_median:.4}) should be shorter than jitter median ({jitter_median:.4})"
+        );
+
+        // gap_target median should be well under 0.05 (typically ~0.001-0.01)
+        assert!(
+            gap_median < 0.05,
+            "gap_target median ({gap_median:.4}) should be < 0.05 (Kleinberg-optimal produces short connections)"
         );
     }
 }

--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -731,6 +731,15 @@ impl ConnectionManager {
         }
     }
 
+    /// Returns all ring-connected peer locations.
+    pub fn location_for_all_peers(&self) -> Vec<Location> {
+        self.connections_by_location
+            .read()
+            .keys()
+            .copied()
+            .collect()
+    }
+
     /// Returns our own socket address if set.
     pub fn get_own_addr(&self) -> Option<SocketAddr> {
         *self.own_addr.lock()


### PR DESCRIPTION
## Problem

Telemetry analysis revealed that 93% of all connect requests in the Freenet network come through `join_ring_request()` which targets the joiner's **own location** with up to ±0.25 random jitter. This produces a median connection distance of ~0.12, far from the Kleinberg-optimal median of ~0.02-0.03.

The topology manager's gap_target algorithm — which correctly produces Kleinberg 1/d-distributed connections — was only responsible for 3% of connect requests. It was being drowned out because `initial_join_procedure` runs in a permanent loop and calls `join_ring_request` whenever connections dip below `min_connections` (10), which happens frequently due to normal churn.

The result: peers form connections that are uniformly distributed rather than following the optimal 1/d distribution, degrading greedy routing performance from O(log²N) hops to significantly worse.

## Approach

When a peer already has ≥3 ring connections, `join_ring_request` now uses `gap_target()` to find the largest gap in the peer's connection distribution in log-distance space and targets its midpoint. This produces Kleinberg-optimal short connections.

The own-location+jitter behavior is preserved only for true bootstrap (0-2 connections) where there aren't enough existing connections to do meaningful gap analysis.

Key insight: the gap_target algorithm was already correct and well-tested — it just wasn't being used by the dominant connection path. This fix routes ~93% of connection requests through gap_target instead of ~3%.

### Changes

- `connect.rs:join_ring_request()` — Added `GAP_TARGET_THRESHOLD = 3`. When `connection_count >= 3`, uses `gap_target()` with current neighbor distances instead of own-location+jitter.
- `connection_manager.rs` — Added `location_for_all_peers()` to expose ring peer locations for gap analysis.

## Testing

- **Unit test**: `test_gap_target_produces_shorter_connections_than_jitter` — Verifies that gap_target produces significantly shorter median connection distances than the jitter approach (asserts gap_target median < jitter median AND < 0.05).
- All 1,893 existing tests pass (1 pre-existing flaky `deadlock_detection` test occasionally fails under parallel execution, unrelated).
- `cargo fmt` and `cargo clippy` clean.

## Evidence

Telemetry classification of 259,662 `connect_request_sent` events:

| Path | % of requests | Median distance |
|------|--------------|-----------------|
| join_ring_request (own location, d<0.001) | 3.7% | ~0.001 |
| join_ring_request (with jitter, d<0.26) | 93.3% | ~0.12 |
| acquire_new (gap_target, d>0.26) | 3.0% | ~0.002 |

Expected impact: Connection distance distribution should shift from P50≈0.12 to P50≈0.02-0.03.

[AI-assisted - Claude]