### PR TITLE
fix: replace full-page reload with JS partial update on local peer dashboard

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -2215,4 +2215,30 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn no_meta_refresh_in_homepage() {
+        let html = homepage_html();
+        assert!(
+            !html.contains("http-equiv=\"refresh\""),
+            "meta refresh must not be present — JS partial update is used instead"
+        );
+    }
+
+    #[test]
+    fn no_meta_refresh_in_peer_detail() {
+        let html = peer_detail_html("127.0.0.1:31337");
+        assert!(
+            !html.contains("http-equiv=\"refresh\""),
+            "meta refresh must not be present — JS partial update is used instead"
+        );
+    }
+
+    #[test]
+    fn js_contains_auto_refresh() {
+        assert!(
+            JS.contains("scheduleRefresh"),
+            "JS constant must contain the auto-refresh scheduler"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

The local peer dashboard at `http://127.0.0.1:<port>/` flickers every 5 seconds. This is caused by `<meta http-equiv="refresh" content="5">` which triggers a **full page reload** — the browser briefly shows a blank page, resets scroll position, and re-renders all CSS/fonts, creating visible flicker.

## Approach

Replace the meta refresh with a JavaScript `setInterval` + `fetch()` that:
1. Fetches the current page HTML every 5 seconds
2. Parses it with `DOMParser`
3. Swaps only the dynamic content (`<main>`, uptime, version badge, favicon)

This preserves scroll position, theme state, and avoids any visible flash. The same fix applies to both the homepage (`/`) and peer detail page (`/peer/{addr}`) since they share the same JS constant.

No new endpoint needed — the existing `GET /` response is parsed client-side.

## Testing

- Verified locally: dashboard updates smoothly without flickering
- `cargo fmt` clean
- `cargo clippy` clean
- No behavioral change to the data displayed, only the refresh mechanism

[AI-assisted - Claude]