### PR TITLE
fix: retry GET with next peer on stream failure instead of erroring

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -2767,7 +2767,7 @@ impl Operation for GetOp {
                             let stalled_peer_info = retry_op.failure_routing_info();
 
                             match retry_op.retry_with_next_alternative(max_htl, &all_connected) {
-                                Ok((new_op, msg)) => {
+                                Ok((mut new_op, msg)) => {
                                     if let Some((peer, contract_location)) = stalled_peer_info {
                                         op_manager.ring.routing_finished(
                                             crate::router::RouteEvent {
@@ -2777,16 +2777,29 @@ impl Operation for GetOp {
                                             },
                                         );
                                     }
+                                    // Track speculative path to respect MAX_SPECULATIVE_PATHS
+                                    // cap, matching the GC task behavior.
+                                    new_op.speculative_paths += 1;
+                                    let target = match new_op.get_next_hop_addr() {
+                                        Some(addr) => addr,
+                                        None => {
+                                            tracing::error!(
+                                                tx = %id,
+                                                "Retry peer has no socket address"
+                                            );
+                                            return Err(OpError::StreamCancelled);
+                                        }
+                                    };
                                     tracing::info!(
                                         tx = %id,
                                         stream_id = %stream_id,
+                                        %target,
                                         error = %e,
                                         "Stream assembly failed, retrying GET with next peer"
                                     );
-                                    let target = new_op.get_next_hop_addr();
                                     return Ok(OperationResult::SendAndContinue {
                                         msg: NetMessage::from(msg),
-                                        next_hop: target,
+                                        next_hop: Some(target),
                                         state: OpEnum::Get(new_op),
                                         stream_data: None,
                                     });


### PR DESCRIPTION
## Problem

When a streaming GET response stalls (sender stops sending fragments), the 5s inactivity timeout fires and the operation returns `OpError::StreamCancelled`. This error propagates all the way to the HTTP client as "stream was cancelled", forcing users to manually retry.

The root cause is a design gap: the streaming response path was added without integrating with the GET operation's retry mechanism. Non-streaming GET timeouts are handled by the GC task which calls `retry_with_next_alternative()`, but streaming failures bypass this entirely because `StreamCancelled` immediately fails and removes the operation from state.

Users report seeing "GET request timed out after 30s" (now 5s after #3750), followed by the error page. The contract is then retrieved on manual refresh via a different peer.

## Approach

On the originator node, when `stream_handle.assemble()` fails:

1. Collect all connected peers as fallback candidates
2. Call `retry_with_next_alternative()` directly (same function the GC task uses)
3. Return `SendAndContinue` to route the retry to the next peer immediately
4. Report routing failure for the stalled peer so the router learns to avoid it

This is an **immediate inline retry**, not a deferred GC-task retry. No wasted bandwidth (the stalled stream is already dead), no speculative parallel paths.

Relay nodes still return `StreamCancelled` since only the originator has the alternatives list and client connection. The originator at the end of the chain handles all retries.

If all alternatives are exhausted, the error is returned to the client as before.

## Why didn't CI catch this?

The streaming GET path's error handling was never tested for retry behavior. Existing GET retry tests cover the non-streaming path via the GC task. A streaming-specific retry test would require simulating a stream that stalls mid-transfer, which the current test infrastructure doesn't support (in-memory sockets deliver reliably).

## Testing

- All 154 GET tests pass
- Build clean (fmt + clippy)
- Manual verification: the fix changes a fatal error path to a retry path, using the same `retry_with_next_alternative` mechanism that's well-tested via the GC task

[AI-assisted - Claude]