### PR TITLE
fix: migrate module delegates to MessageOrigin API

### DIFF
--- a/crates/core/src/wasm_runtime/delegate_api.rs
+++ b/crates/core/src/wasm_runtime/delegate_api.rs
@@ -41,11 +41,11 @@
 //!
 //! **V1 (request/response):**
 //! ```text
-//! fn process(ctx, params, attested, msg) -> Vec<OutboundDelegateMsg> {
+//! fn process(ctx, params, origin, msg) -> Vec<OutboundDelegateMsg> {
 //!     match msg {
 //!         ApplicationMessage(app_msg) => {
 //!             // Can't get contract state inline — must return a request
-//!             let state = DelegateState { pending_contract: contract_id, app };
+//!             let state = DelegateState { pending_contract: contract_id };
 //!             let context = DelegateContext::new(serialize(&state));
 //!             vec![GetContractRequest { contract_id, context, processed: false }]
 //!         }
@@ -62,7 +62,7 @@
 //!
 //! **V2 (host function):**
 //! ```text
-//! fn process(ctx, params, attested, msg) -> Vec<OutboundDelegateMsg> {
+//! fn process(ctx, params, origin, msg) -> Vec<OutboundDelegateMsg> {
 //!     match msg {
 //!         ApplicationMessage(app_msg) => {
 //!             // Get contract state inline — no round-trip!

--- a/modules/antiflood-tokens/Cargo.lock
+++ b/modules/antiflood-tokens/Cargo.lock
@@ -135,6 +135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +262,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.66",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -264,7 +273,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -296,7 +305,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -346,42 +355,41 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
 name = "freenet-macros"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21b0e54ae3e7c5c9b9c845bd9eb4df94d24c94c0c5815ce5aa097492b984259"
+checksum = "d26e5c6bee9ffa0e2683bc8b41a7bd9f1e57e7fd49ac4f6ae433e5a82e9006df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.24"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
+checksum = "cb859b413234ca077e5a3855653cdeed3574470ac63eb2a9b5b7e9ccc3cbc1d1"
 dependencies = [
  "arbitrary",
  "bincode",
  "blake3",
  "bs58",
  "byteorder",
+ "bytes",
  "chrono",
  "flatbuffers",
  "freenet-macros",
  "futures",
- "once_cell",
  "semver",
  "serde",
- "serde_bytes",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
 ]
@@ -426,7 +434,6 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -450,32 +457,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
 
 [[package]]
 name = "futures-sink"
@@ -495,16 +480,11 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -810,9 +790,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -921,9 +901,6 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -935,15 +912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,7 +919,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -992,7 +960,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1023,15 +991,6 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1103,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1118,7 +1077,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1129,7 +1097,18 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1207,7 +1186,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1310,7 +1289,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1332,7 +1311,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/modules/antiflood-tokens/Cargo.toml
+++ b/modules/antiflood-tokens/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 bincode = { version = "1" }
 bs58 = "0.5"
 chrono = { version = "0.4", default-features = false }
-freenet-stdlib = { version = "0.1.24" }
+freenet-stdlib = { version = "0.3.1" }
 rsa = { version = "0.9", default-features = false, features = ["serde", "pem"] }
 serde = { version = "1" }
 serde_json = { version = "1" }

