### PR TITLE
fix: align config connection defaults with Ring constants

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -26,9 +26,9 @@ mod secret;
 pub use secret::*;
 
 /// Default maximum number of connections for the peer.
-pub const DEFAULT_MAX_CONNECTIONS: usize = 20;
+pub const DEFAULT_MAX_CONNECTIONS: usize = crate::ring::Ring::DEFAULT_MAX_CONNECTIONS;
 /// Default minimum number of connections for the peer.
-pub const DEFAULT_MIN_CONNECTIONS: usize = 10;
+pub const DEFAULT_MIN_CONNECTIONS: usize = crate::ring::Ring::DEFAULT_MIN_CONNECTIONS;
 /// Default threshold for randomizing potential peers for new connections.
 ///
 /// If the hops left for the operation is above or equal to this threshold

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -152,9 +152,9 @@ pub struct PruneConnectionResult {
 }
 
 impl Ring {
-    const DEFAULT_MIN_CONNECTIONS: usize = 25;
+    pub const DEFAULT_MIN_CONNECTIONS: usize = 25;
 
-    const DEFAULT_MAX_CONNECTIONS: usize = 200;
+    pub const DEFAULT_MAX_CONNECTIONS: usize = 200;
 
     const DEFAULT_MAX_UPSTREAM_BANDWIDTH: Rate = Rate::new_per_second(1_000_000.0);
 


### PR DESCRIPTION
## Problem

`config.rs` defined its own connection defaults (`min=10`, `max=20`) separately from `Ring`'s constants (`min=25`, `max=200`). The Ring values were tuned upward over time (max→200 in Jan 2024, min→25 in Feb 2025) but `config.rs` was never updated. Since every real installation goes through the config path, all nodes have been running with the stale conservative limits.

## Solution

Make `config.rs` constants aliases of `Ring::DEFAULT_MIN_CONNECTIONS` and `Ring::DEFAULT_MAX_CONNECTIONS`, establishing a single source of truth. Made the Ring constants `pub` to support this.

## Testing

- `cargo check` passes
- No behavioral change for tests that override these values (which is nearly all simulation tests)
- Default installations will now get min=25, max=200 as intended by the ring layer tuning