### PR TITLE
ci: move churn resilience test from nightly to PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,11 +490,27 @@ jobs:
             single-process &
           PID3=$!
 
+          # Churn resilience: tests network behavior under node crashes/restarts.
+          # Only takes a few seconds, so cheap to run on every PR.
+          target/release/fdev test \
+            --name "ci-churn-20" \
+            --seed 0xC102FEED \
+            --gateways 2 --nodes 18 --events 500 \
+            --ring-max-htl 10 --max-connections 15 --min-connections 4 \
+            --latency-min 10 --latency-max 50 \
+            --churn-rate 0.1 --churn-recovery-delay-ms 3000 \
+            --churn-permanent-rate 0.05 --churn-tick-ms 5000 \
+            --min-success-rate 0.80 \
+            --print-summary --print-network-stats \
+            single-process &
+          PID4=$!
+
           # Wait for all and fail if any failed
           FAILED=0
           wait $PID1 || FAILED=1
           wait $PID2 || FAILED=1
           wait $PID3 || FAILED=1
+          wait $PID4 || FAILED=1
           exit $FAILED
 
   nat_validation:

--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -1,10 +1,9 @@
 name: Simulation Tests (Nightly)
 
 # Long-running and large-scale simulation tests too slow for PR CI.
-# Medium-scale fdev tests (50 nodes, fault tolerance, high latency) now
-# run in the main CI workflow. This workflow covers:
+# Medium-scale fdev tests (50 nodes, fault tolerance, high latency, churn
+# resilience) now run in the main CI workflow. This workflow covers:
 #   - Nightly-gated nextest tests (1h virtual time, 250-contract scale)
-#   - Churn resilience (crash/recovery cycles)
 #   - Large scale (500 nodes, 10000 events)
 
 on:
@@ -108,22 +107,6 @@ jobs:
             --test-threads 1 \
             --no-capture \
             --profile nightly
-
-      # Churn resilience test - tests network behavior under node crashes/restarts
-      - name: Churn resilience test (20 nodes, 10% crash rate)
-        run: |
-          echo "Running churn resilience simulation (500 events, 10% crash rate)"
-          target/release/fdev test \
-            --name "nightly-churn-20" \
-            --seed 0xC102FEED \
-            --gateways 2 --nodes 18 --events 500 \
-            --ring-max-htl 10 --max-connections 15 --min-connections 4 \
-            --latency-min 10 --latency-max 50 \
-            --churn-rate 0.1 --churn-recovery-delay-ms 3000 \
-            --churn-permanent-rate 0.05 --churn-tick-ms 5000 \
-            --min-success-rate 0.80 \
-            --print-summary --print-network-stats \
-            single-process
 
       # Large scale test (500 nodes) - uses direct runner (no turmoil overhead)
       # With simulation-mode timer optimizations (~5x fewer timer firings),


### PR DESCRIPTION
## Problem

The churn resilience simulation test (20 nodes, 500 events, 10% crash rate) only runs in the nightly workflow, meaning regressions in crash/recovery behavior aren't caught until the next day. The test only takes a few seconds, so deferring it to nightly is unnecessary.

## Solution

Move the churn resilience test into the main CI \`Simulation\` job's parallel fdev test block, alongside the medium-scale, fault-tolerance, and high-latency tests already moved by #3726. It now runs as \`PID4\` in parallel with the other three.

Update \`simulation-nightly.yml\` header comment and remove the duplicated step.

## Testing

- CI on this PR validates the new parallel execution
- All four parallel fdev tests use unique network names and dynamic ports, so they don't conflict

## Fixes

Follows up on #3726.