--- a/modules/antiflood-tokens/delegates/token-generator/src/lib.rs
+++ b/modules/antiflood-tokens/delegates/token-generator/src/lib.rs
@@ -14,13 +14,13 @@ struct TokenDelegate;
 #[delegate]
 impl DelegateInterface for TokenDelegate {
     fn process(
+        _ctx: &mut DelegateCtx,
         params: Parameters<'static>,
-        _attested: Option<&'static [u8]>,
+        _origin: Option<MessageOrigin>,
         message: InboundDelegateMsg,
     ) -> Result<Vec<OutboundDelegateMsg>, DelegateError> {
         match message {
             InboundDelegateMsg::ApplicationMessage(ApplicationMessage {
-                app,
                 payload,
                 context,
                 processed,
@@ -36,7 +36,7 @@ impl DelegateInterface for TokenDelegate {
                 let params = DelegateParameters::try_from(params)?;
                 match msg {
                     TokenDelegateMessage::RequestNewToken(req) => {
-                        allocate_token(params, &mut context, app, req)
+                        allocate_token(params, &mut context, req)
                     }
                     TokenDelegateMessage::Failure(reason) => Err(DelegateError::Other(format!(
                         "unexpected message type: failure; reason: {reason}"
@@ -59,10 +59,7 @@ impl DelegateInterface for TokenDelegate {
                 let context: DelegateContext = (&context).try_into()?;
                 Ok(vec![OutboundDelegateMsg::ContextUpdated(context)])
             }
-            InboundDelegateMsg::GetSecretResponse(GetSecretResponse { .. }) => Err(
-                DelegateError::Other("unexpected message type: get secret".into()),
-            ),
-            InboundDelegateMsg::GetSecretRequest(_) => unreachable!(),
+            _ => Err(DelegateError::Other("unexpected message type".into())),
         }
     }
 }
@@ -86,7 +83,6 @@ fn user_input(criteria: &AllocationCriteria, assignee: &Assignee) -> Notificatio
 fn allocate_token(
     params: DelegateParameters,
     context: &mut Context,
-    app: ContractInstanceId,
     RequestNewToken {
         request_id,
         delegate_id,
@@ -116,7 +112,7 @@ fn allocate_token(
                     assignment_hash,
                 });
                 OutboundDelegateMsg::ApplicationMessage(
-                    ApplicationMessage::new(app, msg.serialize()?).with_context(context),
+                    ApplicationMessage::new(msg.serialize()?).with_context(context),
                 )
             };
             let request_user_input = OutboundDelegateMsg::RequestUserInput(UserInputRequest {
@@ -141,7 +137,7 @@ fn allocate_token(
                     assignment_hash,
                 });
                 OutboundDelegateMsg::ApplicationMessage(
-                    ApplicationMessage::new(app, msg.serialize()?).with_context(context),
+                    ApplicationMessage::new(msg.serialize()?).with_context(context),
                 )
             };
             Ok(vec![req_allocation])
@@ -159,7 +155,7 @@ fn allocate_token(
                             criteria,
                         });
                         return Ok(vec![OutboundDelegateMsg::ApplicationMessage(
-                            ApplicationMessage::new(app, msg.serialize()?).with_context(context),
+                            ApplicationMessage::new(msg.serialize()?).with_context(context),
                         )]);
                     };
                     let msg = TokenDelegateMessage::AllocatedToken {
@@ -168,7 +164,7 @@ fn allocate_token(
                         records,
                     };
                     OutboundDelegateMsg::ApplicationMessage(
-                        ApplicationMessage::new(app, msg.serialize()?)
+                        ApplicationMessage::new(msg.serialize()?)
                             .processed(true)
                             .with_context(context),
                     )
@@ -177,7 +173,7 @@ fn allocate_token(
                     let context: DelegateContext = (&*context).try_into()?;
                     let msg = TokenDelegateMessage::Failure(FailureReason::UserPermissionDenied);
                     OutboundDelegateMsg::ApplicationMessage(
-                        ApplicationMessage::new(app, msg.serialize()?).with_context(context),
+                        ApplicationMessage::new(msg.serialize()?).with_context(context),
                     )
                 }
             };

--- a/modules/identity-management/Cargo.lock
+++ b/modules/identity-management/Cargo.lock
@@ -128,6 +128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,7 +195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -299,7 +308,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "serdect",
  "subtle",
@@ -318,7 +327,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -340,9 +349,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "freenet-macros"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21b0e54ae3e7c5c9b9c845bd9eb4df94d24c94c0c5815ce5aa097492b984259"
+checksum = "d26e5c6bee9ffa0e2683bc8b41a7bd9f1e57e7fd49ac4f6ae433e5a82e9006df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -351,22 +360,21 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.1.24"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39e2953b4b0d82dd02458653b57166ba8c967c6b3fcec146102a27e05a7081a"
+checksum = "cb859b413234ca077e5a3855653cdeed3574470ac63eb2a9b5b7e9ccc3cbc1d1"
 dependencies = [
  "bincode",
  "blake3",
  "bs58",
  "byteorder",
+ "bytes",
  "chrono",
  "flatbuffers",
  "freenet-macros",
  "futures",
- "once_cell",
  "semver",
  "serde",
- "serde_bytes",
  "serde_json",
  "serde_with",
  "thiserror",
@@ -382,7 +390,6 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -406,32 +413,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -451,16 +436,11 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -486,25 +466,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -760,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -777,29 +745,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.9.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -808,16 +771,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
 ]
 
 [[package]]
@@ -882,9 +836,6 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -893,15 +844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -993,16 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
+ "rand_core",
 ]
 
 [[package]]
@@ -1035,9 +968,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1046,18 +979,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1212,15 +1145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,12 +1285,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zeroize"

--- a/modules/identity-management/Cargo.toml
+++ b/modules/identity-management/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 p384 =  { version = "0.13", default-features = false, features = ["serde", "pem", "pkcs8", "arithmetic"] }
-freenet-stdlib = { version = "0.1.24" }
+freenet-stdlib = { version = "0.3.1" }
 serde = "1"
 serde_json = "1"
 
@@ -16,7 +16,7 @@ serde_json = "1"
 p384 = { version = "0.13", default-features = true }
 ecdsa = "0.16"
 pico-args = "0.5"
-rand = "0.9"
+rand = "0.8"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/identity-management/src/lib.rs
+++ b/modules/identity-management/src/lib.rs
@@ -108,11 +108,14 @@ impl TryFrom<&[u8]> for IdentityManagement {
 #[delegate]
 impl DelegateInterface for IdentityManagement {
     fn process(
+        ctx: &mut DelegateCtx,
         params: Parameters<'static>,
-        _attested: Option<&'static [u8]>,
+        _origin: Option<MessageOrigin>,
         message: InboundDelegateMsg,
     ) -> Result<Vec<OutboundDelegateMsg>, DelegateError> {
         let params = IdentityParams::try_from(params)?;
+        let secret_key =
+            serde_json::to_vec(&params).map_err(|e| DelegateError::Deser(format!("{e}")))?;
         match message {
             InboundDelegateMsg::ApplicationMessage(ApplicationMessage {
                 payload,
@@ -120,21 +123,7 @@ impl DelegateInterface for IdentityManagement {
                 ..
             }) => {
                 let msg = IdentityMsg::try_from(&*payload)?;
-                let action = match msg {
-                    IdentityMsg::CreateIdentity { alias, key, extra } => {
-                        #[cfg(feature = "contract")]
-                        {
-                            freenet_stdlib::log::info(&format!(
-                                "create alias new {alias} for {}",
-                                params.as_secret_id()
-                            ));
-                        }
-                        serde_json::to_vec(&IdentityMsg::CreateIdentity { alias, key, extra })
-                            .unwrap()
-                    }
-                    IdentityMsg::DeleteIdentity { alias } => {
-                        serde_json::to_vec(&IdentityMsg::DeleteIdentity { alias }).unwrap()
-                    }
+                match msg {
                     IdentityMsg::Init => {
                         #[cfg(feature = "contract")]
                         {
@@ -143,59 +132,43 @@ impl DelegateInterface for IdentityManagement {
                                 params.as_secret_id()
                             ));
                         }
-                        let set_secret = OutboundDelegateMsg::SetSecretRequest(SetSecretRequest {
-                            key: params.as_secret_id(),
-                            value: Some(
-                                serde_json::to_vec(&IdentityManagement::default()).unwrap(),
-                            ),
-                        });
-                        return Ok(vec![set_secret]);
+                        let default_value = serde_json::to_vec(&IdentityManagement::default())
+                            .map_err(|e| DelegateError::Deser(format!("{e}")))?;
+                        ctx.set_secret(&secret_key, &default_value);
+                        Ok(vec![])
                     }
-                };
-                let context: DelegateContext = DelegateContext::new(action);
-                let get_secret = OutboundDelegateMsg::GetSecretRequest(GetSecretRequest {
-                    key: SecretsId::new(serde_json::to_vec(&params).unwrap()),
-                    context,
-                    processed: false,
-                });
-                Ok(vec![get_secret])
-            }
-            InboundDelegateMsg::GetSecretResponse(GetSecretResponse {
-                value: Some(value),
-                context,
-                ..
-            }) => {
-                #[cfg(feature = "contract")]
-                {
-                    freenet_stdlib::log::info(&format!(
-                        "got request for {}",
-                        params.as_secret_id()
-                    ));
-                }
-                if !context.as_ref().is_empty() {
-                    let context = IdentityMsg::try_from(context.as_ref()).unwrap();
-                    let mut manager = IdentityManagement::try_from(&*value)?;
-                    match context {
-                        IdentityMsg::CreateIdentity { alias, key, extra } => {
-                            manager.identities.insert(alias, AliasInfo { key, extra });
+                    IdentityMsg::CreateIdentity { alias, key, extra } => {
+                        #[cfg(feature = "contract")]
+                        {
+                            freenet_stdlib::log::info(&format!(
+                                "create alias new {alias} for {}",
+                                params.as_secret_id()
+                            ));
                         }
-                        IdentityMsg::DeleteIdentity { alias } => {
-                            manager.identities.remove(alias.as_str());
-                        }
-                        IdentityMsg::Init => {
-                            unreachable!()
-                        }
-                    };
-                    let outbound = OutboundDelegateMsg::SetSecretRequest(SetSecretRequest {
-                        key: params.as_secret_id(),
-                        value: Some(serde_json::to_vec(&manager).unwrap()),
-                    });
-                    Ok(vec![outbound])
-                } else {
-                    Err(DelegateError::Other("invalid request".into()))
+                        let value = ctx
+                            .get_secret(&secret_key)
+                            .ok_or_else(|| DelegateError::Other("secret not found".into()))?;
+                        let mut manager = IdentityManagement::try_from(value.as_slice())?;
+                        manager.identities.insert(alias, AliasInfo { key, extra });
+                        let updated = serde_json::to_vec(&manager)
+                            .map_err(|e| DelegateError::Deser(format!("{e}")))?;
+                        ctx.set_secret(&secret_key, &updated);
+                        Ok(vec![])
+                    }
+                    IdentityMsg::DeleteIdentity { alias } => {
+                        let value = ctx
+                            .get_secret(&secret_key)
+                            .ok_or_else(|| DelegateError::Other("secret not found".into()))?;
+                        let mut manager = IdentityManagement::try_from(value.as_slice())?;
+                        manager.identities.remove(alias.as_str());
+                        let updated = serde_json::to_vec(&manager)
+                            .map_err(|e| DelegateError::Deser(format!("{e}")))?;
+                        ctx.set_secret(&secret_key, &updated);
+                        Ok(vec![])
+                    }
                 }
             }
-            _ => unreachable!(),
+            _ => Err(DelegateError::Other("unexpected message type".into())),
         }
     }
 }


### PR DESCRIPTION
## Problem

The `antiflood-tokens` and `identity-management` module delegates were still using the old delegate API from freenet-stdlib 0.1.24:
- `_attested: Option<&'static [u8]>` parameter instead of `_origin: Option<MessageOrigin>`
- `ApplicationMessage::new(app, payload)` instead of `ApplicationMessage::new(payload)`
- Request/response pattern for secrets (`GetSecretRequest`/`GetSecretResponse`/`SetSecretRequest`) which no longer exist in the API

This was the last remaining work to close #1498, after PR #3542 migrated the core runtime and test delegates.

## Solution

- **antiflood-tokens**: Upgraded to freenet-stdlib 0.3.1, removed the `app` parameter from `allocate_token()` and all `ApplicationMessage::new()` calls, replaced removed `GetSecretResponse`/`GetSecretRequest` match arms with a wildcard
- **identity-management**: Upgraded to freenet-stdlib 0.3.1, rewrote `process()` to use V2 host functions (`ctx.get_secret()`/`ctx.set_secret()`) instead of the old two-round-trip request/response secret pattern, fixed `rand_core` version conflict by pinning `rand` to 0.8
- **delegate_api.rs**: Updated stale pseudocode examples from `attested` to `origin`

## Testing

- `cargo check` passes for all three workspaces (core, antiflood-tokens, identity-management)
- `cargo fmt` and `cargo clippy` pass
- No remaining `_attested` delegate signatures in the codebase

## Fixes

Closes #1498