### PR TITLE
fix: exempt gateway connections from zombie transport cleanup

### DIFF
--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -454,7 +454,12 @@ fn is_zombie(
     // The exemption is time-bounded: truly dead gateway connections (no
     // traffic for 1 hour) are still cleaned up. The transport-level idle
     // timeout is the primary backstop, but this ensures no permanent leaks.
-    if is_gateway && created_at_elapsed < Duration::from_secs(3600) {
+    /// Gateway connections get a generous exemption window (1 hour) because they
+    /// are intentionally transient but needed for routing. The transport-level
+    /// idle timeout (120s keepalive) is the primary cleanup mechanism for dead
+    /// gateways; this threshold is the safety net.
+    const GATEWAY_ZOMBIE_EXEMPTION: Duration = Duration::from_secs(3600);
+    if is_gateway && created_at_elapsed < GATEWAY_ZOMBIE_EXEMPTION {
         return false;
     }
     if created_at_elapsed > zombie_threshold && !has_pending {


### PR DESCRIPTION
## Problem

Gateway transient connections are incorrectly classified as zombies by the transport cleanup, causing a ~90-second death spiral: prune → reconnect (transient) → zombie cleanup → prune → repeat. This prevents ALL streaming transfers from completing, giving users a 0% routing success rate.

Discovered via user diagnostic report XWNSRQ — a node with 13 ring connections on 1Gbps fiber couldn't fetch any contracts. Router snapshot showed `failure_events=301, success_events=0` across 30+ minutes. Gateway-side logs confirmed the peer kept reconnecting with a new identity every ~90 seconds.

**User impact**: River and all contracts unreachable. GET requests time out, streaming transfers fail with `OrphanStreamClaimFailed`.

## Approach

The root cause chain:
1. Reconnections to known gateways always set `is_gw=true` → `transient=true` (p2p_protoc.rs:1167)
2. Transient connections are NOT added to ring topology
3. After `transient_ttl * 3` (90s), zombie cleanup sees: old transport, not in ring, no pending → zombie
4. `drop_zombie_connection` prunes the gateway → node reconnects as transient → cycle repeats

The zombie check (`is_zombie()`) already exempts ring connections (`if in_ring { return false }`), but gateway transients are *intentionally* not in the ring — they serve as routing relays. The check correctly identifies them as unpromoted, but incorrectly classifies them as disposable.

**Fix**: Add `is_gateway` parameter to `is_zombie()` and exempt gateway connections. This is the minimal correct fix — gateway transients are not zombies, they're working as designed.

## Testing

- New unit test `test_zombie_detection_ignores_gateway_connections`: verifies gateway connections are never classified as zombies even past the absolute threshold
- All 12 existing zombie detection tests updated with new parameter and still pass
- `cargo fmt` + `cargo clippy` clean

Closes #3595

[AI-assisted - Claude]