### PR TITLE
fix: reject Subscribe when contract WASM not cached locally

### DIFF
--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1541,37 +1541,68 @@ async fn process_open_request(
                         // Without WASM, the node can't validate or apply updates,
                         // leading to a "subscribed but can't update" state.
                         // Clients must PUT or GET (with return_contract_code=true) first.
-                        let has_contract = op_manager
+                        //
+                        // Note: This only guards explicit ContractRequest::Subscribe.
+                        // GET+subscribe=true and PUT+subscribe=true bypass this check
+                        // because those operations inherently fetch/provide the WASM.
+                        match op_manager
                             .notify_contract_handler(
                                 crate::contract::ContractHandlerEvent::GetQuery {
                                     instance_id: key,
                                     return_contract_code: true,
                                 },
                             )
-                            .await;
-                        let has_wasm = matches!(
-                            has_contract,
+                            .await
+                        {
                             Ok(crate::contract::ContractHandlerEvent::GetResponse {
-                                response: Ok(crate::contract::StoreResponse {
-                                    state: Some(_),
-                                    contract: Some(_),
-                                }),
+                                response:
+                                    Ok(crate::contract::StoreResponse {
+                                        state: Some(_),
+                                        contract: Some(_),
+                                    }),
                                 ..
-                            })
-                        );
-                        if !has_wasm {
-                            tracing::warn!(
-                                client_id = %client_id,
-                                request_id = %request_id,
-                                contract = %key,
-                                "Rejecting SUBSCRIBE: contract WASM not cached locally. \
-                                 PUT the contract or GET with return_contract_code=true first."
-                            );
-                            return Err(Error::Node(format!(
-                                "Cannot subscribe to contract {key}: contract WASM/parameters \
-                                 not cached locally. PUT the contract or GET with \
-                                 return_contract_code=true before subscribing."
-                            )));
+                            }) => {
+                                // Contract WASM and state are cached locally, proceed
+                            }
+                            Ok(crate::contract::ContractHandlerEvent::GetResponse { .. }) => {
+                                tracing::warn!(
+                                    client_id = %client_id,
+                                    request_id = %request_id,
+                                    contract = %key,
+                                    "Rejecting SUBSCRIBE: contract WASM not cached locally. \
+                                     PUT the contract or GET with return_contract_code=true first."
+                                );
+                                return Err(Error::Node(format!(
+                                    "Cannot subscribe to contract {key}: contract WASM/parameters \
+                                     not cached locally. PUT the contract or GET with \
+                                     return_contract_code=true before subscribing."
+                                )));
+                            }
+                            Err(err) => {
+                                tracing::error!(
+                                    client_id = %client_id,
+                                    request_id = %request_id,
+                                    contract = %key,
+                                    error = %err,
+                                    "Contract handler error while checking WASM for SUBSCRIBE"
+                                );
+                                return Err(Error::Node(format!(
+                                    "Cannot subscribe to contract {key}: \
+                                     failed to query contract store: {err}"
+                                )));
+                            }
+                            Ok(unexpected) => {
+                                tracing::error!(
+                                    client_id = %client_id,
+                                    request_id = %request_id,
+                                    contract = %key,
+                                    "Unexpected contract handler response for SUBSCRIBE WASM check: {unexpected:?}"
+                                );
+                                return Err(Error::Node(format!(
+                                    "Cannot subscribe to contract {key}: \
+                                     unexpected contract handler response"
+                                )));
+                            }
                         }
 
                         let Some(subscriber_listener) = subscription_listener else {

--- a/crates/core/tests/error_notification.rs
+++ b/crates/core/tests/error_notification.rs
@@ -309,6 +309,86 @@ async fn test_subscribe_failure_notifies_client(ctx: &mut TestContext) -> TestRe
     Ok(())
 }
 
