### PR TITLE
fix: add Win32 message pump for tray icon right-click menu

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -296,6 +296,13 @@ fn sleep_with_jitter_interruptible(
 /// On Windows and macOS, shows a system tray / menu bar icon.
 /// On Linux, runs the wrapper loop directly (no tray).
 fn run_wrapper(version: &str) -> Result<()> {
+    // On Windows, detach from the console so no terminal window is visible.
+    // The wrapper runs as a background service — all output goes to log files.
+    #[cfg(target_os = "windows")]
+    unsafe {
+        winapi::um::wincon::FreeConsole();
+    }
+
     use freenet::tracing::tracer::get_log_dir;
     use std::sync::mpsc;
 

--- a/crates/core/src/bin/commands/tray.rs
+++ b/crates/core/src/bin/commands/tray.rs
@@ -53,22 +53,30 @@ mod platform {
     /// Dispatch pending Win32 messages so the tray-icon crate's hidden HWND
     /// receives user interaction events (WM_USER_TRAYICON → right-click menu).
     /// On macOS, tray-icon uses a Cocoa run-loop internally, so this is a no-op.
+    /// Returns `true` if `WM_QUIT` was received (caller should exit the loop).
     #[cfg(target_os = "windows")]
-    fn pump_platform_messages() {
-        use winapi::um::winuser::{DispatchMessageW, PM_REMOVE, PeekMessageW, TranslateMessage};
+    fn pump_platform_messages() -> bool {
+        use winapi::um::winuser::{
+            DispatchMessageW, PM_REMOVE, PeekMessageW, TranslateMessage, WM_QUIT,
+        };
         // Safety: standard Win32 message pump on the thread that created the HWND.
         unsafe {
             let mut msg = std::mem::zeroed();
             while PeekMessageW(&mut msg, std::ptr::null_mut(), 0, 0, PM_REMOVE) != 0 {
+                if msg.message == WM_QUIT {
+                    return true;
+                }
                 TranslateMessage(&msg);
                 DispatchMessageW(&msg);
             }
         }
+        false
     }
 
     #[cfg(target_os = "macos")]
-    fn pump_platform_messages() {
+    fn pump_platform_messages() -> bool {
         // macOS: tray-icon drives the NSRunLoop internally; nothing to pump.
+        false
     }
 
     /// Build the tray icon from embedded RGBA pixel data of the Freenet logo.
@@ -163,7 +171,10 @@ mod platform {
         loop {
             // Pump platform messages so the tray-icon crate's hidden HWND
             // receives user interaction events (right-click, etc.).
-            pump_platform_messages();
+            if pump_platform_messages() {
+                action_tx.send(TrayAction::Quit).ok();
+                break;
+            }
 
             // Process menu events (non-blocking peek)
             if let Ok(event) = menu_rx.try_recv() {


### PR DESCRIPTION
## Problem

Two cosmetic issues with the Windows tray icon reported by HostFat on Matrix:

1. **No right-click menu** — the tray icon appears but clicking/right-clicking shows no context menu
2. **Console window visible** — the wrapper runs as a console app, showing a terminal window

### Root cause (menu)

The `tray-icon` crate creates a hidden HWND whose window procedure (`tray_proc`) handles right-click events and shows the popup menu via `TrackPopupMenu`. For this to work, a Win32 message pump must dispatch messages on the same thread. Without it, `WM_USER_TRAYICON` messages are queued but never delivered to `tray_proc`. The icon itself appears because `Shell_NotifyIconW` is a direct API call that doesn't need message dispatching.

### Root cause (console)

The wrapper was not calling `FreeConsole()` to detach from the console session when launched at logon.

## Approach

1. Added `pump_platform_messages()` that calls `PeekMessageW`/`TranslateMessage`/`DispatchMessageW` on each loop iteration — the standard Win32 message pump pattern required by the `tray-icon` crate's documentation.
2. Handle `WM_QUIT` in the message pump to avoid hanging on OS shutdown.
3. Call `FreeConsole()` at the start of `run_wrapper` on Windows to hide the console window.

On macOS, `pump_platform_messages` is a no-op since `tray-icon` drives the Cocoa NSRunLoop internally.

## Testing

- Cannot be automated on Linux CI (tray module is `cfg(windows, macos)`)
- Verified Linux build still compiles (`cargo check -p freenet --bin freenet`)
- Follows exact pattern from `tray-icon` crate documentation
- Needs Windows testing by HostFat to confirm

Closes #3691

[AI-assisted - Claude]