### PR TITLE
build: add bare freenet.exe to release assets

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -322,7 +322,7 @@ jobs:
           cp artifacts/x86_64-windows-freenet/freenet.exe freenet.exe
 
           # Display the created files
-          ls -lh *.tar.gz *.zip
+          ls -lh *.tar.gz *.zip *.exe
 
       - name: Generate SHA256 checksums
         run: |


### PR DESCRIPTION
## Problem

Windows release assets are only available as a zip (`freenet-x86_64-pc-windows-msvc.zip`), requiring users to extract before running. Since freenet.exe now has a setup wizard (PR #3680), the zip adds friction without value — browsers already compress downloads.

## Approach

Copy the bare `freenet.exe` to the release root alongside the existing zip. The zip is kept for backwards compat with `install.ps1`. The bare exe is included in SHA256 checksums and uploaded as a release asset.

## Testing

- CI workflow change only — no code changes
- The `ls -lh` step at the end will show `freenet.exe` alongside the archives
- Existing zip packaging is unchanged

[AI-assisted - Claude]