+/// Subscribe without prior PUT is rejected immediately with a descriptive error.
+///
+/// When a client subscribes to a contract that hasn't been PUT or GET'd (with
+/// return_contract_code=true), the node lacks the WASM needed to validate updates.
+/// The Subscribe must be rejected fast (not after a network timeout).
+///
+/// Regression test for #3601.
+#[freenet_test(
+    health_check_readiness = true,
+    nodes = ["gateway"],
+    timeout_secs = 60,
+    startup_wait_secs = 15,
+    tokio_flavor = "multi_thread",
+    tokio_worker_threads = 4
+)]
+async fn test_subscribe_without_wasm_rejected(ctx: &mut TestContext) -> TestResult {
+    let gateway = ctx.gateway()?;
+    let (ws_stream, _) = connect_async(&gateway.ws_url()).await?;
+    let mut client = WebApi::start(ws_stream);
+
+    const TEST_CONTRACT: &str = "test-contract-integration";
+    let contract = load_contract(TEST_CONTRACT, vec![42u8; 32].into())?;
+
+    // Subscribe WITHOUT prior PUT — should be rejected quickly
+    make_subscribe(&mut client, contract.key()).await?;
+
+    let start = tokio::time::Instant::now();
+    let mut got_rejection = false;
+
+    // The rejection should arrive fast (seconds, not minutes)
+    while start.elapsed() < Duration::from_secs(15) {
+        match timeout(Duration::from_secs(5), client.recv()).await {
+            Ok(Err(e)) => {
+                let err_str = format!("{e}");
+                if err_str.contains("WASM") || err_str.contains("not cached locally") {
+                    got_rejection = true;
+                    info!("Got expected WASM rejection error: {err_str}");
+                    break;
+                } else {
+                    // Any error counts as rejection (handler error, etc.)
+                    got_rejection = true;
+                    info!("Got error (not WASM-specific): {err_str}");
+                    break;
+                }
+            }
+            Ok(Ok(HostResponse::ContractResponse(
+                freenet_stdlib::client_api::ContractResponse::SubscribeResponse {
+                    subscribed: false,
+                    ..
+                },
+            ))) => {
+                got_rejection = true;
+                info!("Got SubscribeResponse with subscribed=false");
+                break;
+            }
+            Ok(Ok(other)) => {
+                tracing::debug!("Skipping unrelated response: {other}");
+            }
+            Err(_) => break, // timeout
+        }
+    }
+
+    assert!(
+        got_rejection,
+        "Subscribe without prior PUT should be rejected, but no error received within 15s"
+    );
+    // Verify it was fast (not a network timeout)
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "Rejection took too long ({:?}), should be immediate",
+        start.elapsed()
+    );
+
+    client
+        .send(ClientRequest::Disconnect { cause: None })
+        .await?;
+
+    Ok(())
+}
+
 /// Test that errors are delivered when a peer connection drops
 ///
 /// This test verifies that when a connection to a peer is lost during an operation,


### PR DESCRIPTION
## Problem

A client can successfully send `ContractRequest::Subscribe` for a contract the node has never seen (no prior GET or PUT). The subscribe succeeds — the node joins the subscription tree and receives UPDATE broadcasts — but it cannot process those updates because it lacks the contract WASM and parameters.

This creates a confusing state where the node is "subscribed" but can't validate or apply any updates. Any subsequent `ContractRequest::Update` fails with "missing contract parameters".

Discovered via River's invite acceptance flow (freenet/river#179).

## Approach

Added a check in the client API Subscribe handler (`client_events.rs`) that queries the local contract store for both state and WASM code before allowing the subscription. If either is missing, returns an error instructing the client to PUT or GET (with `return_contract_code=true`) first.

This is Option A (strict) from the issue — it forces the client to register the contract properly before subscribing, preventing the "subscribed but can't update" state entirely.

The companion River PR (freenet/river#180) ensures River always requests contract code before subscribing.

## Deploy order

1. Deploy River fix first (backward-compatible with current freenet-core)
2. Deploy this freenet-core change (River already doing the right thing)

## Testing

- All existing tests pass (`cargo test -p freenet --lib -- subscribe` — 96 passed, 2 ignored)
- `cargo clippy` clean
- The ping app tests already guard Subscribe behind `has_contract` checks, so they are unaffected

Closes #3601

[AI-assisted - Claude]