### PR TITLE
feat: periodic gateway version probe for update discovery

### DIFF
--- a/crates/core/src/operations/connect.rs
+++ b/crates/core/src/operations/connect.rs
@@ -2460,6 +2460,22 @@ pub(crate) async fn join_ring_request(
     send_gateway_connect(gateway, gateway_addr, op_manager, own, desired_location).await
 }
 
+/// Resolve the socket address of a gateway selected for a version probe.
+///
+/// Extracted from [`gateway_version_probe`] so the failure mode (gateway with
+/// no known address) is unit-testable without an `OpManager`. Caller logs the
+/// failure at debug level and retries on the next maintenance cycle.
+pub(crate) fn resolve_probe_gateway_addr(
+    gateway: &PeerKeyLocation,
+) -> Result<std::net::SocketAddr, OpError> {
+    use crate::node::ConnectionError;
+
+    gateway.socket_addr().ok_or_else(|| {
+        tracing::error!(phase = "error", "Gateway address not found");
+        OpError::ConnError(ConnectionError::LocationUnknown)
+    })
+}
+
 /// Initiate a CONNECT to a gateway for version discovery (#3677).
 ///
 /// Skips `should_accept()` so the probe runs even when the ring is full.
@@ -2470,12 +2486,7 @@ pub(crate) async fn gateway_version_probe(
     gateway: &PeerKeyLocation,
     op_manager: &OpManager,
 ) -> Result<(), OpError> {
-    use crate::node::ConnectionError;
-
-    let gateway_addr = gateway.socket_addr().ok_or_else(|| {
-        tracing::error!(phase = "error", "Gateway address not found");
-        OpError::ConnError(ConnectionError::LocationUnknown)
-    })?;
+    let gateway_addr = resolve_probe_gateway_addr(gateway)?;
 
     let own = op_manager.ring.connection_manager.own_location();
     let desired_location = own.location().unwrap_or_else(Location::random);
@@ -2945,6 +2956,36 @@ mod tests {
     use super::*;
     use crate::transport::TransportKeypair;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn resolve_probe_gateway_addr_returns_known_socket() {
+        let pub_key = TransportKeypair::new().public().clone();
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 12345);
+        let gateway = PeerKeyLocation::new(pub_key, addr);
+
+        let resolved = resolve_probe_gateway_addr(&gateway).expect("known address resolves");
+        assert_eq!(resolved, addr);
+    }
+
+    #[test]
+    fn resolve_probe_gateway_addr_errors_on_unknown_address() {
+        // The probe loop in connection_maintenance treats this Err as a debug
+        // log + continue. The structural guarantee here is that we never call
+        // send_gateway_connect with a placeholder address — we surface the
+        // error before any network state is mutated.
+        let pub_key = TransportKeypair::new().public().clone();
+        let gateway = PeerKeyLocation::with_unknown_addr(pub_key);
+
+        let err =
+            resolve_probe_gateway_addr(&gateway).expect_err("unknown address must fail to resolve");
+        assert!(
+            matches!(
+                err,
+                OpError::ConnError(crate::node::ConnectionError::LocationUnknown)
+            ),
+            "expected LocationUnknown, got {err:?}"
+        );
+    }
 
     struct TestRelayContext {
         self_loc: PeerKeyLocation,

--- a/crates/core/src/ring.rs
+++ b/crates/core/src/ring.rs
@@ -2083,22 +2083,29 @@ impl Ring {
 
             // Periodic gateway version probe: initiate a CONNECT to a gateway so the
             // transport handshake exchanges version info, even when the ring is full (#3677).
-            if !is_gateway && Instant::now() >= next_gateway_probe {
-                if !op_manager.configured_gateways.is_empty() {
-                    let gw_index =
-                        GlobalRng::random_u64() as usize % op_manager.configured_gateways.len();
-                    let gateway = &op_manager.configured_gateways[gw_index];
+            //
+            // The combined predicate (`!is_gateway && !configured_gateways.is_empty() &&
+            // now >= next_probe`) is extracted into `should_probe_gateway` so each branch
+            // is unit-testable. Without the empty-gateways guard merged into the same
+            // condition, the index/modulo on the next line would panic.
+            if should_probe_gateway(
+                is_gateway,
+                !op_manager.configured_gateways.is_empty(),
+                Instant::now(),
+                next_gateway_probe,
+            ) {
+                let gw_index =
+                    GlobalRng::random_u64() as usize % op_manager.configured_gateways.len();
+                let gateway = &op_manager.configured_gateways[gw_index];
 
-                    if let Err(e) =
-                        crate::operations::connect::gateway_version_probe(gateway, &op_manager)
-                            .await
-                    {
-                        tracing::debug!(
-                            error = %e,
-                            gateway = %gateway,
-                            "Gateway version probe failed, will retry next cycle"
-                        );
-                    }
+                if let Err(e) =
+                    crate::operations::connect::gateway_version_probe(gateway, &op_manager).await
+                {
+                    tracing::debug!(
+                        error = %e,
+                        gateway = %gateway,
+                        "Gateway version probe failed, will retry next cycle"
+                    );
                 }
 
                 let base_secs = GATEWAY_VERSION_PROBE_INTERVAL.as_secs() as f64;
@@ -2728,6 +2735,78 @@ fn deferred_swap_drops_to_execute(
         }
     }
     n_to_drop
+}
+
+/// Predicate controlling when `connection_maintenance` fires a gateway version probe.
+///
+/// Extracted as a free function so each branch (gateway role, empty configuration,
+/// timing) can be exercised in unit tests without standing up an `OpManager`. The
+/// caller relies on `has_configured_gateways` to gate the modulo-indexing into
+/// `op_manager.configured_gateways` — flipping that flag at the call site (rather
+/// than inside this function) keeps the borrow of the gateway slice local to the
+/// caller.
+#[inline]
+fn should_probe_gateway(
+    is_gateway: bool,
+    has_configured_gateways: bool,
+    now: Instant,
+    next_probe: Instant,
+) -> bool {
+    !is_gateway && has_configured_gateways && now >= next_probe
+}
+
+#[cfg(test)]
+mod gateway_version_probe_predicate_tests {
+    use super::should_probe_gateway;
+    use std::time::Duration;
+    use tokio::time::Instant;
+
+    #[test]
+    fn fires_on_non_gateway_with_configured_gateways_at_due_time() {
+        let now = Instant::now();
+        let next_probe = now - Duration::from_secs(1);
+        assert!(should_probe_gateway(false, true, now, next_probe));
+    }
+
+    #[test]
+    fn skipped_when_running_as_gateway() {
+        // Gateways must never probe themselves — they are the destination, not
+        // the originator. This is the protection that keeps the gateway loop
+        // from generating phantom CONNECTs.
+        let now = Instant::now();
+        let next_probe = now - Duration::from_secs(1);
+        assert!(!should_probe_gateway(true, true, now, next_probe));
+    }
+
+    #[test]
+    fn skipped_when_no_gateways_are_configured() {
+        // The empty-gateways case is the boundary that previously sat in an
+        // inner `if` and was unreachable from any test. Merging it into the
+        // predicate makes the modulo-indexing in the caller structurally safe.
+        let now = Instant::now();
+        let next_probe = now - Duration::from_secs(1);
+        assert!(!should_probe_gateway(false, false, now, next_probe));
+    }
+
+    #[test]
+    fn skipped_before_due_time() {
+        let now = Instant::now();
+        let next_probe = now + Duration::from_secs(60);
+        assert!(!should_probe_gateway(false, true, now, next_probe));
+    }
+
+    #[test]
+    fn fires_at_exact_due_time_boundary() {
+        // `>=` semantics: a now equal to next_probe should fire, not skip.
+        let now = Instant::now();
+        assert!(should_probe_gateway(false, true, now, now));
+    }
+
+    #[test]
+    fn gateway_with_no_configured_gateways_is_still_skipped() {
+        let now = Instant::now();
+        assert!(!should_probe_gateway(true, false, now, now));
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -6262,18 +6262,35 @@ fn test_gateway_version_probe_fires() {
         .expect("Simulation should complete without panic");
 
     let rt = create_runtime();
-    let connect_events = rt.block_on(async {
+    let unique_connect_txs = rt.block_on(async {
         let logs = logs_handle.lock().await;
-        logs.iter()
-            .filter(|log| log.kind.variant_name() == "Connect")
-            .count()
+        // Count distinct Connect transactions, not raw events. Each CONNECT op
+        // emits multiple log entries (sent/received/accepted) that share a Tx.
+        // Counting unique Tx values gives us the number of *operations*, which
+        // is what the probe code path actually generates.
+        let mut seen = std::collections::HashSet::new();
+        for log in logs.iter() {
+            if log.kind.variant_name() == "Connect" {
+                seen.insert(log.tx);
+            }
+        }
+        seen.len()
     });
 
-    // Bootstrap alone produces ~6 CONNECTs (3 nodes × min_connections=2).
-    // Version probes (10s interval, 30s sim) push this well above 10.
+    // Bootstrap baseline: each of the 3 non-gateway nodes initiates an initial
+    // CONNECT to the gateway, so the bootstrap floor is 3 unique transactions.
+    // (Bootstrap may also retry on failure, but that just adds to the floor.)
+    //
+    // Probe budget: cfg(test) sets GATEWAY_VERSION_PROBE_INTERVAL to 10s with
+    // a random initial delay in [0, 10)s and ±20% jitter per cycle. Over 30s
+    // of sim time, each non-gateway can fire 1–3 probes, so 3 nodes contribute
+    // an additional 3–9 unique CONNECT transactions on top of bootstrap.
+    //
+    // Asserting > 6 (bootstrap floor + at least one probe per node) is robust
+    // against the random initial delay while still proving probes fire.
     assert!(
-        connect_events > 10,
-        "Expected version probe CONNECTs beyond bootstrap, got {connect_events}"
+        unique_connect_txs > 6,
+        "Expected bootstrap (~3) + at least 4 probe CONNECTs, got {unique_connect_txs}"
     );
 }
 


### PR DESCRIPTION
## Problem

Nodes with full same-version connections never perform new transport handshakes, so the handshake-based version discovery mechanism never fires. These nodes form stale sub-networks that stay on old versions indefinitely — even after newer versions are released and the gateway has updated.

Reported by Ivvor: node stuck on 0.2.13 overnight with all peers on 0.2.13, unable to discover 0.2.15.

## Solution

Add a periodic CONNECT to a configured gateway from `connection_maintenance`, purely for version exchange. The transport handshake during CONNECT calls `report_peer_version()` / `signal_urgent_update()`, feeding into the existing 3-tier update check system.

Key design decisions:

- **Bypass `should_accept()`**: the probe must run even when the ring is full — that's the whole point. A new `gateway_version_probe()` function handles this.
- **Reuse existing CONNECT flow**: no new protocol messages or transport-level changes. The version exchange happens in the transport handshake that CONNECT already triggers.
- **Shared helper `send_gateway_connect()`**: extracted from `join_ring_request()` to avoid duplicating the CONNECT initiation logic (ttl, bloom filter, telemetry, `notify_op_change`, error cleanup).
- **Anti-thundering-herd**: random initial delay (0..4h) + ±20% jitter on each cycle prevents all nodes from probing simultaneously.

## Changes

| File | Change |
|------|--------|
| `crates/core/src/operations/connect.rs` | `gateway_version_probe()` (skips `should_accept`), `send_gateway_connect()` (shared helper extracted from `join_ring_request`) |
| `crates/core/src/ring.rs` | ~4h probe timer in `connection_maintenance` with jitter; gateways skip probing via existing `!is_gateway` guard |
| `crates/core/tests/simulation_integration.rs` | Integration test verifying probes fire (Connect event count exceeds bootstrap-only baseline) |

## Fixes

Closes #3677