### PR TITLE
fix: replace shuffle with age-based sorting for subscribe retry fairness

### DIFF
--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1725,8 +1725,9 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                             // Sort by age (oldest first) to guarantee fairness:
                             // shuffle would cause probabilistic starvation when
                             // candidates consistently exceed the per-tick cap.
-                            retry_candidates
-                                .sort_by(|a, b| b.elapsed().cmp(&a.elapsed()));
+                            retry_candidates.sort_by_cached_key(|tx| {
+                                std::cmp::Reverse(tx.elapsed())
+                            });
                         }
 
                         for tx in retry_candidates.into_iter().take(MAX_SUBSCRIBE_RETRIES_PER_TICK) {
@@ -2881,5 +2882,65 @@ mod tests {
             // Should not panic or record anything
             record_connect_uphill_timeout(&tx, &op, &cm);
         }
+    }
+
+    /// Regression test for #3535: age-based retry prioritization prevents starvation.
+    ///
+    /// When retry candidates exceed MAX_SUBSCRIBE_RETRIES_PER_TICK, the oldest
+    /// transactions must be processed first (FIFO fairness). Random shuffling
+    /// would cause probabilistic starvation where some transactions could timeout
+    /// without ever being retried.
+    #[test]
+    fn subscribe_retry_candidates_sorted_oldest_first() {
+        use crate::config::GlobalSimulationTime;
+        use crate::operations::subscribe::SubscribeMsg;
+
+        let base_time: u64 = 1_700_000_000_000; // arbitrary epoch ms
+
+        // Create transactions at different simulation times so they have
+        // different ages. Oldest transaction is created first (lowest timestamp).
+        let mut txs = Vec::new();
+        for i in 0..20u64 {
+            GlobalSimulationTime::set_time_ms(base_time + i * 1000);
+            txs.push(Transaction::new::<SubscribeMsg>());
+        }
+
+        // Advance simulation time so elapsed() returns meaningful durations.
+        // tx[0] was created at base_time, tx[19] at base_time + 19s.
+        // At base_time + 30s: tx[0].elapsed() = 30s, tx[19].elapsed() = 11s.
+        GlobalSimulationTime::set_time_ms(base_time + 30_000);
+
+        // Shuffle to simulate arbitrary DashMap iteration order.
+        let mut candidates = txs.clone();
+        candidates.reverse();
+
+        // Apply the same sorting logic used in garbage_cleanup_task.
+        candidates.sort_by_cached_key(|tx| std::cmp::Reverse(tx.elapsed()));
+
+        // Verify: oldest transactions (largest elapsed) come first.
+        for window in candidates.windows(2) {
+            assert!(
+                window[0].elapsed() >= window[1].elapsed(),
+                "candidates not sorted oldest-first: {:?} < {:?}",
+                window[0].elapsed(),
+                window[1].elapsed(),
+            );
+        }
+
+        // The first candidate should be the oldest transaction (txs[0]).
+        assert_eq!(
+            candidates[0].elapsed(),
+            txs[0].elapsed(),
+            "oldest transaction should be first after sorting"
+        );
+
+        // The last candidate should be the newest transaction (txs[19]).
+        assert_eq!(
+            candidates[19].elapsed(),
+            txs[19].elapsed(),
+            "newest transaction should be last after sorting"
+        );
+
+        GlobalSimulationTime::clear_time();
     }
 }


### PR DESCRIPTION
## Summary
Changed the subscribe retry candidate selection strategy from random shuffling to deterministic age-based sorting to prevent starvation when retry candidates exceed the per-tick processing limit.

## Key Changes
- Replaced `GlobalRng::shuffle()` with a deterministic sort by elapsed time (oldest first)
- This ensures candidates that have been waiting longest are processed first, guaranteeing fairness
- Addresses a probabilistic starvation issue where shuffle could cause some candidates to be perpetually skipped when the retry queue consistently exceeds `MAX_SUBSCRIBE_RETRIES_PER_TICK`

## Implementation Details
- Candidates are now sorted in descending order of elapsed time (`b.elapsed().cmp(&a.elapsed())`) so older candidates appear first
- The `take(MAX_SUBSCRIBE_RETRIES_PER_TICK)` operation then processes the oldest candidates first
- This provides deterministic, fair scheduling rather than probabilistic fairness from shuffling

Closes #3535