### PR TITLE
feat: add Delta website builder to local dashboard apps

### DIFF
--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -77,6 +77,10 @@ fn homepage_html() -> String {
                     <a href="/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/">River Chat</a>
                     <p class="note">You'll need an <a href="https://freenet.org/quickstart#invite-form" target="_blank" rel="noopener noreferrer">invite</a> to join the "Freenet Official" room.</p>
                 </li>
+                <li>
+                    <a href="/v1/contract/web/EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr/">Delta</a>
+                    <p class="note">A website builder for Freenet.</p>
+                </li>
             </ul>
         </div>
 


### PR DESCRIPTION
## Summary
- Adds Delta (a website builder for Freenet) to the Freenet Apps section on the local peer dashboard
- Listed alongside River Chat with contract key `EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr`

[AI-assisted - Claude]