### PR TITLE
feat: scroll to invitation box on quickstart page from dashboard

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -76,7 +76,7 @@ fn homepage_html() -> String {
             <ul class="app-list">
                 <li>
                     <a href="/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/">River Chat</a>
-                    <p class="note">You'll need an <a href="https://freenet.org/quickstart/" target="_blank" rel="noopener noreferrer">invite</a> to join the "Freenet Official" room.</p>
+                    <p class="note">You'll need an <a href="https://freenet.org/quickstart#invite-form" target="_blank" rel="noopener noreferrer">invite</a> to join the "Freenet Official" room.</p>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary

Fixes #3473

When users click the invite link from the dashboard, they are now directed to the `#invite-form` section of the quickstart page, so they don't have to manually scroll to find the invitation box.

### Changes

- Updated the quickstart URL to include the `#invite-form` anchor fragment

---

> **Transparency note**: This PR was authored with AI assistance (Claude). The change is trivial but addresses a UX improvement.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>