### PR TITLE
fix: include hosted contracts in subscription renewal

### DIFF
--- a/crates/core/src/ring/hosting.rs
+++ b/crates/core/src/ring/hosting.rs
@@ -819,6 +819,25 @@ impl HostingManager {
             }
         }
 
+        // 3. Hosted contracts without an active subscription.
+        // After restart, subscriptions are lost (in-memory only) but hosted
+        // contracts are loaded from disk. Since hosted contracts are served
+        // from local cache (#3761), they must be subscribed to stay fresh.
+        // Without this, hosted-but-unsubscribed contracts serve stale state
+        // indefinitely after restart (the #3698 staleness bug).
+        let now_check = self.time_source.now();
+        let hosted_keys = self.hosting_cache.read().iter().collect::<Vec<_>>();
+        for key in hosted_keys {
+            let has_active = self
+                .active_subscriptions
+                .get(&key)
+                .map(|expires_at| *expires_at > now_check)
+                .unwrap_or(false);
+            if !has_active {
+                needs_renewal_set.insert(key);
+            }
+        }
+
         // Convert set to vec and sort for deterministic return order
         let mut result: Vec<ContractKey> = needs_renewal_set.into_iter().collect();
         result.sort_by(|a, b| a.id().as_bytes().cmp(b.id().as_bytes()));
@@ -1398,23 +1417,42 @@ mod tests {
         assert!(manager.should_host(&contract));
     }
 
-    /// Regression test for #3698: after restart, hosted-but-unsubscribed contracts
-    /// must NOT appear in the renewal list. Without subscriptions (lost on restart),
-    /// the GET handler must query the network rather than serve stale cached state.
+    // Superseded: #3761 serves hosted contracts from local cache, so they MUST
+    // be subscribed to stay fresh. The old test asserted hosted-only contracts
+    // were excluded from renewal (the #3546/#3698 policy). That policy is now
+    // reversed: hosted contracts without subscriptions ARE included in renewal
+    // to prevent serving stale state after restart.
+    #[ignore]
     #[test]
     fn test_hosted_contract_not_in_renewal_after_restart() {
         let manager = HostingManager::new();
         let contract = make_contract_key(42);
-
-        // Simulate post-restart state: contract in hosting cache (restored from disk)
-        // but no subscriptions (in-memory only, lost on restart)
         manager.record_contract_access(contract, 1000, AccessType::Get);
         assert!(manager.is_hosting_contract(&contract));
-
-        // Must not appear in renewal list — no subscription to renew
         assert!(
             manager.contracts_needing_renewal().is_empty(),
             "Hosted-only contract must NOT be in renewal list"
+        );
+    }
+
+    /// After restart, hosted contracts have no active subscription (in-memory only).
+    /// Since #3761 serves hosted contracts from local cache, they must be included
+    /// in the renewal list so the subscription system refreshes them.
+    #[test]
+    fn test_hosted_contract_included_in_renewal_after_restart() {
+        let manager = HostingManager::new();
+        let contract = make_contract_key(42);
+
+        // Simulate post-restart: contract in hosting cache, no subscriptions
+        manager.record_contract_access(contract, 1000, AccessType::Get);
+        assert!(manager.is_hosting_contract(&contract));
+        assert!(!manager.is_subscribed(&contract));
+
+        // Must appear in renewal list to get re-subscribed
+        let needs_renewal = manager.contracts_needing_renewal();
+        assert!(
+            needs_renewal.contains(&contract),
+            "Hosted contract without subscription must be in renewal list"
         );
     }
 
@@ -1454,24 +1492,38 @@ mod tests {
         assert!(manager.is_receiving_updates(&contract));
     }
 
+    // Superseded: #3761 serves hosted contracts from local cache, so they must
+    // be subscribed to stay fresh. Hosted-only contracts are now included in
+    // the renewal list.
+    #[ignore]
     #[test]
     fn test_contracts_needing_renewal_excludes_hosted_only() {
+        let manager = HostingManager::new();
+        let contract = make_contract_key(1);
+        manager.record_contract_access(contract, 1000, AccessType::Get);
+        let needs_renewal = manager.contracts_needing_renewal();
+        assert!(
+            !needs_renewal.contains(&contract),
+            "Hosted-only contract should NOT be in renewal list"
+        );
+    }
+
+    #[test]
+    fn test_contracts_needing_renewal_includes_hosted() {
         let manager = HostingManager::new();
         let contract = make_contract_key(1);
 
         // Add to hosting cache (simulating GET operation)
         manager.record_contract_access(contract, 1000, AccessType::Get);
 
-        // Hosted-only contracts should NOT be renewed — contracts persisted to
-        // disk are a recovery mechanism, not actively subscribed. Only contracts
-        // with client subscriptions or expiring active subscriptions are renewed.
+        // Hosted contracts must be renewed to keep local cache fresh (#3761)
         let needs_renewal = manager.contracts_needing_renewal();
         assert!(
-            !needs_renewal.contains(&contract),
-            "Hosted-only contract should NOT be in renewal list"
+            needs_renewal.contains(&contract),
+            "Hosted contract should be in renewal list"
         );
 
-        // But a client subscription DOES trigger renewal
+        // Client subscription also triggers renewal (unchanged)
         let client_id = crate::client_events::ClientId::next();
         manager.add_client_subscription(contract.id(), client_id);
         let needs_renewal = manager.contracts_needing_renewal();
@@ -1577,44 +1629,43 @@ mod tests {
         );
     }
 
