### PR TITLE
fix: add logarithmic TTL decay for uphill CONNECT routing to prevent amplification

### DIFF
--- a/.claude/rules/ring.md
+++ b/.claude/rules/ring.md
@@ -29,8 +29,8 @@ WHEN accepting a new connection (should_accept):
   1b. CHECK: Is this peer already connected or pending? → REJECT
       (Forces CONNECT to route uphill, discovering new unconnected peers
        instead of silently no-op'ing on already-known ones. See PR #3557.)
-      Note: uphill routing burns TTL at O(log TTL) rate (halves remaining
-      TTL per hop) to prevent amplification at scale. See PR #3582.
+      Note: uphill routing halves the forwarded TTL per hop (applied to the
+      outgoing message only) to limit uphill hops to O(log TTL). See PR #3582.
   2. CHECK: Are we at max_connections (open + pending)? → REJECT
   3. Compute Kleinberg gap score (small_world_rand::kleinberg_score):
      → Map all connection distances to log-space (1/d = uniform in log)

--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -654,12 +654,14 @@ impl RelayState {
             // At terminus but should_accept() returned false (e.g., already connected
             // or at capacity). Route uphill to give other peers a chance to accept.
             //
-            // Uphill routing burns half the remaining TTL per hop to prevent
+            // Uphill routing halves the forwarded TTL per hop to prevent
             // amplification cascades at scale. Without this, 500-node networks
             // with high connectivity generate O(nodes × TTL) uphill messages per
             // maintenance cycle, overwhelming the transport layer.
-            // With TTL=15 this allows ~4 uphill hops (15→8→4→2→1→reject).
-            // With TTL=4 this allows ~2 uphill hops (4→2→1→reject).
+            // The burn applies only to the outgoing message (not self.request),
+            // so retries after rejection still have enough TTL.
+            // With TTL=15: forwarded as 7→3→1→reject (~3 uphill hops).
+            // With TTL=4: forwarded as 1→reject (~1 uphill hop).
             if self.request.ttl >= 2 {
                 let uphill_hop = ctx.select_uphill_hop(
                     self.request.desired_location,
@@ -678,12 +680,16 @@ impl RelayState {
                         ring_distance_to_target = ?dist,
                         "connect: at terminus but cannot accept, routing uphill"
                     );
-                    // Halve TTL on uphill routing (on top of the -1 in forward_to_peer).
-                    // This limits uphill hops to O(log TTL) instead of O(TTL).
-                    let extra_burn = self.request.ttl / 2;
-                    self.request.ttl = self.request.ttl.saturating_sub(extra_burn);
-                    actions.forward =
-                        Some(self.forward_to_peer(ctx, uphill_peer, forward_attempts, now));
+                    // Halve TTL on the forwarded request to limit uphill hops to
+                    // O(log TTL) instead of O(TTL). The burn is applied only to the
+                    // outgoing message, NOT to self.request.ttl, so that if this
+                    // uphill attempt is rejected and we retry with a different peer,
+                    // the retry still has enough TTL to proceed.
+                    let (peer, mut fwd_req) =
+                        self.forward_to_peer(ctx, uphill_peer, forward_attempts, now);
+                    let extra_burn = fwd_req.ttl / 2;
+                    fwd_req.ttl = fwd_req.ttl.saturating_sub(extra_burn);
+                    actions.forward = Some((peer, fwd_req));
                 } else {
                     tracing::info!(
                         target = %self.request.desired_location,
@@ -3755,8 +3761,8 @@ mod tests {
             .expect("should route uphill when at terminus but cannot accept");
         assert_eq!(forward_to.pub_key(), uphill_peer.pub_key());
         assert_eq!(
-            request.ttl, 2,
-            "TTL should be decremented for uphill forward"
+            request.ttl, 1,
+            "TTL should be decremented (-1) then halved for uphill forward: (3-1)/2 = 1"
         );
 
         // forwarded_to should be set


### PR DESCRIPTION
## Problem

The nightly "Large Scale Simulation" test (500 nodes) has been failing since March 14. The test hangs until the CI runner is killed.

Root cause: the already-connected peer rejection (#3557) correctly rejects peers and triggers uphill routing to discover new peers. However, at 500 nodes with TTL=15, each rejected CONNECT can bounce through up to 15 uphill hops. With 500 nodes all doing connection maintenance simultaneously, this creates O(nodes × TTL) message amplification per cycle that overwhelms the transport layer:

1. CONNECT reaches terminus → `should_accept()` rejects (peer already connected)
2. Uphill routing: request forwarded away from target, consuming 1 TTL per hop
3. At TTL=15, up to 15 uphill hops per rejected CONNECT
4. Network flooded → "max connection attempts reached" → operation timeouts → stall

**Production telemetry confirms the issue**: 33% of CONNECT operations are rejected (13,341/39,532 in the last hour), with 7,277 rejections from `should_accept` and 6,064 cascading "relay no retry peers" failures.

## Solution

Halve the remaining TTL on each uphill hop (on top of the standard -1 from `forward_to_peer`). This limits uphill hops to **O(log TTL)** instead of O(TTL):

| TTL | Max uphill hops before | Max uphill hops after |
|-----|----------------------|---------------------|
| 15  | 15                   | ~4 (15→8→4→2→reject) |
| 7   | 7                    | ~3 (7→4→2→reject)    |
| 4   | 4                    | ~2 (4→2→reject)      |

The #3557 rejection behavior is preserved — peers still reject already-connected joiners and route uphill for diversity. Only the amplification is bounded.

Also fixes pre-existing clippy warnings in get.rs and subscribe/tests.rs.

## Testing

- All 99 simulation integration tests pass, including:
  - `test_connection_growth_stall_regression` (the original plateau fix)
  - `test_connection_growth_plateau_diagnostic` (the #3557 diagnostic test)
  - `test_get_routing_coverage_low_htl` (low-TTL routing, validates proportional approach)
- `cargo clippy --all-targets` clean

## Fixes

Fixes nightly simulation test failures from March 14-17.