### PR TITLE
fix: close WebSocket connection immediately on stale auth token

### DIFF
--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -686,8 +686,17 @@ async fn websocket_interface(
 
         send_response_message(&mut server_sink, serialized_error, &mut conn_state, None).await?;
 
-        tracing::debug!("Sent AUTH_TOKEN_INVALID error to client");
-        // Don't close connection immediately - let client handle the error gracefully
+        tracing::debug!("Sent AUTH_TOKEN_INVALID error to client, closing connection");
+        // Close the connection after sending the error. Keeping it open causes delegate
+        // failures: all subsequent messages would be processed with origin_contract=None
+        // (since auth_token=None), so the delegate receives origin=None and fails with
+        // "missing message origin". The client handles AUTH_TOKEN_INVALID by reloading
+        // the page to get a fresh token, so closing is the correct behavior.
+        notify_disconnect(&request_sender, client_id, &auth_token, api_version).await;
+        if let Err(e) = server_sink.send(Message::Close(None)).await {
+            tracing::debug!(error = %e, "Failed to send WebSocket close frame after auth error");
+        }
+        return Ok(());
     }
 
     // Per-connection rate limiter for delegate operations (#3305, #3332)


### PR DESCRIPTION
## Problem

After a node restart, the `origin_contracts` map (in-memory `DashMap`) is cleared. When a client reconnects with a stale auth token:

1. Node correctly detects the invalid token and sends `AUTH_TOKEN_INVALID` error
2. But the connection **stays open** ("let client handle it gracefully")
3. Client sends delegate messages before processing the error / reloading
4. These messages are processed with `origin_contract=None` (no auth token → no origin)
5. Delegate receives `origin=None` and fails with "missing message origin"
6. The error is not propagated to the UI, which gets stuck on "Subscribing to room" forever

This was triggered by the v0.1.186 release which introduced `MessageOrigin` (PR #3542). The new delegate API requires a valid origin for `ApplicationMessage` processing, so the previously-harmless `None` origin now causes a hard failure.

## Approach

Close the connection immediately after sending `AUTH_TOKEN_INVALID`, with proper disconnect notification and WebSocket close frame. This prevents any delegate messages from being processed with a missing origin.

The previous comment said "Don't close connection immediately - let client handle the error gracefully," but keeping it open is actively harmful: every subsequent message fails because `auth_token=None` → `origin_contract=None`. The client already handles `AUTH_TOKEN_INVALID` by reloading the page to get a fresh token (see River's `connection_manager.rs`), so closing is the correct behavior.

## Why didn't CI catch this?

This bug requires a node restart between sessions — the token is valid when first issued but becomes stale after restart. The existing `token_expiration.rs` tests validate token lifecycle (expiration via TTL and cleanup) but don't test the WebSocket message processing behavior when a stale token is presented. A proper end-to-end test would require:
1. Starting a node with a contract web app
2. Connecting a client and getting a valid auth token
3. Restarting the node (clearing origin_contracts)
4. Reconnecting with the stale token
5. Sending a delegate message and verifying it's rejected cleanly

This is integration-test level and would require significant test infrastructure investment beyond the scope of this fix.

## Testing

- `cargo fmt` clean
- `cargo clippy` clean
- `cargo test -p freenet --test token_expiration` passes (3/3)
- Verified by diagnostic report P9U7FW from production peer

[AI-assisted - Claude]