### PR TITLE
build: release 0.2.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "fdev"
-version = "0.3.190"
+version = "0.3.191"
 dependencies = [
  "anyhow",
  "axum",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "aes-gcm",
  "ahash",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freenet"
-version = "0.2.27"
+version = "0.2.28"
 edition = "2024"
 rust-version = "1.85"
 publish = true
@@ -13,7 +13,7 @@ readme = "README.md"
 # Minimum compatible protocol version. Peers older than this are rejected.
 # Updated by scripts/release.sh during releases. The env var
 # FREENET_MIN_COMPATIBLE_VERSION overrides this at build time.
-min-compatible-version = "0.2.26"
+min-compatible-version = "0.2.27"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/freenet-{ target }.tar.gz"

--- a/crates/fdev/Cargo.toml
+++ b/crates/fdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdev"
-version = "0.3.190"
+version = "0.3.191"
 edition = "2024"
 rust-version = "1.85"
 publish = true
@@ -44,7 +44,7 @@ reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 http = { workspace = true }
 
 # internal
-freenet = { path = "../core", version = "0.2.27", features = ["testing"] }
+freenet = { path = "../core", version = "0.2.28", features = ["testing"] }
 freenet-stdlib = { workspace = true }
 
 [features]


### PR DESCRIPTION
**Automated release PR**

- freenet: → **0.2.28**
- fdev: → **0.3.191**

This PR will auto-merge once GitHub CI passes.
Generated by: `scripts/release.sh`