### PR TITLE
fix: windows wrapper fails to spawn child after FreeConsole (os error 6)

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -457,17 +457,27 @@ fn run_wrapper_loop(
         cmd.arg("network");
 
         // On Windows, prevent a console window from appearing for the child process.
-        // The wrapper has already detached from the console via FreeConsole().
+        // The wrapper has already detached from the console via FreeConsole(),
+        // which invalidates the standard handles. We must explicitly set
+        // stdin/stdout to null to avoid inheriting the invalid handles
+        // (otherwise spawn fails with "The handle is invalid" os error 6).
         #[cfg(target_os = "windows")]
         {
             use std::os::windows::process::CommandExt;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             cmd.creation_flags(CREATE_NO_WINDOW);
+            cmd.stdin(std::process::Stdio::null());
+            cmd.stdout(std::process::Stdio::null());
         }
 
-        // Redirect stderr to a file for port-conflict detection
+        // Redirect stderr to a file for port-conflict detection.
+        // On Windows, stderr must also be explicitly set to avoid
+        // inheriting the invalid handle after FreeConsole().
         if let Some(stderr_file) = stderr_file {
             cmd.stderr(stderr_file);
+        } else {
+            #[cfg(target_os = "windows")]
+            cmd.stderr(std::process::Stdio::null());
         }
 
         // Use spawn + polling so we can handle tray actions while child runs


### PR DESCRIPTION
## Problem

After the 0.2.20 release added `CREATE_NO_WINDOW` to the child process spawn, Windows users report the node fails to start on reboot:

```
Failed to spawn freenet network: The handle is invalid. (os error 6)
```

The tray app appears and gives the impression things are working, but the node never starts.

## Approach

`FreeConsole()` (called early in the wrapper to detach from the console) invalidates the standard handles (stdin/stdout/stderr). When the wrapper later spawns `freenet network` with `CREATE_NO_WINDOW`, Windows attempts to inherit these now-invalid handles, causing the spawn to fail with OS error 6.

Fix: explicitly set stdin/stdout/stderr to `Stdio::null()` on the child command so Windows doesn't try to inherit the invalid console handles. stderr is also set to null as a fallback when the stderr log file can't be created.

## Testing

- Build verified clean: `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt`
- Windows-only change (`#[cfg(target_os = "windows")]`)

Reported by Ivvor on Matrix (2026-03-29).

[AI-assisted - Claude]