### PR TITLE
fix: add progress timeout after ForwardingAck to re-enable GET retry

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1507,13 +1507,24 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                 // When a relay forwards a GET request, it sends a ForwardingAck back
                 // to its upstream within milliseconds. If no ACK arrives within 3s,
                 // the downstream peer is likely dead — launch a speculative retry on
-                // a different path (same tx ID). If an ACK has been received, the
-                // chain is alive — trust it and wait for OPERATION_TTL (60s).
+                // a different path (same tx ID).
+                //
+                // If an ACK has been received, the chain is alive — trust it for
+                // PROGRESS_TIMEOUT (20s). If no response arrives within that window,
+                // the chain has stalled and we re-enable speculative retry (#3570).
+                // Without this, a single ACK permanently disables retry, causing
+                // the originator to wait the full OPERATION_TTL (60s) with no recovery.
                 //
                 // Only the originator speculates (max 2 parallel paths). Relay peers
                 // just forward once, so network overhead is bounded.
                 const ACK_TIMEOUT: Duration = Duration::from_secs(3);
                 const MAX_SPECULATIVE_PATHS: u8 = 2;
+                /// Time to wait after ForwardingAck before re-enabling retry.
+                /// If a relay ACKed but no response arrives within this window,
+                /// the downstream chain has likely stalled. 20s balances giving
+                /// slow multi-hop chains time to complete vs. not wasting the
+                /// full 60s OPERATION_TTL on dead chains.
+                const PROGRESS_TIMEOUT: Duration = Duration::from_secs(20);
                 {
                     // Clean up entries for completed operations
                     get_retried.retain(|tx, _| ops.get.contains_key(tx));
@@ -1528,21 +1539,38 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                             continue;
                         }
 
-                        // If ACK received, the downstream chain is alive — don't retry.
-                        // Wait for OPERATION_TTL to expire naturally.
-                        if get_op.ack_received {
-                            continue;
-                        }
-
                         // Cap speculative paths to bound network overhead
                         if get_op.speculative_paths >= MAX_SPECULATIVE_PATHS {
                             continue;
                         }
 
-                        // No ACK after ACK_TIMEOUT — speculative retry with ±20% jitter
                         let elapsed = tx.elapsed();
+
+                        if get_op.ack_received {
+                            // ACK received — the chain was alive when the relay forwarded.
+                            // Trust it for PROGRESS_TIMEOUT, then re-enable retry if no
+                            // response has arrived (#3570: ForwardingAck retry-disable fix).
+                            if elapsed <= PROGRESS_TIMEOUT {
+                                continue;
+                            }
+                            // Chain has stalled past PROGRESS_TIMEOUT — fall through to retry.
+                            tracing::info!(
+                                %tx,
+                                elapsed_ms = elapsed.as_millis(),
+                                "GET chain stalled after ForwardingAck — re-enabling speculative retry"
+                            );
+                        }
+
+                        // No ACK after ACK_TIMEOUT, or ACK received but chain stalled
+                        // past PROGRESS_TIMEOUT — speculative retry with ±20% jitter
                         let retry_count = get_retried.get(&tx).copied().unwrap_or(0);
