### PR TITLE
fix: gate GET diagnostic tests behind nightly_tests feature

### DIFF
--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -269,13 +269,16 @@ where
                         op_manager.completed(tx_id);
                     }
                     Err(e) => {
-                        // Return directly (bypasses the Aborted-sending error
-                        // handler at the top of this function intentionally —
-                        // we want the op to stay alive in under_progress for
-                        // GC retry, not be aborted).
+                        // Return directly — bypasses the Aborted-sending error
+                        // handler at the top of this function intentionally.
+                        // For relay nodes: the op state was already consumed by
+                        // process_message, so the tx sits in under_progress until
+                        // the 5× TTL cutoff cleans it up. The originator recovers
+                        // independently via its own speculative retry (ACK_TIMEOUT
+                        // or PROGRESS_TIMEOUT in the GC task).
                         tracing::warn!(
                             %tx_id, %target, error = %e,
-                            "Response send failed — keeping op for GC retry"
+                            "Response send failed — originator will retry via speculative path"
                         );
                         return Err(e);
                     }

--- a/crates/core/src/operations/subscribe/tests.rs
+++ b/crates/core/src/operations/subscribe/tests.rs
@@ -1839,7 +1839,11 @@ fn make_retry_op(alternatives: Vec<PeerKeyLocation>, tried: &[PeerKeyLocation]) 
 fn extract_request_htl(msg: &SubscribeMsg) -> usize {
     match msg {
         SubscribeMsg::Request { htl, .. } => *htl,
-        other => panic!("Expected Request, got {other:?}"),
+        other @ SubscribeMsg::Response { .. }
+        | other @ SubscribeMsg::Unsubscribe { .. }
+        | other @ SubscribeMsg::ForwardingAck { .. } => {
+            panic!("Expected Request, got {other:?}")
+        }
     }
 }
 
@@ -1847,7 +1851,11 @@ fn extract_request_htl(msg: &SubscribeMsg) -> usize {
 fn extract_awaiting_data(op: &SubscribeOp) -> &super::AwaitingResponseData {
     match &op.state {
         SubscribeState::AwaitingResponse(data) => data,
-        other => panic!("Expected AwaitingResponse, got {other:?}"),
+        other @ SubscribeState::PrepareRequest(_)
+        | other @ SubscribeState::Completed(_)
+        | other @ SubscribeState::Failed => {
+            panic!("Expected AwaitingResponse, got {other:?}")
+        }
     }
 }
 
@@ -1905,7 +1913,7 @@ fn test_retry_uses_fallback_peers() {
 #[test]
 fn test_retry_skips_tried_fallback_peers() {
     let tried_peer = random_peer();
-    let op = make_retry_op(vec![], &[tried_peer.clone()]);
+    let op = make_retry_op(vec![], std::slice::from_ref(&tried_peer));
 
     let result = op.retry_with_next_alternative(10, &[tried_peer]);
     assert!(

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -7362,9 +7362,8 @@ async fn test_connection_growth_plateau_diagnostic() {
 /// A soft assertion ensures GET success rate doesn't fall below 50% (catastrophic).
 ///
 /// Uses `run_controlled_simulation` for deterministic reproduction.
-// Long-running diagnostic test (~2min). Run with:
-// cargo test -p freenet --features "simulation_tests,testing" --test simulation_integration -- --ignored test_get_reliability_diagnostic
-#[ignore]
+// Long-running diagnostic test (~2min). Runs in nightly CI.
+#[cfg(feature = "nightly_tests")]
 #[test_log::test]
 fn test_get_reliability_diagnostic() {
     use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
@@ -7677,9 +7676,8 @@ fn test_get_reliability_diagnostic() {
 /// The latency means multi-hop GETs accumulate realistic delays (e.g., 5 hops × 100ms avg
 /// = 500ms per hop chain), which triggers the ACK_TIMEOUT (3s) and OPERATION_TTL (60s)
 /// timing windows that are invisible in zero-latency simulations.
-// Long-running diagnostic test (~3min). Run with:
-// cargo test -p freenet --features "simulation_tests,testing" --test simulation_integration -- --ignored test_get_reliability_with_latency
-#[ignore]
+// Long-running diagnostic test (~3min). Runs in nightly CI.
+#[cfg(feature = "nightly_tests")]
 #[test_log::test]
 fn test_get_reliability_with_latency() {
     use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
@@ -7933,9 +7931,8 @@ fn test_get_reliability_with_latency() {
 ///
 /// Measures GET success rate under these conditions to see if churn degrades
 /// reliability beyond what static routing exhaustion causes.
-// Long-running diagnostic test (~4min). Run with:
-// cargo test -p freenet --features "simulation_tests,testing" --test simulation_integration -- --ignored test_get_reliability_with_churn
-#[ignore]
+// Long-running diagnostic test (~4min). Runs in nightly CI.
+#[cfg(feature = "nightly_tests")]
 #[test_log::test]
 fn test_get_reliability_with_churn() {
     use freenet::dev_tool::ChurnConfig;


### PR DESCRIPTION
## Problem

The 3 GET reliability diagnostic tests added in #3583 use `#[ignore]` which means they never run automatically. They should run in the nightly CI workflow.

## Solution

- Switch `#[ignore]` → `#[cfg(feature = "nightly_tests")]` on all 3 tests, matching the existing convention for long-running tests (`test_long_running_deterministic`, `test_subscription_renewal_at_scale`, etc.)
- Clarify the `SendAndComplete` error comment in `operations.rs`: relay nodes have no retry path — the op state was consumed by `process_message`, so the tx sits in `under_progress` until 5× TTL cleanup. The originator recovers independently via speculative retry.
- Fix pre-existing clippy warnings in subscribe tests (wildcard match arms, `clone` → `from_ref`)

## Related issues

- #3529 — `case_37_n8_g1_s2` aarch64 divergence (already worked around with seed change; verify still passes in nightly)
- #3527 — intermediate nodes have `stats: None`, invisible to health tracking (related to relay failure handling)

## Testing

- `cargo clippy --all-targets --features "simulation_tests,testing"` — clean
- `cargo clippy --all-targets --features "simulation_tests,testing,nightly_tests"` — clean
- Tests will run automatically in nightly via `simulation-nightly.yml`

## Refs

Follows up on #3583 (merged)