### PR TITLE
fix: update freenet-stdlib to 0.3.5 for native build compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ dependencies = [
  "dashmap",
  "either",
  "freenet",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "futures 0.3.32",
  "glob",
  "http 1.4.0",
@@ -1743,7 +1743,7 @@ dependencies = [
  "flatbuffers 25.12.19",
  "flate2",
  "freenet-macros 0.1.0",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "freenet-test-network",
  "futures 0.3.32",
  "gag",
@@ -1848,7 +1848,7 @@ dependencies = [
  "clap",
  "freenet",
  "freenet-ping-types",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "freenet-test-network",
  "futures 0.3.32",
  "humantime",
@@ -1870,7 +1870,7 @@ name = "freenet-ping-contract"
 version = "0.1.11"
 dependencies = [
  "freenet-ping-types",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "serde_json",
 ]
 
@@ -1880,7 +1880,7 @@ version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "humantime",
  "humantime-serde",
  "serde",
@@ -1917,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -5431,7 +5431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5461,7 +5461,7 @@ dependencies = [
 name = "test-contract-integration"
 version = "0.1.11"
 dependencies = [
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "serde",
  "serde_json",
 ]
@@ -5471,14 +5471,14 @@ name = "test-contract-mock-aligned"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
 ]
 
 [[package]]
 name = "test-contract-update-nochange"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ winapi = "0.3"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet
-freenet-stdlib = "0.3.4"
+freenet-stdlib = "0.3.5"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/apps/freenet-microblogging/Cargo.lock
+++ b/apps/freenet-microblogging/Cargo.lock
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "bincode",
  "blake3",

--- a/apps/freenet-microblogging/Cargo.toml
+++ b/apps/freenet-microblogging/Cargo.toml
@@ -14,7 +14,7 @@ panic = 'abort'
 strip = true
 
 [workspace.dependencies]
-freenet-stdlib = { version = "0.3.4", default-features = false, features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", default-features = false, features = ["contract"] }
 
 #[target.wasm32-unknown-unknown]
 #rustflags = ["-C", "link-arg=--import-memory"]

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
  "event-listener",
  "flatbuffers 25.12.19",
  "flate2",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "futures",
  "gag",
  "headers",
@@ -1364,7 +1364,7 @@ dependencies = [
  "clap",
  "freenet",
  "freenet-ping-types",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "freenet-test-network",
  "futures",
  "humantime",
@@ -1386,7 +1386,7 @@ name = "freenet-ping-contract"
 version = "0.1.11"
 dependencies = [
  "freenet-ping-types",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "serde_json",
 ]
 
@@ -1396,7 +1396,7 @@ version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
- "freenet-stdlib 0.3.4",
+ "freenet-stdlib 0.3.5",
  "humantime",
  "humantime-serde",
  "serde",
@@ -1433,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -2184,14 +2184,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d72a21f6a71a6c4c3160e095e8925861f5119dd26ef71acee1b9146f74f76c8"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
  "socket2",
  "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
- "winreg",
 ]
 
 [[package]]
@@ -5171,6 +5172,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5211,15 +5223,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5391,16 +5394,6 @@ name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
-
-[[package]]
-name = "winreg"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
-dependencies = [
- "cfg-if",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/apps/freenet-ping/Cargo.toml
+++ b/apps/freenet-ping/Cargo.toml
@@ -4,7 +4,7 @@ members = ["contracts/ping", "app", "types"]
 
 [workspace.dependencies]
 # freenet-stdlib = { path = "./../../stdlib/rust", features = ["contract"] }
-freenet-stdlib = { version = "0.3.4" }
+freenet-stdlib = { version = "0.3.5" }
 freenet-ping-types = { path = "types", default-features = false }
 
 # Core dependencies

--- a/tests/test-app-1/Cargo.toml
+++ b/tests/test-app-1/Cargo.toml
@@ -14,4 +14,4 @@ panic = 'abort'
 strip = true
 
 [workspace.dependencies]
-freenet-stdlib = { version = "0.3.4", default-features = false }
+freenet-stdlib = { version = "0.3.5", default-features = false }

--- a/tests/test-contract-1/Cargo.lock
+++ b/tests/test-contract-1/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-contract-1/Cargo.toml
+++ b/tests/test-contract-1/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 
 [features]
 default = ["freenet-main-contract"]

--- a/tests/test-contract-2/Cargo.lock
+++ b/tests/test-contract-2/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-contract-2/Cargo.toml
+++ b/tests/test-contract-2/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 
 [features]
 default = ["freenet-main-contract"]

--- a/tests/test-contract-metering/Cargo.lock
+++ b/tests/test-contract-metering/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-contract-metering/Cargo.toml
+++ b/tests/test-contract-metering/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 
 [features]

--- a/tests/test-delegate-2/Cargo.lock
+++ b/tests/test-delegate-2/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-2/Cargo.toml
+++ b/tests/test-delegate-2/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 serde = "1"
 serde_json = "1"
 bincode = "1"

--- a/tests/test-delegate-attested/Cargo.toml
+++ b/tests/test-delegate-attested/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 

--- a/tests/test-delegate-capabilities/Cargo.lock
+++ b/tests/test-delegate-capabilities/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-capabilities/Cargo.toml
+++ b/tests/test-delegate-capabilities/Cargo.toml
@@ -10,7 +10,7 @@ description = "Test delegate for exercising all delegate capabilities in issue #
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 

--- a/tests/test-delegate-creation/Cargo.toml
+++ b/tests/test-delegate-creation/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 

--- a/tests/test-delegate-integration/Cargo.toml
+++ b/tests/test-delegate-integration/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 serde = "1"
 serde_json = "1"
 bincode = "1"

--- a/tests/test-delegate-messaging/Cargo.lock
+++ b/tests/test-delegate-messaging/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-messaging/Cargo.toml
+++ b/tests/test-delegate-messaging/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 

--- a/tests/test-delegate-v2-contracts/Cargo.lock
+++ b/tests/test-delegate-v2-contracts/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef488e176c95a18617414d4861dfd205d92a114afb006572fe6dd3e1fd055d09"
+checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-v2-contracts/Cargo.toml
+++ b/tests/test-delegate-v2-contracts/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.4", features = ["contract"] }
+freenet-stdlib = { version = "0.3.5", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 


### PR DESCRIPTION
## Summary
Update all freenet-stdlib dependencies from 0.3.4 to 0.3.5.

## Problem
stdlib 0.3.4 gates `__frnt__fill_buffer` extern with `#[cfg(not(test))]`, which still links the extern on native (non-WASM) builds when the `contract` feature is enabled. This causes linker errors (`Undefined symbols: ___frnt__fill_buffer`) when contract crates are compiled for native targets (release script verification, test builds).

## Fix
stdlib 0.3.5 uses `#[cfg(target_family = "wasm")]` instead, providing a stub on native builds.

## Test plan
- [x] `cargo build` passes (was failing with linker errors on 0.3.4)
- [x] `cargo clippy` clean