### PR TITLE
fix: add allow-popups-to-escape-sandbox to gateway iframe

### DIFF
--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -158,6 +158,20 @@ async fn web_home(
         .unwrap_or(false);
 
     if is_sandbox {
+        // Block top-level navigation to sandbox URLs. With allow-popups-to-escape-sandbox
+        // on the iframe, a malicious contract could window.open() its own URL to escape
+        // the sandbox and gain same-origin access to the API. Sec-Fetch-Dest: iframe
+        // is set by the browser automatically and cannot be spoofed by scripts.
+        let fetch_dest = req_headers
+            .get("sec-fetch-dest")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if fetch_dest == "document" {
+            // Top-level navigation to a sandbox URL — redirect to the shell page instead
+            let shell_url = format!("/{}/contract/web/{key}/", api_version.prefix());
+            return Ok(axum::response::Redirect::to(&shell_url).into_response());
+        }
+
         // Serve sandbox content (contract HTML + WS shim) inside the iframe.
         // No auth token or cookie — the shell page handles auth via postMessage.
         let contract_response = path_handlers::serve_sandbox_content(key, api_version).await?;

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -3,8 +3,10 @@
 //! Contract web apps are served inside sandboxed iframes to provide origin isolation.
 //! The local API server returns a "shell" page that holds the auth token and
 //! proxies WebSocket connections via postMessage, while the contract runs in an
-//! `<iframe sandbox="allow-scripts allow-forms">` with an opaque origin that cannot
-//! access other contracts' data.
+//! `<iframe sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox">`
+//! with an opaque origin that cannot access other contracts' data.
+//! `allow-popups-to-escape-sandbox` lets external links open normally; sandbox content
+//! is protected from top-level access via Sec-Fetch-Dest checks in client_api.rs.
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Problem

When clicking a link inside River (or any Freenet webapp), the link opens in a new browser tab but the target website is broken with CORS errors like:

> Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource. (Reason: CORS header 'Access-Control-Allow-Origin' missing)

Copying the URL and pasting it into a new tab works fine. This is because the gateway's iframe sandbox uses `allow-popups` but not `allow-popups-to-escape-sandbox` — new tabs opened from the sandbox inherit the sandbox restrictions, giving them a null/opaque origin that breaks all cross-origin requests.

## Approach

1. **Add `allow-popups-to-escape-sandbox`** to the iframe's sandbox attribute. This lets popups (new tabs opened via `target="_blank"`) escape the sandbox and behave as normal browser tabs.

2. **Block top-level navigation to sandbox URLs** via `Sec-Fetch-Dest` header check. Without this, a malicious contract could call `window.open(location.href)` to open its own `?__sandbox=1` URL as a top-level page, escaping the sandbox and gaining same-origin API access. When the server detects `Sec-Fetch-Dest: document` on a sandbox content request, it redirects to the shell page instead of serving the raw contract HTML. `Sec-Fetch-Dest` is set automatically by the browser and cannot be spoofed by scripts.

**Security analysis**: The iframe itself remains fully sandboxed (no `allow-same-origin`, no `allow-top-navigation`). Only new tabs escape the sandbox, and the `Sec-Fetch-Dest` check prevents contracts from exploiting this to gain unsandboxed access to their own content.

## Testing

- All 46 server module tests pass, including the updated sandbox attribute test
- Manual reproduction: click a link in River → target site should load normally
- Security: `window.open(location.href)` from a contract → redirected to shell page, not raw content

Closes #3613

[AI-assisted - Claude]