### PR TITLE
chore: restore original seed for CRDT 8-node 1-gateway test case

### DIFF
--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2587,8 +2587,7 @@ use freenet::dev_tool::{register_crdt_contract, NodeLabel, ScheduledOperation, S
 #[case::n7_g1_s4("crdt-7n-1gw-s4", 0x2773_0007_0010, 1, 7)]
 #[case::n7_g1_s5("crdt-7n-1gw-s5", 0x2773_0007_0005, 1, 7)]
 #[case::n8_g1_s1("crdt-8n-1gw-s1", 0x2773_0008_0001, 1, 8)]
-// Seed changed from 0x2773_0008_0002: original diverges on aarch64 CI (#3529)
-#[case::n8_g1_s2("crdt-8n-1gw-s2", 0x2773_0008_0012, 1, 8)]
+#[case::n8_g1_s2("crdt-8n-1gw-s2", 0x2773_0008_0002, 1, 8)]
 #[case::n8_g1_s3("crdt-8n-1gw-s3", 0x2773_0008_0003, 1, 8)]
 #[case::n8_g1_s4("crdt-8n-1gw-s4", 0x2773_0008_0004, 1, 8)]
 #[case::n8_g1_s5("crdt-8n-1gw-s5", 0x2773_0008_0005, 1, 8)]


### PR DESCRIPTION
## Summary
Reverts the test seed for the `n8_g1_s2` CRDT simulation test case back to its original value, removing the workaround that was previously applied.

## Changes
- Restored the original seed value `0x2773_0008_0002` for the `crdt-8n-1gw-s2` test case
- Removed the comment referencing issue #3529 that explained the seed change was needed to avoid divergence on aarch64 CI

## Details
The seed was previously changed from `0x2773_0008_0002` to `0x2773_0008_0012` as a workaround for a divergence issue observed on aarch64 CI. This change restores the original seed, indicating that the underlying issue has been resolved and the test now passes consistently across all platforms.

https://claude.ai/code/session_01KU8i59Woff9gA1nedso9jS