### PR TITLE
fix: decrement downstream_subscriber_count on TTL expiry and peer disconnect

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1188,19 +1188,15 @@ impl OpManager {
     ///
     /// Proximity cache is cleared immediately. Interest removal is deferred for
     /// `INTEREST_DISCONNECT_GRACE_PERIOD` to survive transient disconnects.
-    /// Downstream subscriber entries are removed immediately (they have their
-    /// own lease-based TTL, so no grace period is needed).
+    /// Downstream subscriber entries in the hosting manager are NOT removed here —
+    /// they have lease-based TTL and will be cleaned up by the periodic
+    /// `expire_stale_downstream_subscribers` sweep, which also decrements the
+    /// interest manager's `downstream_subscriber_count` and triggers upstream
+    /// unsubscribe when appropriate.
     pub(crate) fn on_ring_connection_lost(&self, pub_key: &TransportPublicKey) {
-        let peer_key = PeerKey::from(pub_key.clone());
         self.neighbor_hosting.on_peer_disconnected(pub_key);
-        self.interest_manager.schedule_deferred_removal(&peer_key);
-
-        // Remove this peer from hosting manager's downstream subscribers
-        // and decrement the interest manager's downstream_subscriber_count.
-        let affected = self.ring.remove_peer_from_all_downstream(&peer_key);
-        for (contract, _) in &affected {
-            self.interest_manager.remove_downstream_subscriber(contract);
-        }
+        self.interest_manager
+            .schedule_deferred_removal(&PeerKey::from(pub_key.clone()));
     }
 }
 

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -1569,10 +1569,6 @@ impl Ring {
         self.hosting_manager.expire_stale_downstream_subscribers()
     }
 
-    pub fn remove_peer_from_all_downstream(&self, peer: &PeerKey) -> Vec<(ContractKey, bool)> {
-        self.hosting_manager.remove_peer_from_all_downstream(peer)
-    }
-
     pub fn should_unsubscribe_upstream(&self, contract: &ContractKey) -> bool {
         self.hosting_manager.should_unsubscribe_upstream(contract)
     }

--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -539,34 +539,6 @@ impl HostingManager {
         expired_counts
     }
 
-    /// Remove a specific peer from all downstream subscriber entries.
-    /// Returns affected contracts paired with whether the contract lost ALL downstream subscribers.
-    pub fn remove_peer_from_all_downstream(&self, peer: &PeerKey) -> Vec<(ContractKey, bool)> {
-        let mut affected = Vec::new();
-
-        let keys: Vec<ContractKey> = self
-            .downstream_subscribers
-            .iter()
-            .map(|entry| *entry.key())
-            .collect();
-
-        for key in keys {
-            if let Some(mut peers) = self.downstream_subscribers.get_mut(&key) {
-                if peers.remove(peer).is_some() {
-                    let now_empty = peers.is_empty();
-                    if now_empty {
-                        drop(peers);
-                        self.downstream_subscribers
-                            .remove_if(&key, |_, peers| peers.is_empty());
-                    }
-                    affected.push((key, now_empty));
-                }
-            }
-        }
-
-        affected
-    }
-
     /// Check if a contract has no local clients and no downstream subscribers,
     /// meaning we can safely unsubscribe upstream.
     pub fn should_unsubscribe_upstream(&self, contract: &ContractKey) -> bool {
@@ -2278,36 +2250,5 @@ mod tests {
             !interest.has_local_interest(&contract),
             "downstream_subscriber_count should be 0 after syncing with TTL expiry"
         );
-    }
-
-    /// Regression test: remove_peer_from_all_downstream must remove a specific
-    /// peer from all contracts and return affected contracts.
-    #[test]
-    fn test_remove_peer_from_all_downstream() {
-        let manager = HostingManager::new();
-        let contract_a = make_contract_key(92);
-        let contract_b = make_contract_key(93);
-        let peer = make_peer_key(92);
-        let other_peer = make_peer_key(93);
-
-        // peer subscribes to both contracts
-        manager.add_downstream_subscriber(&contract_a, peer.clone());
-        manager.add_downstream_subscriber(&contract_b, peer.clone());
-        // other_peer subscribes to contract_b only
-        manager.add_downstream_subscriber(&contract_b, other_peer.clone());
-
-        let affected = manager.remove_peer_from_all_downstream(&peer);
-        assert_eq!(affected.len(), 2, "Peer was downstream for 2 contracts");
-
-        // contract_a had only peer -> now_empty = true
-        let a_entry = affected.iter().find(|(c, _)| *c == contract_a).unwrap();
-        assert!(a_entry.1, "contract_a should have no remaining downstream");
-
-        // contract_b had peer + other_peer -> now_empty = false
-        let b_entry = affected.iter().find(|(c, _)| *c == contract_b).unwrap();
-        assert!(!b_entry.1, "contract_b should still have other_peer");
-
-        assert!(!manager.has_downstream_subscribers(&contract_a));
-        assert!(manager.has_downstream_subscribers(&contract_b));
     }
 }


### PR DESCRIPTION
## Problem

The `downstream_subscriber_count` in `InterestManager.local_interests` was never decremented when downstream subscribers expired via TTL, causing the counter to grow monotonically. This meant `has_local_interest()` stayed true indefinitely for contracts whose downstream subscribers had all expired, wasting resources by maintaining stale interest state.

### TTL expiry path
`expire_stale_downstream_subscribers()` removed stale leases from `HostingManager.downstream_subscribers` but never called `InterestManager::remove_downstream_subscriber()`.

### Peer disconnect path
When a peer disconnects, their downstream subscriber entries in the hosting manager have lease-based TTL and will expire naturally via the periodic sweep. The TTL expiry path now correctly decrements the interest manager, so this case is handled automatically.

## Approach

Changed `expire_stale_downstream_subscribers()` to return `Vec<(ContractKey, usize)>` (contract + expired peer count) instead of `Vec<ContractKey>`. The caller in `ring.rs` now decrements the interest manager for each expired peer and triggers upstream unsubscribe when no interest remains.

This is the minimal fix — the TTL expiry path is the single authoritative cleanup point for downstream subscribers, and it now correctly syncs both the hosting manager and interest manager.

## Testing

- Added `test_expire_returns_expired_count_for_interest_sync`: verifies that TTL expiry returns correct expired counts and that syncing with the interest manager zeroes out `downstream_subscriber_count`
- Updated existing tests for the new return type
- All 2042 tests pass

Closes #3469

[AI-assisted - Claude]