### PR TITLE
fix: add img-src data: to shell page CSP for favicon support

### DIFF
--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -216,7 +216,7 @@ async fn web_home(
     response.headers_mut().insert(
         axum::http::header::CONTENT_SECURITY_POLICY,
         axum::http::HeaderValue::from_static(
-            "default-src 'none'; script-src 'unsafe-inline'; frame-src 'self'; style-src 'unsafe-inline'; connect-src ws: wss:",
+            "default-src 'none'; script-src 'unsafe-inline'; frame-src 'self'; style-src 'unsafe-inline'; img-src data:; connect-src ws: wss:",
         ),
     );
     // Shell page must not be framed itself


### PR DESCRIPTION
## Problem

The gateway shell page includes a data URI favicon (`<link rel="icon" type="image/svg+xml" href="data:...">`) but its CSP policy has `default-src 'none'` without an `img-src` directive. Browsers fall back to `default-src` for image resources, blocking the favicon:

```
Loading the image 'data:image/svg+xml,...' violates the Content Security Policy
directive: "default-src 'none'". Note that 'img-src' was not explicitly set,
so 'default-src' is used as a fallback.
```

Reported by a community member in [river#157](https://github.com/freenet/river/issues/157) and Matrix.

## Approach

Add `img-src data:` to the shell page CSP. This allows data URI images (the SVG favicon) without permitting external image requests — maintaining the security posture of `default-src 'none'` for everything else.

The sandbox CSP (for iframe content) already allows `data:` URIs and is unaffected.

## Testing

- `cargo check -p freenet` passes
- One-line CSP string change — the only behavioral difference is that data URI images are now allowed on the shell page

[AI-assisted - Claude]