### PR TITLE
fix: cap subscribe retries per GC tick to prevent notification channel flood

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1641,10 +1641,10 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                 // Cap retries per GC tick to avoid flooding the notification channel.
                 // The gateway subscribes to 90+ contracts; retrying all at once saturates
                 // the 2048-capacity event loop channel, blocking UPDATEs and broadcasts.
-                // Value of 5: low enough to leave most channel capacity for normal ops
-                // (UPDATEs, broadcasts, etc.), high enough to cycle through 90+ contracts
-                // within a few minutes at the 5-second GC interval.
-                const MAX_SUBSCRIBE_RETRIES_PER_TICK: usize = 5;
+                // Value of 10: at 5s GC interval, processes 120 retries/minute — enough
+                // to cycle through 90+ contracts within OPERATION_TTL (60s). Low enough
+                // to leave most channel capacity for normal ops (UPDATEs, broadcasts).
+                const MAX_SUBSCRIBE_RETRIES_PER_TICK: usize = 10;
                 {
                     // Clean up entries for completed operations
                     subscribe_retried.retain(|tx, _| ops.subscribe.contains_key(tx));


### PR DESCRIPTION
## Problem

The subscribe retry feature introduced in v0.1.182 (#3525) can saturate the event loop notification channel when many subscriptions need retrying simultaneously. The nova gateway subscribes to 90+ contracts, and when retries for all of them trigger in the same GC tick, the burst fills the 2048-capacity notification channel. Once full, UPDATEs and broadcasts time out with "notification channel send timed out — event loop is likely stuck."

**Evidence from production logs (v0.1.182):**
- Hour 04 (first hour after release): 0 channel-full errors
- Hour 05 (retries ramped up): 620 channel-full errors, starting 90 seconds after subscribe retries began
- Pre-release hours 01-03: 0 channel-full errors

## Approach

Cap subscribe retries to 10 per GC tick (`MAX_SUBSCRIBE_RETRIES_PER_TICK = 10`). At the 5-second GC interval, this processes 120 retries/minute — enough to cycle through 90+ contracts well within OPERATION_TTL (60s). When capping, candidates are shuffled via `GlobalRng::shuffle` to prevent DashMap iteration order from starving some subscriptions.

Candidates not processed in the current tick remain eligible and will be retried in subsequent ticks.

## Testing

- All 1959 unit tests pass
- CI will run full simulation suite
- Production verification: deploy and monitor that channel-full errors stop while subscribe retries still make progress

[AI-assisted - Claude]