### PR TITLE
fix: scale admission selectivity with connection deficit during bootstrap

### DIFF
--- a/crates/core/src/ring/connection_manager.rs
+++ b/crates/core/src/ring/connection_manager.rs
@@ -574,17 +574,36 @@ impl ConnectionManager {
             // stalling bootstrap when many peers try to connect.
             //
             // Below KLEINBERG_FILTER_MIN_CONNECTIONS we always accept (too few
-            // connections for a meaningful gap score). Above that, higher gap
-            // scores get higher acceptance probability, with a 50% floor so
-            // bootstrap is never blocked.
+            // connections for a meaningful gap score). Above that, selectivity
+            // scales with how close we are to min_connections:
+            //   - At KLEINBERG_FILTER_MIN_CONNECTIONS: floor ~0.9 (accept almost all)
+            //   - Approaching min_connections: floor ~0.3 (be selective)
+            // This prevents bootstrap stalls when NAT traversal is unreliable
+            // while still shaping topology as the node fills up.
             let accepted = if open < KLEINBERG_FILTER_MIN_CONNECTIONS {
                 true
             } else if let Some(me) = self.get_stored_location() {
                 let score = self.compute_kleinberg_score(me, location);
-                // score ranges from 0.0 (next to existing connection) to ~0.5
-                // (centered in empty range). Normalize to [0, 1] and apply
-                // a 50% floor: accept_prob = 0.5 + score (clamped to 1.0).
-                let accept_prob = (0.5 + score).min(1.0);
+                // Compute a sliding floor based on how far we are from min_connections.
+                // progress=0.0 at KLEINBERG_FILTER_MIN_CONNECTIONS, 1.0 at min_connections.
+                let range = self.min_connections - KLEINBERG_FILTER_MIN_CONNECTIONS;
+                let progress = if range > 0 {
+                    (open - KLEINBERG_FILTER_MIN_CONNECTIONS) as f64 / range as f64
+                } else {
+                    1.0
+                };
+                // Floor slides from 0.9 (desperate for connections) to 0.3 (nearly full).
+                let floor = 0.9 - 0.6 * progress;
+                let accept_prob = (floor + score).min(1.0);
+                tracing::debug!(
+                    open,
+                    min = self.min_connections,
+                    %progress,
+                    %floor,
+                    %score,
+                    %accept_prob,
+                    "should_accept: sliding Kleinberg floor"
+                );
                 GlobalRng::random_range(0.0..1.0) < accept_prob
             } else {
                 true


### PR DESCRIPTION
## Problem

Nodes with only 3 ring connections (vs `min_connections=10`) were randomly rejecting ~50% of successfully NAT-traversed peers. The Kleinberg admission filter had a flat 50% acceptance floor that kicked in at just 3 connections, meaning half of hard-won connections were discarded even though the node desperately needed more.

Multiple users reported being stuck at 2-3 connections for 20+ minutes on v0.1.183:
- Ivvor (diagnostic report USE86A): 3 ring connections, promotion rejected by admission logic despite successful NAT traversal
- fluffomat: "startup was quick with 10 peers. So it looks like there is something going over time..."
- Puro: "I've only got four peers, and one of them is the gateway"
- Framework test peer: RING_TRANSPORT_DESYNC for extended periods, 4 promotion rejections

## Approach

Replace the fixed 50% acceptance floor with a sliding floor that scales based on how far the node is from `min_connections`:

| Connections | Floor | Behavior |
|---|---|---|
| 0-2 | 100% (always accept) | Unchanged |
| 3 (KLEINBERG_FILTER_MIN_CONNECTIONS) | ~90% | Accept almost everything — survival mode |
| Midway to min_connections | ~60% | Gradually shape topology |
| Near min_connections | ~30% | Be selective for good distribution |
| >= min_connections | ConnectionEvaluator | Unchanged (strict best-in-window) |

The formula: `floor = 0.9 - 0.6 * progress` where `progress` is `(open - 3) / (min_connections - 3)`.

This preserves small-world distribution shaping as the node fills up while preventing bootstrap stalls when NAT traversal is unreliable.

## Testing

- Unit tests pass (`cargo test -p freenet --lib -- connection_manager`)
- `cargo fmt` + `cargo clippy` clean
- Logic change is in a single function (`should_accept`) with existing test coverage

[AI-assisted - Claude]