### PR TITLE
fix: backward-compatible streaming buffers for old contracts

### DIFF
--- a/crates/core/src/wasm_runtime/contract.rs
+++ b/crates/core/src/wasm_runtime/contract.rs
@@ -112,25 +112,12 @@ impl ContractRuntimeInterface for super::Runtime {
         let result = (|| -> RuntimeResult<ValidateResult> {
             let linear_mem = self.linear_mem(&running.handle)?;
 
-            let param_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                parameters.as_ref(),
-                STREAMING_BUF_CAP,
-            )?;
-            let state_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                state.as_ref(),
-                STREAMING_BUF_CAP,
-            )?;
-            let related_serialized = bincode::serialize(related)?;
-            let related_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                &related_serialized,
-                STREAMING_BUF_CAP,
-            )?;
+            let param_buf_ptr =
+                self.write_contract_buf(&running, parameters.as_ref(), STREAMING_BUF_CAP)?;
+            let state_buf_ptr =
+                self.write_contract_buf(&running, state.as_ref(), STREAMING_BUF_CAP)?;
+            let related_buf_ptr =
+                self.write_contract_buf_serialized(&running, related, STREAMING_BUF_CAP)?;
 
             let result = self.engine.call_3i64_blocking(
                 &running.handle,
@@ -171,25 +158,12 @@ impl ContractRuntimeInterface for super::Runtime {
         let result = (|| -> RuntimeResult<UpdateModification<'static>> {
             let linear_mem = self.linear_mem(&running.handle)?;
 
-            let param_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                parameters.as_ref(),
-                STREAMING_BUF_CAP,
-            )?;
-            let state_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                state.as_ref(),
-                STREAMING_BUF_CAP,
-            )?;
-            let update_data_serialized = bincode::serialize(update_data)?;
-            let update_data_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                &update_data_serialized,
-                STREAMING_BUF_CAP,
-            )?;
+            let param_buf_ptr =
+                self.write_contract_buf(&running, parameters.as_ref(), STREAMING_BUF_CAP)?;
+            let state_buf_ptr =
+                self.write_contract_buf(&running, state.as_ref(), STREAMING_BUF_CAP)?;
+            let update_data_buf_ptr =
+                self.write_contract_buf_serialized(&running, update_data, STREAMING_BUF_CAP)?;
 
             let result = self.engine.call_3i64_blocking(
                 &running.handle,
@@ -228,18 +202,10 @@ impl ContractRuntimeInterface for super::Runtime {
         let result = (|| -> RuntimeResult<StateSummary<'static>> {
             let linear_mem = self.linear_mem(&running.handle)?;
 
-            let param_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                parameters.as_ref(),
-                STREAMING_BUF_CAP,
-            )?;
-            let state_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                state.as_ref(),
-                STREAMING_BUF_CAP,
-            )?;
+            let param_buf_ptr =
+                self.write_contract_buf(&running, parameters.as_ref(), STREAMING_BUF_CAP)?;
+            let state_buf_ptr =
+                self.write_contract_buf(&running, state.as_ref(), STREAMING_BUF_CAP)?;
 
             let result = self.engine.call_2i64_blocking(
                 &running.handle,
@@ -278,24 +244,12 @@ impl ContractRuntimeInterface for super::Runtime {
         let result = (|| -> RuntimeResult<StateDelta<'static>> {
             let linear_mem = self.linear_mem(&running.handle)?;
 
-            let param_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                parameters.as_ref(),
-                STREAMING_BUF_CAP,
-            )?;
-            let state_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                state.as_ref(),
-                STREAMING_BUF_CAP,
-            )?;
-            let summary_buf_ptr = self.write_streaming_buf(
-                &running.handle,
-                running.id,
-                summary.as_ref(),
-                STREAMING_BUF_CAP,
-            )?;
+            let param_buf_ptr =
+                self.write_contract_buf(&running, parameters.as_ref(), STREAMING_BUF_CAP)?;
+            let state_buf_ptr =
+                self.write_contract_buf(&running, state.as_ref(), STREAMING_BUF_CAP)?;
+            let summary_buf_ptr =
+                self.write_contract_buf(&running, summary.as_ref(), STREAMING_BUF_CAP)?;
 
             let result = self.engine.call_3i64_blocking(
                 &running.handle,

--- a/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
+++ b/crates/core/src/wasm_runtime/engine/wasmtime_engine.rs
@@ -713,6 +713,15 @@ fn refresh_mem_addr_from_caller(caller: &mut Caller<'_, HostState>, instance_id:
 }
 
 impl WasmtimeEngine {
+    /// Check if a compiled module imports the streaming buffer host function.
+    /// Contracts compiled against freenet-stdlib >= 0.3.4 import `freenet_contract_io`;
+    /// older contracts do not and must use the legacy one-shot buffer protocol.
+    pub(crate) fn module_has_streaming_io(&self, module: &Module) -> bool {
+        module
+            .imports()
+            .any(|import| import.module() == "freenet_contract_io")
+    }
+
     /// Create a new backend engine that can be shared across multiple Runtime instances.
     pub(crate) fn create_backend_engine(config: &RuntimeConfig) -> Result<Engine, ContractError> {
         let (engine, _, _) = Self::create_engine(config)?;
@@ -2039,6 +2048,46 @@ mod tests {
             after_refresh_maps < leaked_maps,
             "Store refresh should reduce memory maps: \
              before_refresh={leaked_maps}, after_refresh={after_refresh_maps}"
+        );
+    }
+
+    #[test]
+    fn test_module_without_streaming_io_detected_as_legacy() {
+        let config = RuntimeConfig::default();
+        let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+
+        // A minimal contract module with no freenet_contract_io import
+        let wat = r#"
+        (module
+          (memory (export "memory") 1)
+          (func (export "validate_state") (param i64 i64 i64) (result i64)
+            i64.const 0))
+        "#;
+        let module = engine.compile(wat.as_bytes()).unwrap();
+        assert!(
+            !engine.module_has_streaming_io(&module),
+            "Legacy module should not have freenet_contract_io imports"
+        );
+    }
+
+    #[test]
+    fn test_module_with_streaming_io_detected() {
+        let config = RuntimeConfig::default();
+        let mut engine = WasmtimeEngine::new(&config, false).unwrap();
+
+        // A contract module that imports the streaming fill buffer function
+        let wat = r#"
+        (module
+          (import "freenet_contract_io" "__frnt__fill_buffer"
+            (func $fill (param i64 i64) (result i32)))
+          (memory (export "memory") 1)
+          (func (export "validate_state") (param i64 i64 i64) (result i64)
+            i64.const 0))
+        "#;
+        let module = engine.compile(wat.as_bytes()).unwrap();
+        assert!(
+            engine.module_has_streaming_io(&module),
+            "Module with freenet_contract_io import should be detected as streaming"
         );
     }
 }

--- a/crates/core/src/wasm_runtime/runtime.rs
+++ b/crates/core/src/wasm_runtime/runtime.rs
@@ -62,6 +62,9 @@ pub const DEFAULT_MODULE_CACHE_CAPACITY: usize = 1024;
 pub(super) struct RunningInstance {
     pub id: i64,
     pub handle: InstanceHandle,
+    /// Whether the contract imports `freenet_contract_io` (streaming buffer support).
+    /// Contracts compiled against stdlib >= 0.3.4 have this; older ones don't.
+    pub supports_streaming: bool,
     /// Set to true when the engine instance has been explicitly cleaned up.
     dropped_from_engine: bool,
 }
@@ -80,9 +83,15 @@ impl RunningInstance {
         let (ptr, size) = engine.memory_info(&handle)?;
         native_api::MEM_ADDR.insert(id, InstanceInfo::new(ptr as i64, size, key));
 
+        // Detect if the contract supports streaming buffers by checking
+        // whether it imports the freenet_contract_io namespace. Contracts
+        // compiled against stdlib >= 0.3.4 have this import.
+        let supports_streaming = engine.module_has_streaming_io(module);
+
         Ok(Self {
             id,
             handle,
+            supports_streaming,
             dropped_from_engine: false,
         })
     }
@@ -377,6 +386,43 @@ impl Runtime {
         }
 
         Ok(ptr)
+    }
+
+    /// Write data into a WASM buffer, choosing between the streaming protocol
+    /// (for contracts compiled against stdlib >= 0.3.4) and the legacy one-shot
+    /// protocol (for older contracts).
+    pub(super) fn write_contract_buf(
+        &mut self,
+        running: &RunningInstance,
+        data: &[u8],
+        max_cap: usize,
+    ) -> RuntimeResult<*mut BufferBuilder> {
+        if running.supports_streaming {
+            self.write_streaming_buf(&running.handle, running.id, data, max_cap)
+        } else {
+            let mut buf = self.init_buf(&running.handle, data)?;
+            buf.write(data)?;
+            Ok(buf.ptr())
+        }
+    }
+
+    /// Write bincode-serialized data into a WASM buffer, choosing between
+    /// streaming and legacy protocols.
+    pub(super) fn write_contract_buf_serialized<T: serde::Serialize + ?Sized>(
+        &mut self,
+        running: &RunningInstance,
+        value: &T,
+        max_cap: usize,
+    ) -> RuntimeResult<*mut BufferBuilder> {
+        if running.supports_streaming {
+            let serialized = bincode::serialize(value)?;
+            self.write_streaming_buf(&running.handle, running.id, &serialized, max_cap)
+        } else {
+            let size = bincode::serialized_size(value)? as usize;
+            let mut buf = self.init_buf_with_capacity(&running.handle, size)?;
+            bincode::serialize_into(&mut buf, value)?;
+            Ok(buf.ptr())
+        }
     }
 
     pub(super) fn linear_mem(&mut self, handle: &InstanceHandle) -> RuntimeResult<WasmLinearMem> {


### PR DESCRIPTION
## Problem
v0.2.12 introduced streaming refill buffers that write a `[total_len: u32]` header into WASM buffers. Contracts compiled against stdlib < 0.3.4 don't understand this header and crash with `unreachable!()` when the host tries to execute them. This breaks all existing deployed contracts on the network.

## Solution
Detect at WASM instantiation time whether the contract imports `freenet_contract_io` (the streaming buffer host function namespace). If the contract **does** import it (stdlib >= 0.3.4), use the streaming protocol. If not, fall back to the legacy one-shot buffer protocol.

## Changes
- Add `module_has_streaming_io()` to `WasmtimeEngine` — checks module imports
- Add `supports_streaming` field to `RunningInstance` — set during `prepare_contract_call`
- Add `write_contract_buf()` and `write_contract_buf_serialized()` dispatchers
- All 4 contract operations use the dispatcher instead of directly calling `write_streaming_buf`

## Test plan
- [x] All 11 WASM conformance tests pass (including 100KB large state)
- [x] Test contracts use new stdlib (streaming path exercised)
- [x] Legacy contracts will use the old path (no streaming header)
- [x] `cargo clippy` clean