-                        let base = ACK_TIMEOUT * (retry_count as u32 + 1);
+                        let base = if get_op.ack_received {
+                            // For stalled-after-ACK, use PROGRESS_TIMEOUT as the base
+                            // instead of ACK_TIMEOUT to avoid immediate rapid retries
+                            PROGRESS_TIMEOUT + ACK_TIMEOUT * (retry_count as u32)
+                        } else {
+                            ACK_TIMEOUT * (retry_count as u32 + 1)
+                        };
                         // Only consume GlobalRng when elapsed exceeds 80% of base
                         // (minimum possible jittered threshold). This avoids shifting
                         // the global RNG state on every GC tick for ops that are

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -4720,28 +4720,36 @@ mod tests {
     /// Returns true if the op would be selected as a retry candidate.
     fn gc_would_retry(op: &GetOp, retry_count: usize) -> bool {
         const ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+        const PROGRESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
         const MAX_SPECULATIVE_PATHS: u8 = 2;
 
         // Must be originator
         if !op.is_client_initiated() {
             return false;
         }
-        // ACK received → trust chain, don't retry
-        if op.ack_received {
-            return false;
-        }
         // Capped speculative paths
         if op.speculative_paths >= MAX_SPECULATIVE_PATHS {
             return false;
         }
-        // Check elapsed vs threshold (without jitter for deterministic testing)
         let elapsed = op.id.elapsed();
+
+        if op.ack_received {
+            // ACK received — trust chain for PROGRESS_TIMEOUT, then re-enable (#3570)
+            if elapsed <= PROGRESS_TIMEOUT {
+                return false;
+            }
+            // Chain stalled past PROGRESS_TIMEOUT — eligible for retry
+            let base = PROGRESS_TIMEOUT + ACK_TIMEOUT * (retry_count as u32);
+            return elapsed > base;
+        }
+
+        // No ACK — check against ACK_TIMEOUT (without jitter for deterministic testing)
         let base = ACK_TIMEOUT * (retry_count as u32 + 1);
         elapsed > base
     }
 
     #[test]
-    fn ack_received_prevents_gc_retry() {
+    fn ack_received_prevents_gc_retry_within_progress_timeout() {
         use crate::config::GlobalSimulationTime;
 
         let base_ms = 1_700_000_000_000;
@@ -4750,12 +4758,31 @@ mod tests {
         let mut op = make_awaiting_op(vec![make_peer(5001)], &[]);
         op.ack_received = true;
 
-        // Advance time well past ACK_TIMEOUT (3s)
+        // Advance time past ACK_TIMEOUT (3s) but within PROGRESS_TIMEOUT (20s)
         GlobalSimulationTime::set_time_ms(base_ms + 10_000);
 
         assert!(
             !gc_would_retry(&op, 0),
-            "Op with ack_received should NOT be retried by GC"
+            "Op with ack_received should NOT be retried within PROGRESS_TIMEOUT"
+        );
+    }
+
+    #[test]
+    fn ack_received_allows_retry_after_progress_timeout() {
+        use crate::config::GlobalSimulationTime;
+
+        let base_ms = 1_700_000_000_000;
+        GlobalSimulationTime::set_time_ms(base_ms);
+
+        let mut op = make_awaiting_op(vec![make_peer(5001)], &[]);
+        op.ack_received = true;
+
+        // Advance time past PROGRESS_TIMEOUT (20s) + ACK_TIMEOUT (3s) for jitter headroom
+        GlobalSimulationTime::set_time_ms(base_ms + 25_000);
+
+        assert!(
+            gc_would_retry(&op, 0),
+            "Op with ack_received SHOULD be retried after PROGRESS_TIMEOUT (#3570)"
         );
     }
 


### PR DESCRIPTION
## Problem

When a relay peer sends a ForwardingAck for a GET request, the originator permanently disables speculative retry (`ack_received = true`). If the downstream chain then stalls — peer crash, slow response, lost message — the originator waits the full OPERATION_TTL (60s) with no recovery path.

This is the **direct cause of user-visible browser timeouts** reported in #3570. The irony: GETs where the relay was *more responsive* (sent an ACK) had *worse* outcomes than GETs where the relay was dead (no ACK → speculative retry fired after 3s).

**Evidence:**
- Production telemetry: 34% of GETs silently drop with no outcome event
- Simulation: 489 ForwardingAcks received in a 100-node network, each permanently disabling retry
- Diagnostic report NBJZ9S: GET with ACK → 63s timeout; GET without ACK → retry after 6s → success

## Solution

Add a `PROGRESS_TIMEOUT` (20s) after ForwardingAck receipt. If ACK received but no response arrives within 20s, the chain has stalled — re-enable speculative retry on an alternative path.

**Timing flow:**
```
0-3s:  Wait for ForwardingAck
3s (no ACK):  Speculative retry (existing behavior, unchanged)
3s (ACK):     Trust chain, wait for response
20s (ACK, no response):  Chain stalled → re-enable retry ← NEW
60s:  OPERATION_TTL hard timeout
```

This preserves the ACK mechanism's purpose (avoiding premature retries on slow-but-working chains) while adding recovery for genuinely stalled chains.

## Testing

52 GET unit tests pass (including 2 new tests for the progress timeout):
- `ack_received_prevents_gc_retry_within_progress_timeout`: ACK blocks retry within 20s
- `ack_received_allows_retry_after_progress_timeout`: ACK allows retry after 20s

```
cargo test -p freenet --lib -- operations::get::tests
# 52 passed; 0 failed
```

## Fixes

Fixes #3570