### PR TITLE
feat: persist routing history across peer restarts

### DIFF
--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -668,11 +668,16 @@ impl Ring {
         self.event_register.register_events(events).await;
     }
 
+    /// Maximum number of route events to load from the AOF event log on startup
+    /// and during periodic refresh. Caps memory use while retaining enough history
+    /// for the isotonic estimators to converge.
+    const ROUTER_HISTORY_LIMIT: usize = 10_000;
+
     async fn refresh_router<ER: NetEventRegister>(router: Arc<RwLock<Router>>, register: ER) {
         // Load routing history immediately on startup so the router doesn't
         // start cold — without this, peers route suboptimally for ~5 minutes
         // until the first periodic refresh.
-        match register.get_router_events(10_000).await {
+        match register.get_router_events(Self::ROUTER_HISTORY_LIMIT).await {
             Ok(history) if !history.is_empty() => {
                 tracing::info!(
                     events = history.len(),
@@ -692,7 +697,7 @@ impl Ring {
         interval.tick().await;
         loop {
             interval.tick().await;
-            let history = match register.get_router_events(10_000).await {
+            let history = match register.get_router_events(Self::ROUTER_HISTORY_LIMIT).await {
                 Ok(h) => h,
                 Err(error) => {
                     // Previously this was an `expect()` that would silently panic


### PR DESCRIPTION
## Problem

When a peer restarts, the routing model starts cold with no historical data (`Router::new(&[])`). The `refresh_router` background task rebuilds the router from the AOF event log every 5 minutes, but the first rebuild doesn't happen until ~5 minutes after startup. During this window, the router falls back to distance-based routing, leading to suboptimal peer selection.

The renegade predictor (from #3667) is particularly affected — it needs accumulated peer × contract interaction history to make predictions, and starting from zero means ~30 minutes of suboptimal routing after every restart.

## Approach

The AOF event log already persists `RouteEvent`s, and `get_router_events()` already reads them back. The only gap was *when* the initial load happened. This PR loads routing history immediately at the start of `refresh_router` — before entering the periodic interval loop — so the router has historical data from the moment the node starts.

No new persistence format, file, or serialization code is needed. We reuse the exact same `register.get_router_events(10_000)` + `Router::new(&history)` path that the periodic refresh already uses.

## Testing

- `Router::new(&history)` initialization from historical events is covered by existing tests (`test_request_time` in `router.rs`)
- The startup load is a non-failing operation — errors are logged as warnings and the node gracefully falls back to cold start
- Clippy and fmt clean

Closes #3670

[AI-assisted - Claude]