### PR TITLE
fix: downgrade missing delegate errors from ERROR to WARN

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -115,12 +115,21 @@ where
                 return accumulated_messages;
             }
             Err(err) => {
-                tracing::error!(
-                    delegate_key = %delegate_key,
-                    error = %err,
-                    phase = "execution_failed",
-                    "Failed executing delegate request"
-                );
+                // Downgrade "not found" to warn — expected during legacy
+                // migration probes when old delegate WASM isn't on this node
+                if err.is_missing_delegate() {
+                    tracing::warn!(
+                        delegate_key = %delegate_key,
+                        "Delegate not found in store (expected for migration probes)"
+                    );
+                } else {
+                    tracing::error!(
+                        delegate_key = %delegate_key,
+                        error = %err,
+                        phase = "execution_failed",
+                        "Failed executing delegate request"
+                    );
+                }
                 // Return whatever we accumulated so far
                 return accumulated_messages;
             }

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -256,6 +256,19 @@ impl ExecutorError {
         self.fatal
     }
 
+    /// Returns true if the error is due to a missing delegate (not found in store).
+    /// This is expected during legacy migration probes and should be logged at
+    /// warn level rather than error.
+    pub fn is_missing_delegate(&self) -> bool {
+        matches!(
+            &self.inner,
+            Either::Left(err) if matches!(
+                err.as_ref(),
+                RequestError::DelegateError(StdDelegateError::Missing(_))
+            )
+        )
+    }
+
     pub fn unwrap_request(self) -> RequestError {
         match self.inner {
             Either::Left(err) => *err,

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2536,16 +2536,25 @@ impl Executor<Runtime> {
                 ) {
                     Ok(values) => Ok(DelegateResponse { key, values }),
                     Err(err) => {
-                        tracing::error!(
-                            delegate_key = %key,
-                            error = %err,
-                            phase = "execution_failed",
-                            "Failed executing delegate"
-                        );
-                        Err(ExecutorError::execution(
-                            err,
-                            Some(InnerOpError::Delegate(key)),
-                        ))
+                        let key_display = key.to_string();
+                        let exec_err =
+                            ExecutorError::execution(err, Some(InnerOpError::Delegate(key)));
+                        // Downgrade "not found" to warn — expected during legacy
+                        // migration probes when old delegate WASM isn't on this node
+                        if exec_err.is_missing_delegate() {
+                            tracing::warn!(
+                                delegate_key = %key_display,
+                                "Delegate not found in store (expected for migration probes)"
+                            );
+                        } else {
+                            tracing::error!(
+                                delegate_key = %key_display,
+                                error = %exec_err,
+                                phase = "execution_failed",
+                                "Failed executing delegate"
+                            );
+                        }
+                        Err(exec_err)
                     }
                 }
             }


### PR DESCRIPTION
## Problem

When River's UI starts up, it probes legacy delegate keys to migrate room data from old delegate versions. On nodes that never had those old delegates, the node logs ERROR-level messages for each missing delegate — typically 7-8 errors in rapid succession on every page load. This alarms users who see a wall of red errors in their logs despite everything working correctly.

Example from user report: https://gist.github.com/Ivvvor/20fca531360d4de581aec793e57527bf

## Solution

Add `ExecutorError::is_missing_delegate()` to distinguish "delegate not found in store" from other execution failures. At both log sites (`contract/executor/runtime.rs` and `contract.rs`), check this before logging and downgrade to WARN with an explanatory message.

Real delegate execution failures (WASM errors, missing secrets, etc.) remain at ERROR level.

## Testing

- `cargo test -p freenet` — 2089 passed, 85 ignored
- `cargo clippy --all-targets` — clean

[AI-assisted - Claude]