-    /// Regression test for subscription accumulation (#3546).
-    ///
-    /// Verifies that hosting hundreds of contracts (simulating relay-cached
-    /// contracts loaded from disk) does NOT cause them to appear in the
-    /// renewal list. Only explicitly client-subscribed contracts should
-    /// be renewed.
+    /// Verify that hosted contracts are included in renewal and the renewal
+    /// system handles scale (200 hosted contracts). The batch limit in
+    /// renew_subscriptions_task (MAX_RECOVERY_ATTEMPTS_PER_INTERVAL = 10)
+    /// prevents subscription storms by processing at most 10 per cycle.
     #[test]
-    fn test_hosted_contracts_not_renewed_at_scale() {
+    fn test_hosted_contracts_renewed_at_scale() {
         let manager = HostingManager::new();
 
-        // Simulate 200 relay-cached contracts loaded from disk
+        // Simulate 200 contracts loaded from disk after restart
         for i in 0..200u8 {
             let contract = make_contract_key(i);
             manager.record_contract_access(contract, 1000, AccessType::Get);
         }
         assert_eq!(manager.hosting_contracts_count(), 200);
 
-        // None should appear in renewal list
+        // All 200 should appear in renewal list (batch limiting happens
+        // in the renewal task, not in contracts_needing_renewal)
         let needs_renewal = manager.contracts_needing_renewal();
-        assert!(
-            needs_renewal.is_empty(),
-            "200 hosted-only contracts should NOT be in renewal list, found {}",
-            needs_renewal.len()
+        assert_eq!(
+            needs_renewal.len(),
+            200,
+            "All hosted contracts should be in renewal list"
         );
 
-        // Subscribe to exactly 2 (simulating River client)
+        // Subscribe to 2 -- they should still be in the list
         let client_id = crate::client_events::ClientId::next();
         let contract_a = make_contract_key(42);
         let contract_b = make_contract_key(99);
         manager.add_client_subscription(contract_a.id(), client_id);
         manager.add_client_subscription(contract_b.id(), client_id);
 
-        // Only those 2 should need renewal
+        // Still 200 (client subscription doesn't change hosted status)
         let needs_renewal = manager.contracts_needing_renewal();
         assert_eq!(
             needs_renewal.len(),
-            2,
-            "Only 2 client-subscribed contracts should need renewal, found {}",
+            200,
+            "All 200 hosted contracts should still need renewal, found {}",
             needs_renewal.len()
         );
         assert!(needs_renewal.contains(&contract_a));


### PR DESCRIPTION
## Problem

PR #3761 serves hosted contracts from local cache for faster page loads. But after restart, subscriptions are lost (in-memory only) while the hosting cache is restored from disk. The `contracts_needing_renewal()` function excluded hosted-only contracts (#3546 policy to prevent subscription storms), so hosted contracts would never get re-subscribed -- serving stale state indefinitely.

This was flagged by all 4 review agents on #3761 as a regression of #3698.

## Approach

Add hosted contracts without active subscriptions as a third category in `contracts_needing_renewal()`, alongside:
1. Contracts with expiring subscriptions (existing)
2. Contracts with client subscriptions but no network subscription (existing)
3. **Hosted contracts without any active subscription (new)**

The subscription storm concern from #3546 is addressed by the existing batch limit: `MAX_RECOVERY_ATTEMPTS_PER_INTERVAL = 10` per 30-second renewal cycle. A peer with 200 hosted contracts will re-subscribe over ~10 minutes, not all at once.

## Testing

- New test: `test_hosted_contract_included_in_renewal_after_restart` -- verifies hosted-only contracts appear in renewal list
- New test: `test_contracts_needing_renewal_includes_hosted` -- verifies hosted contracts are included, with and without client subscriptions
- Updated test: `test_hosted_contracts_renewed_at_scale` -- verifies 200 hosted contracts appear in renewal list (batch limiting happens in the task, not the function)
- Superseded tests (`test_hosted_contract_not_in_renewal_after_restart`, `test_contracts_needing_renewal_excludes_hosted_only`) marked `#[ignore]` with explanatory comments

All 68 hosting tests pass.

[AI-assisted - Claude]