### PR TITLE
fix: add display:block to sandbox iframe to eliminate baseline gap

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -343,7 +343,7 @@ fn shell_page(
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Freenet</title>
 <link rel="icon" type="image/svg+xml" href="{favicon}">
-<style>*{{margin:0;padding:0}}html,body{{width:100%;height:100%;overflow:hidden}}iframe{{width:100%;height:100%;border:none}}</style>
+<style>*{{margin:0;padding:0}}html,body{{width:100%;height:100%;overflow:hidden}}iframe{{width:100%;height:100%;border:none;display:block}}</style>
 </head>
 <body>
 <iframe id="app" sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox" src="{iframe_src}"></iframe>


### PR DESCRIPTION
## Problem

Any webapp served through the Freenet gateway shows a few pixels of white lines at the bottom of the page. This is visible in River UI and would affect any other contract UI.

## Approach

The `<iframe>` element defaults to `display: inline`, which means the browser reserves space below it for text descenders (the baseline gap — space for the bottom of characters like "g", "y", "p"). Adding `display: block` to the iframe's inline styles eliminates this gap entirely.

This is a well-known HTML/CSS issue with inline-replaced elements. The fix is a single CSS property addition with zero risk of side effects.

## Testing

- Visual inspection: white lines at bottom of River UI are eliminated
- No behavioral change — only affects iframe layout positioning

[AI-assisted - Claude]