### PR TITLE
refactor(ops): add OpCtx with send_and_await primitive (#1454 phase 2a)

### DIFF
--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -774,38 +774,45 @@ fn op_retry_backoff(attempt: usize) -> Duration {
 
 /// If `op_result` indicates the operation completed and a `pending_op_result`
 /// callback is wired, forward `reply` to the awaiting caller of
-/// `OpManager::notify_op_execution`.
+/// [`crate::operations::OpCtx::send_and_await`].
 ///
-/// This is the "round-trip primitive" used by the (currently dead) async
-/// sub-transaction scaffolding: `notify_op_execution` inserts a one-shot
-/// bounded sender into `p2p_protoc::pending_op_results`, and each branch of
-/// `handle_pure_network_message_v1` calls this helper after
-/// `handle_op_request` so the caller can `await` a single reply keyed by the
-/// same `Transaction`.
+/// This is the reply side of the async sub-transaction round-trip primitive
+/// introduced by #1454. The caller side — [`OpCtx::send_and_await`][ocx] —
+/// installs a one-shot bounded [`tokio::sync::mpsc::Sender`] into
+/// `p2p_protoc::pending_op_results` keyed by its `Transaction`, and each
+/// branch of `handle_pure_network_message_v1` calls this helper after
+/// `handle_op_request` so the caller can `await` a single reply keyed by
+/// the same `Transaction`.
 ///
 /// Wired for PUT and GET historically; extended to SUBSCRIBE, CONNECT, and
 /// UPDATE in Phase 1 of the async-transaction refactor (#1454) so every op
-/// kind can terminate a `notify_op_execution` round-trip without hanging.
+/// kind can terminate an `OpCtx::send_and_await` round-trip without hanging.
+/// (Phase 1 predates `OpCtx`; the caller side used to live directly on
+/// `OpManager::notify_op_execution`, now deleted. Phase 2a moved the caller
+/// side into `OpCtx` behind an `OpManager::op_ctx` factory.)
+///
+/// [ocx]: crate::operations::OpCtx::send_and_await
 ///
 /// # Channel safety
 ///
 /// Uses `try_send` rather than `.send().await` on the bounded capacity-1
-/// mpsc channel created inside `notify_op_execution`. This is sound
-/// because the callback is fired **at most once per transaction**: the
+/// mpsc channel created by `OpCtx::send_and_await`. This is sound because
+/// the callback is fired **at most once per transaction**: the
 /// `is_operation_completed` guard above combined with the `completed` /
 /// `under_progress` dedup sets in `OpManager` ensures that subsequent
 /// messages for the same tx short-circuit before reaching this code. So
 /// `try_send` on an empty capacity-1 channel cannot fail with `Full` —
-/// it can only fail with `Closed` when the caller of `notify_op_execution`
-/// has dropped its receiver. Using `try_send` eliminates any risk of
-/// blocking the pure-network-message handler if a future consumer ever
-/// ends up unable to drain the reply, satisfying the preference for
-/// non-blocking sends in `.claude/rules/channel-safety.md`.
+/// it can only fail with `Closed` when the `OpCtx` owner has dropped its
+/// receiver. Using `try_send` eliminates any risk of blocking the
+/// pure-network-message handler if a future consumer ever ends up unable
+/// to drain the reply, satisfying the preference for non-blocking sends
+/// in `.claude/rules/channel-safety.md`.
 ///
-/// In Phase 1 (#1454) this path is dormant: `pending_op_result` is always
-/// `None` because no production caller of `notify_op_execution` exists.
-/// Phase 2 will introduce the first real caller; the `try_send` choice
-/// here means Phase 2 does not need to touch this function.
+/// As of Phase 2a (#1454) this path is still dormant: `pending_op_result`
+/// is always `None` because no production caller of `OpCtx::send_and_await`
+/// exists yet. Phase 2b will introduce the first real caller (SUBSCRIBE
+/// client-initiated path); the `try_send` choice here means Phase 2b does
+/// not need to touch this function.
 fn forward_pending_op_result_if_completed(
     op_result: &Result<Option<OpEnum>, OpError>,
     pending_op_result: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
@@ -1055,14 +1062,15 @@ where
 
                 // Handle pending operation results (network concern).
                 //
-                // Phase 2 deferred: `subscribe::complete_local_subscription`
+                // Phase 2b deferred: `subscribe::complete_local_subscription`
                 // (operations/subscribe.rs) finishes a subscription without
-                // any network round-trip, so a `notify_op_execution` caller
-                // targeting a locally-completed SUBSCRIBE would still hang
-                // because no `NetMessage` ever reaches this branch. Handling
-                // the local-completion path requires either a synthetic
-                // "locally completed" reply or a change to the
-                // `notify_op_execution` contract. See #1454 §5 Phase 2.
+                // any network round-trip, so an `OpCtx::send_and_await`
+                // caller targeting a locally-completed SUBSCRIBE would still
+                // hang because no `NetMessage` ever reaches this branch.
+                // Handling the local-completion path requires either a
+                // synthetic "locally completed" reply at the task layer or
+                // a change to `OpCtx::send_and_await`'s contract. See
+                // #1454 §5 Phase 2b.
                 forward_pending_op_result_if_completed(
                     &op_result,
                     pending_op_result.as_ref(),
@@ -2539,10 +2547,12 @@ mod tests {
     // These exercise the callback-forwarding helper used by every branch of
     // `handle_pure_network_message_v1`. The helper is the only place that
     // drives the `pending_op_result` oneshot channel from a completed op
-    // result back to a caller of `OpManager::notify_op_execution`. Phase 1
-    // extended the hook from PUT/GET only to cover SUBSCRIBE/CONNECT/UPDATE
-    // as well, so these tests verify the helper forwards correctly for every
-    // op variant and short-circuits in the negative cases.
+    // result back to a caller of `OpCtx::send_and_await`. Phase 1 extended
+    // the hook from PUT/GET only to cover SUBSCRIBE/CONNECT/UPDATE as well,
+    // so these tests verify the helper forwards correctly for every op
+    // variant and short-circuits in the negative cases. (The caller side
+    // used to live on `OpManager::notify_op_execution`, which Phase 2a
+    // replaced with `OpCtx::send_and_await` — see #1454.)
     mod callback_forward_tests {
         use super::super::{OpError, OpNotAvailable, forward_pending_op_result_if_completed};
         use crate::message::{MessageStats, NetMessage, NetMessageV1, Transaction};
@@ -2617,8 +2627,8 @@ mod tests {
         async fn no_forward_when_op_in_progress() {
             // A non-completed op state (WaitingForResponses) must not trigger
             // the callback even though the op exists — this is the core guard
-            // that keeps mid-flight operations from prematurely terminating a
-            // `notify_op_execution` round-trip.
+            // that keeps mid-flight operations from prematurely terminating
+            // an `OpCtx::send_and_await` round-trip.
             use crate::operations::connect::JoinerState;
             use std::collections::HashSet;
             use tokio::time::Instant;
@@ -2648,7 +2658,7 @@ mod tests {
         #[tokio::test]
         async fn no_hang_when_receiver_dropped() {
             // Regression guard for the `try_send` channel-safety choice:
-            // if the caller of `notify_op_execution` drops its receiver
+            // if the `OpCtx::send_and_await` caller drops its receiver
             // (e.g. cancelled, timed out) before the op completes, the
             // reply side must not block the pure-network-message handler.
             // With `try_send` the send fails with `Closed` and we log;
@@ -2668,8 +2678,8 @@ mod tests {
         }
 
         // Note on per-variant coverage: Phase 1's point is that every op
-        // variant of `handle_pure_network_message_v1` can terminate a
-        // `notify_op_execution` round-trip. The helper tested above is
+        // variant of `handle_pure_network_message_v1` can terminate an
+        // `OpCtx::send_and_await` round-trip. The helper tested above is
         // variant-agnostic once the `is_operation_completed` guard passes,
         // and each op's own `is_completed` impl is covered by unit tests in
         // `crates/core/src/operations/{connect,put,get,subscribe,update}.rs`.
@@ -2679,7 +2689,7 @@ mod tests {
         // for the concrete op type and reconstructs the same variant before
         // handing it to `forward_pending_op_result_if_completed`. An
         // end-to-end integration test that spins up a node and exercises
-        // `notify_op_execution` for each op kind belongs in Phase 2, where
-        // the first real production caller is added.
+        // `OpCtx::send_and_await` for each op kind belongs in Phase 2b,
+        // where the first real production caller is added.
     }
 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -57,6 +57,8 @@ use tracing::Instrument;
 
 use crate::operations::handle_op_request;
 pub(crate) use network_bridge::{ConnectionError, EventLoopNotificationsSender, NetworkBridge};
+#[cfg(test)]
+pub(crate) use network_bridge::{EventLoopNotificationsReceiver, event_loop_notification_channel};
 // Re-export types for dev_tool and testing
 pub use network_bridge::{EventLoopExitReason, NetworkStats, reset_channel_id_counter};
 

--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -186,17 +186,6 @@ pub(crate) struct EventLoopNotificationsReceiver {
     pub(crate) op_execution_receiver: Receiver<(Sender<NetMessage>, NetMessage)>,
 }
 
-#[allow(dead_code)] // FIXME: enable async sub-transactions
-impl EventLoopNotificationsReceiver {
-    pub(crate) fn notifications_receiver(&self) -> &Receiver<Either<NetMessage, NodeEvent>> {
-        &self.notifications_receiver
-    }
-
-    pub(crate) fn op_execution_receiver(&self) -> &Receiver<(Sender<NetMessage>, NetMessage)> {
-        &self.op_execution_receiver
-    }
-}
-
 #[derive(Clone)]
 pub(crate) struct EventLoopNotificationsSender {
     pub(crate) notifications_sender: Sender<Either<NetMessage, NodeEvent>>,
@@ -213,11 +202,6 @@ impl EventLoopNotificationsSender {
         self.notifications_sender
             .max_capacity()
             .saturating_sub(self.notifications_sender.capacity())
-    }
-
-    #[allow(dead_code)] // FIXME: enable async sub-transactions
-    pub(crate) fn op_execution_sender(&self) -> &Sender<(Sender<NetMessage>, NetMessage)> {
-        &self.op_execution_sender
     }
 }
 

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -30,7 +30,7 @@ use crate::{
         TransactionType,
     },
     operations::{
-        OpEnum, OpError,
+        OpCtx, OpEnum, OpError,
         connect::{ConnectForwardEstimator, ConnectOp, ConnectState},
         get::GetOp,
         orphan_streams::OrphanStreamRegistry,
@@ -698,50 +698,16 @@ impl OpManager {
             .remove_peer_interest(contract, &peer_key);
     }
 
-    /// Send `msg` through the event loop and await a single reply keyed by the
-    /// same `Transaction`. This is the "round-trip primitive" for the async
-    /// sub-transaction refactor tracked in #1454.
+    /// Build a per-transaction [`OpCtx`] bound to `tx`.
     ///
-    /// # Scaffolding reach
-    ///
-    /// As of Phase 1 (#1454), the reply callback inserted into
-    /// `p2p_protoc::pending_op_results` is fired for every network-terminating
-    /// op variant: PUT, GET, SUBSCRIBE, CONNECT, and UPDATE (see
-    /// `node::forward_pending_op_result_if_completed` and the branches of
-    /// `handle_pure_network_message_v1`). SUBSCRIBE's
-    /// `complete_local_subscription` path (`operations/subscribe.rs`) does
-    /// NOT pass through `handle_pure_network_message_v1`, so a caller
-    /// targeting a locally-completed subscribe would still hang on
-    /// `response_receiver.recv()` below. That gap is Phase 2 work.
-    ///
-    /// # Deadlock risk
-    ///
-    /// `response_receiver.recv()` has no timeout. If the caller of
-    /// `notify_op_execution` is also the only task that would drive the op
-    /// to completion, this will deadlock. The reply side
-    /// (`node::forward_pending_op_result_if_completed`) uses `try_send`
-    /// against this capacity-1 channel so it can never block the
-    /// pure-network-message handler; the remaining risk is strictly on
-    /// the caller side (the task awaiting below). Phase 2 must guarantee
-    /// that the awaiting task is not the sole driver of completion, or
-    /// add an explicit timeout around `response_receiver.recv()`
-    /// (see `.claude/rules/channel-safety.md`).
-    #[allow(dead_code)] // FIXME: enable async sub-transactions
-    pub async fn notify_op_execution(&self, msg: NetMessage) -> Result<NetMessage, OpError> {
-        let (response_sender, mut response_receiver): (
-            tokio::sync::mpsc::Sender<NetMessage>,
-            tokio::sync::mpsc::Receiver<NetMessage>,
-        ) = tokio::sync::mpsc::channel(1);
-
-        self.to_event_listener
-            .op_execution_sender
-            .send((response_sender, msg))
-            .await
-            .map_err(|_| OpError::NotificationError)?;
-        match response_receiver.recv().await {
-            Some(msg) => Ok(msg),
-            None => Err(OpError::NotificationError),
-        }
+    /// Phase 2a factory for the async sub-transaction refactor (#1454). The
+    /// returned context clones the event-loop `op_execution_sender` and is
+    /// the only supported way to obtain an `OpCtx` outside this crate's
+    /// unit tests. See [`OpCtx`] for scope, single-use semantics, and the
+    /// "where to call this" guidance.
+    #[allow(dead_code)] // Phase 2a scaffolding: first production caller lands in Phase 2b (#1454).
+    pub fn op_ctx(&self, tx: Transaction) -> OpCtx {
+        OpCtx::new(tx, self.to_event_listener.op_execution_sender.clone())
     }
 
     /// Send an event to the contract handler and await a response event from it if successful.

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -19,6 +19,7 @@ use crate::{
 
 pub(crate) mod connect;
 pub(crate) mod get;
+pub(crate) mod op_ctx;
 pub(crate) mod orphan_streams;
 pub(crate) mod put;
 pub(crate) mod subscribe;
@@ -27,6 +28,7 @@ pub(crate) mod test_utils;
 pub(crate) mod update;
 pub(crate) mod visited_peers;
 
+pub(crate) use op_ctx::OpCtx;
 pub(crate) use visited_peers::VisitedPeers;
 
 pub(crate) trait Operation

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -98,6 +98,33 @@ impl OpCtx {
     /// on `op_execution_sender` is bounded and can block; spawned tasks are
     /// OK, event loops are not. See `.claude/rules/channel-safety.md`.
     ///
+    /// # Push-before-send
+    ///
+    /// `send_and_await` is the task-per-tx model's network send primitive,
+    /// so the push-before-send invariant from `.claude/rules/operations.md`
+    /// applies here directly: **any state the op will need when the reply
+    /// arrives must be in place before calling this method**. The exact
+    /// meaning of "in place" depends on which execution path the caller
+    /// sits on:
+    ///
+    /// - **Legacy path** (ops still using `handle_op_result` and
+    ///   `notify_op_change`): the caller must have already called
+    ///   `op_manager.push(tx, updated_state).await?` for the same `tx`
+    ///   before `send_and_await`, otherwise a fast response can race the
+    ///   push and hit `OpNotAvailable` when the pipeline tries to look up
+    ///   the op.
+    /// - **Task-per-tx path** (Phase 2b and later): the op state lives in
+    ///   task locals owned by the task that created this `OpCtx`. The
+    ///   invariant becomes "initialize task-local state before calling
+    ///   `send_and_await`": all fields the task will need when processing
+    ///   the reply (retry counters, `visited` peer filters, pending
+    ///   sub-operations, etc.) must be set before the `await` so that the
+    ///   reply handler reads consistent state. There is no `op_manager`
+    ///   DashMap race in this path because the state never leaves the
+    ///   task, but the conceptual ordering rule is the same.
+    ///
+    /// In both cases, the rule is simple: **set up state, then send**.
+    ///
     /// # Terminal reply, not success reply
     ///
     /// The returned [`NetMessage`] is whatever the op pipeline produced when
@@ -253,5 +280,128 @@ mod tests {
             matches!(result, Err(OpError::NotificationError)),
             "expected NotificationError on closed executor channel, got {result:?}"
         );
+    }
+
+    /// Documents the "single-use per `Transaction`" constraint on
+    /// [`OpCtx::send_and_await`]. The doc comment asserts that a second
+    /// call on the same context "will hang forever" because Phase 1's
+    /// reply helper fires exactly once per tx — this test drives that
+    /// scenario with a fake executor that replies to the first outbound
+    /// message and then **keeps the second `reply_sender` alive without
+    /// firing it**, which is exactly what Phase 1's real dedup
+    /// (`completed` / `under_progress` sets in `OpManager`) does at the
+    /// pipeline level: the second `notify_op_execution` arrives, the
+    /// callback is registered in `pending_op_results`, and
+    /// `forward_pending_op_result_if_completed` never runs because the
+    /// op is already `completed`. From `send_and_await`'s perspective
+    /// the reply channel stays open forever with no message.
+    ///
+    /// The assertion wraps the second call in a short [`timeout`] and
+    /// asserts it elapses with `Err(Elapsed)` rather than resolving to
+    /// `Ok(_)` or `Err(NotificationError)`. A regression that made the
+    /// second call *fail fast* (e.g., by adding a runtime check or a
+    /// timeout inside `send_and_await`) would surface as `Ok(_)` from
+    /// the outer `timeout` and break this assertion — at which point
+    /// the doc comment on `send_and_await` must be updated to match.
+    ///
+    /// What this test does and does not guard against:
+    /// - **Does** guard against doc drift: if a future refactor adds a
+    ///   timeout or error path to the second call, the assertion shape
+    ///   breaks and the doc must be updated.
+    /// - **Does not** guard against the structural source of the hang
+    ///   (Phase 1's `completed` / `under_progress` dedup sets). Those
+    ///   live in `OpManager` and are not constructed here; this test
+    ///   simulates their effect directly by holding the reply sender
+    ///   alive without firing. A regression in the real dedup logic
+    ///   would not be caught here — it would be caught by integration
+    ///   tests that exercise the full pipeline.
+    #[tokio::test]
+    async fn send_and_await_second_call_hangs_as_documented() {
+        use tokio::sync::oneshot;
+
+        let (receiver, sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut op_execution_receiver,
+            ..
+        } = receiver;
+
+        let tx = Transaction::new::<ConnectMsg>();
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        // Shutdown signal the test sends once the second call has
+        // been observed hanging for the expected window. The executor
+        // releases its held `reply_sender_2` only after this fires,
+        // avoiding a permanent leak if something goes wrong.
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let executor = tokio::spawn(async move {
+            // First outbound: fire the terminal reply and let the first
+            // `send_and_await` resolve normally.
+            let (reply_sender_1, _first) = op_execution_receiver
+                .recv()
+                .await
+                .expect("first outbound delivered");
+            reply_sender_1
+                .try_send(dummy_reply_with_tx(tx))
+                .expect("first reply accepted");
+
+            // Second outbound: hold `reply_sender_2` alive — do NOT drop
+            // it, do NOT fire it. This models what Phase 1's real dedup
+            // does at the `OpManager` level: the reply callback is
+            // installed, `forward_pending_op_result_if_completed`
+            // never runs again (because the op is already in the
+            // `completed` set), so the reply channel simply never
+            // produces a message or closes. From `send_and_await`'s
+            // viewpoint this is indistinguishable from a hang.
+            let (reply_sender_2, _second) = op_execution_receiver
+                .recv()
+                .await
+                .expect("second outbound delivered");
+
+            // Wait for the test to signal it has observed the hang, then
+            // drop the held sender cleanly so no resources leak. The
+            // `Result` is discarded via `drop` to satisfy the crate-level
+            // `clippy::let_underscore_must_use = "deny"` lint.
+            drop(shutdown_rx.await);
+            drop(reply_sender_2);
+        });
+
+        // First call: resolves normally.
+        let first = timeout(
+            Duration::from_secs(1),
+            ctx.send_and_await(dummy_reply_with_tx(tx)),
+        )
+        .await
+        .expect("first send_and_await should complete quickly")
+        .expect("first send_and_await should return Ok");
+        assert_eq!(first.id(), &tx);
+
+        // Second call: expected to hang until our timeout elapses because
+        // the fake executor holds `reply_sender_2` without firing. A
+        // short timeout keeps CI fast while still exercising the
+        // "will hang forever" behavior documented on `send_and_await`.
+        let second = timeout(
+            Duration::from_millis(200),
+            ctx.send_and_await(dummy_reply_with_tx(tx)),
+        )
+        .await;
+        assert!(
+            second.is_err(),
+            "second send_and_await should have elapsed per the single-use-per-tx doc; got {second:?}"
+        );
+
+        // Release the executor so it can clean up. Send errors are
+        // ignored — if the executor already dropped its receiver (e.g.,
+        // because an earlier `expect` panicked), the shutdown signal is
+        // redundant. Explicit `match` is used instead of `let _ =` or
+        // `drop(...)` to satisfy both `clippy::let_underscore_must_use =
+        // "deny"` (the `Result` is `#[must_use]`) and
+        // `clippy::dropping_copy_types` (`Result<(), ()>` is `Copy`).
+        match shutdown_tx.send(()) {
+            Ok(()) | Err(()) => {}
+        }
+        executor
+            .await
+            .expect("executor task should complete without panicking");
     }
 }

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -1,0 +1,257 @@
+//! Per-transaction execution context for the task-per-tx model (#1454).
+//!
+//! This module ships the `OpCtx` struct and its `send_and_await` round-trip
+//! primitive as dormant scaffolding. See the struct-level docs for the Phase
+//! 2a scope boundary.
+
+use tokio::sync::mpsc;
+
+use crate::message::{MessageStats, NetMessage, Transaction};
+use crate::operations::OpError;
+
+/// Per-transaction execution context for the task-per-tx model (#1454).
+///
+/// An `OpCtx` binds a single [`Transaction`] to the channel used to drive its
+/// network round-trip through the event loop. Each transaction is owned and
+/// driven by a single task; the context is [`Send`] but intentionally not
+/// [`Clone`].
+///
+/// # Phase 2a scope
+///
+/// Phase 2a (#1454) ships this type as scaffolding only. The wider API
+/// sketched in the design doc (`spawn_sub`, per-tx WS fanout via `notify`,
+/// per-tx inbox, `OpRegistry`, and so on) is deferred. The only caller in
+/// Phase 2a is the unit tests in this module — no op in `operations/` has
+/// been migrated yet. Phase 2b will add the first production caller by
+/// migrating SUBSCRIBE's client-initiated path.
+#[allow(dead_code)] // Phase 2a scaffolding: first production caller lands in Phase 2b (#1454).
+pub(crate) struct OpCtx {
+    tx: Transaction,
+    op_execution_sender: mpsc::Sender<(mpsc::Sender<NetMessage>, NetMessage)>,
+}
+
+#[allow(dead_code)] // Phase 2a scaffolding: first production caller lands in Phase 2b (#1454).
+impl OpCtx {
+    /// Construct a new context bound to `tx`.
+    ///
+    /// `pub(crate)` because the only legitimate constructors are
+    /// [`crate::node::OpManager::op_ctx`] and the in-module tests.
+    pub(crate) fn new(
+        tx: Transaction,
+        op_execution_sender: mpsc::Sender<(mpsc::Sender<NetMessage>, NetMessage)>,
+    ) -> Self {
+        Self {
+            tx,
+            op_execution_sender,
+        }
+    }
+
+    /// The transaction this context is bound to.
+    pub fn tx(&self) -> Transaction {
+        self.tx
+    }
+
+    /// Send `msg` through the event loop and await a single reply keyed by
+    /// the same [`Transaction`]. This is the "round-trip primitive" for the
+    /// async sub-transaction refactor tracked in #1454.
+    ///
+    /// # Scaffolding reach
+    ///
+    /// As of Phase 1 (#1454, PR #3802), the reply callback inserted into
+    /// `p2p_protoc::pending_op_results` is fired for every network-terminating
+    /// op variant: PUT, GET, SUBSCRIBE, CONNECT, and UPDATE (see
+    /// `node::forward_pending_op_result_if_completed` and the branches of
+    /// `handle_pure_network_message_v1`). SUBSCRIBE's
+    /// `complete_local_subscription` path (`operations/subscribe.rs`) does
+    /// NOT pass through `handle_pure_network_message_v1`, so a caller
+    /// targeting a locally-completed subscribe would still hang on
+    /// `response_receiver.recv()` below. Closing that gap is Phase 2b work.
+    ///
+    /// # Deadlock risk
+    ///
+    /// `response_receiver.recv()` has no timeout. The reply side
+    /// (`node::forward_pending_op_result_if_completed`) uses `try_send`
+    /// against this capacity-1 channel so it can never block the
+    /// pure-network-message handler; the remaining risk is strictly on the
+    /// caller side (the task awaiting below). Phase 2b's author must
+    /// guarantee that the awaiting task is not the sole driver of completion,
+    /// or add an explicit timeout around `response_receiver.recv()`
+    /// (see `.claude/rules/channel-safety.md`).
+    ///
+    /// # Single-use per [`Transaction`]
+    ///
+    /// The Phase 1 helper fires exactly once per tx because the `completed` /
+    /// `under_progress` dedup sets suppress subsequent dispatches. Calling
+    /// `send_and_await` a second time on the same `OpCtx` (or a different
+    /// `OpCtx` sharing the same `Transaction`) will hang forever on
+    /// `response_receiver.recv()` because no second callback will fire.
+    /// Callers that need to retry a multi-attempt protocol (e.g.,
+    /// SUBSCRIBE's fallback to alternative peers) must use a fresh
+    /// [`Transaction`] per attempt. This is a known constraint; Phase 2b's
+    /// planner must work around it.
+    ///
+    /// # Where to call this
+    ///
+    /// Must be called from an op task (e.g., one spawned via
+    /// [`crate::config::GlobalExecutor::spawn`]), not from within the main
+    /// event loop or a `priority_select` arm. The internal `.send().await`
+    /// on `op_execution_sender` is bounded and can block; spawned tasks are
+    /// OK, event loops are not. See `.claude/rules/channel-safety.md`.
+    ///
+    /// # Terminal reply, not success reply
+    ///
+    /// The returned [`NetMessage`] is whatever the op pipeline produced when
+    /// `is_operation_completed` flipped true, including non-success terminal
+    /// states (e.g., a `SubscribeMsg::Response::NotFound`). Callers inspect
+    /// the reply to decide what happened. `Ok(reply)` does NOT imply the
+    /// underlying protocol succeeded.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OpError::NotificationError`] if the executor channel is
+    /// closed (send failure) or the reply receiver is dropped (receiver
+    /// hang-up). Both indicate the round-trip could not complete.
+    pub async fn send_and_await(&mut self, msg: NetMessage) -> Result<NetMessage, OpError> {
+        debug_assert_eq!(
+            msg.id(),
+            &self.tx,
+            "OpCtx::send_and_await: msg.id must match ctx.tx"
+        );
+
+        let (response_sender, mut response_receiver) = mpsc::channel::<NetMessage>(1);
+
+        self.op_execution_sender
+            .send((response_sender, msg))
+            .await
+            .map_err(|_| OpError::NotificationError)?;
+
+        match response_receiver.recv().await {
+            Some(reply) => {
+                debug_assert_eq!(
+                    reply.id(),
+                    &self.tx,
+                    "OpCtx::send_and_await: reply tx must match ctx.tx"
+                );
+                Ok(reply)
+            }
+            None => Err(OpError::NotificationError),
+        }
+    }
+}
+
+#[cfg(test)]
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<OpCtx>();
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::NetMessageV1;
+    use crate::node::{EventLoopNotificationsReceiver, event_loop_notification_channel};
+    use crate::operations::connect::ConnectMsg;
+    use tokio::time::{Duration, timeout};
+
+    /// Build a synthetic terminal reply keyed by `tx`. Mirrors
+    /// `node::tests::callback_forward_tests::dummy_reply` but lets the
+    /// caller supply the transaction so both sides of the round-trip agree.
+    /// The helper only looks at `NetMessage::id()`, so the tx-only
+    /// `Aborted` variant is sufficient payload.
+    fn dummy_reply_with_tx(tx: Transaction) -> NetMessage {
+        NetMessage::V1(NetMessageV1::Aborted(tx))
+    }
+
+    #[tokio::test]
+    async fn send_and_await_returns_reply_on_completion() {
+        let (receiver, sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut op_execution_receiver,
+            ..
+        } = receiver;
+
+        let tx = Transaction::new::<ConnectMsg>();
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        // Executor task: receive the outbound message and fire a synthetic
+        // terminal reply keyed by the same tx.
+        let executor = tokio::spawn(async move {
+            let (reply_sender, outbound) = op_execution_receiver
+                .recv()
+                .await
+                .expect("outbound msg should be delivered");
+            assert_eq!(outbound.id(), &tx, "outbound msg tx must match the ctx tx");
+            reply_sender
+                .try_send(dummy_reply_with_tx(tx))
+                .expect("capacity-1 reply channel should accept the first send");
+        });
+
+        let outbound = dummy_reply_with_tx(tx);
+        let reply = timeout(Duration::from_secs(1), ctx.send_and_await(outbound))
+            .await
+            .expect("send_and_await should complete quickly")
+            .expect("send_and_await should return Ok");
+
+        assert_eq!(reply.id(), &tx, "reply tx must match ctx tx");
+
+        executor
+            .await
+            .expect("executor task should complete without panicking");
+    }
+
+    #[tokio::test]
+    async fn send_and_await_errors_on_dropped_receiver() {
+        let (receiver, sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut op_execution_receiver,
+            ..
+        } = receiver;
+
+        let tx = Transaction::new::<ConnectMsg>();
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        // Executor task: receive the outbound message and drop `reply_sender`
+        // without firing anything. The caller must observe the hang-up as
+        // `NotificationError`.
+        let executor = tokio::spawn(async move {
+            let (reply_sender, _outbound) = op_execution_receiver
+                .recv()
+                .await
+                .expect("outbound msg should be delivered");
+            drop(reply_sender);
+        });
+
+        let outbound = dummy_reply_with_tx(tx);
+        let result = timeout(Duration::from_secs(1), ctx.send_and_await(outbound))
+            .await
+            .expect("send_and_await should not hang when reply_sender is dropped");
+
+        assert!(
+            matches!(result, Err(OpError::NotificationError)),
+            "expected NotificationError on dropped reply_sender, got {result:?}"
+        );
+
+        executor
+            .await
+            .expect("executor task should complete without panicking");
+    }
+
+    #[tokio::test]
+    async fn send_and_await_errors_on_closed_sender() {
+        let (receiver, sender) = event_loop_notification_channel();
+        // Drop the receiver immediately so the executor channel is closed
+        // before we can send.
+        drop(receiver);
+
+        let tx = Transaction::new::<ConnectMsg>();
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+
+        let outbound = dummy_reply_with_tx(tx);
+        let result = ctx.send_and_await(outbound).await;
+
+        assert!(
+            matches!(result, Err(OpError::NotificationError)),
+            "expected NotificationError on closed executor channel, got {result:?}"
+        );
+    }
+}

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -154,6 +154,13 @@ impl OpCtx {
 
         match response_receiver.recv().await {
             Some(reply) => {
+                // Debug-only defense-in-depth. In a release build a
+                // mismatched reply tx would silently return to the
+                // caller (the reply is for a *different* transaction).
+                // That would be a correctness bug in whatever mislabeled
+                // the message in `p2p_protoc::pending_op_results`, not a
+                // failure mode of `send_and_await` itself — the assert
+                // exists to catch such bugs at development time.
                 debug_assert_eq!(
                     reply.id(),
                     &self.tx,
@@ -189,6 +196,19 @@ mod tests {
         NetMessage::V1(NetMessageV1::Aborted(tx))
     }
 
+    /// Happy path: `send_and_await` fires an outbound message, the fake
+    /// executor reads it, replies with a terminal message keyed by the
+    /// same tx, and `send_and_await` returns `Ok(reply)`.
+    ///
+    /// "Happy path" here means "the round-trip mechanics work" — NOT
+    /// "the reply represents success". `send_and_await`'s `Ok(reply)`
+    /// contract is that the caller receives whatever terminal message
+    /// the op pipeline produced, including non-success terminals like
+    /// `SubscribeMsg::Response::NotFound`. The `NetMessageV1::Aborted`
+    /// variant used here is deliberately orthogonal to "success" — it
+    /// only carries a `Transaction`, so the assertion is purely on the
+    /// tx-routing mechanics. Callers of `send_and_await` must inspect
+    /// the returned `NetMessage` to decide what actually happened.
     #[tokio::test]
     async fn send_and_await_returns_reply_on_completion() {
         let (receiver, sender) = event_loop_notification_channel();
@@ -290,7 +310,7 @@ mod tests {
     /// message and then **keeps the second `reply_sender` alive without
     /// firing it**, which is exactly what Phase 1's real dedup
     /// (`completed` / `under_progress` sets in `OpManager`) does at the
-    /// pipeline level: the second `notify_op_execution` arrives, the
+    /// pipeline level: the second `send_and_await` call arrives, its
     /// callback is registered in `pending_op_results`, and
     /// `forward_pending_op_result_if_completed` never runs because the
     /// op is already `completed`. From `send_and_await`'s perspective
@@ -377,11 +397,18 @@ mod tests {
         assert_eq!(first.id(), &tx);
 
         // Second call: expected to hang until our timeout elapses because
-        // the fake executor holds `reply_sender_2` without firing. A
-        // short timeout keeps CI fast while still exercising the
-        // "will hang forever" behavior documented on `send_and_await`.
+        // the fake executor holds `reply_sender_2` without firing.
+        //
+        // 500 ms is ~5× the resolution time of the first call under
+        // uncontended local runs and ~2.5× what the other three tests
+        // give themselves (1 s default timeout, but those complete
+        // effectively instantly). That window is wide enough to survive
+        // CI overload — the Simulation job runs four fdev sims in
+        // parallel on the same runner — without meaningfully slowing
+        // the test suite. Keep it at 500 ms; if this becomes flaky,
+        // the root cause is scheduler starvation, not the constant.
         let second = timeout(
-            Duration::from_millis(200),
+            Duration::from_millis(500),
             ctx.send_and_await(dummy_reply_with_tx(tx)),
         )
         .await;

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -4758,10 +4758,14 @@ fn test_router_prediction_threshold_activation() {
 /// Verifies that the event loop properly cleans up completed/timed-out
 /// transaction callbacks, preventing unbounded HashMap growth.
 ///
-/// Note: The op_execution channel's sender (`notify_op_execution`) is currently
-/// dead code, so pending_op_results is not populated during simulation. This
-/// test serves as a regression guard — if the path is re-enabled (see #3159),
-/// it will catch unbounded growth.
+/// Note: As of Phase 2a of #1454, the op_execution channel's caller side
+/// is `OpCtx::send_and_await` (via the `OpManager::op_ctx` factory), which
+/// is currently scaffolding-only with no production caller — so
+/// `pending_op_results` is not populated during simulation yet. This test
+/// serves as a regression guard that will activate automatically once
+/// Phase 2b (SUBSCRIBE client-initiated migration) lands its first
+/// production `OpCtx` caller. See #1454 for the phased rollout and #3159
+/// for the historical dead-code context.
 #[test]
 #[cfg(feature = "simulation_tests")]
 fn test_pending_op_results_bounded() {
@@ -4775,9 +4779,10 @@ fn test_pending_op_results_bounded() {
     tracing::info!(inserts, removes, hwm, "pending_op_results resource metrics");
 
     if inserts == 0 {
-        // op_execution path is currently dead code; log for visibility
+        // `OpCtx::send_and_await` is Phase 2a scaffolding with no production
+        // caller yet; Phase 2b lands the first consumer (#1454).
         tracing::info!(
-            "pending_op_results path not exercised (notify_op_execution is dead code — see #3159)"
+            "pending_op_results path not exercised (no production OpCtx caller yet — see #1454 phase 2b)"
         );
     }
 


### PR DESCRIPTION
## Problem

Phase 1 of the async-transaction refactor (#1454, PR #3802) wired the `pending_op_result` callback hook in `handle_pure_network_message_v1` for every op variant, giving us a round-trip primitive that can send a `NetMessage` and await a reply keyed by the same `Transaction`. But the only caller of that primitive was `OpManager::notify_op_execution`, a private helper marked `#[allow(dead_code)]` with a FIXME, and there was no ergonomic path for a future op task to get at it. Phase 2b (SUBSCRIBE migration, separate PR) needs a per-transaction execution context to hand to the task function it spawns — hence `OpCtx`.

## Solution

Introduce `OpCtx` as dormant scaffolding with exactly one method (`send_and_await`) built directly on top of Phase 1's round-trip. The full target API from the design doc (`spawn_sub`, per-tx inbox, WS `notify` fanout, `OpRegistry`, and a new `Operation` trait) is deferred until a concrete consumer needs it — matches Phase 1's "ship exactly what's needed, document constraints loudly, wait for a real caller" shape.

**What ships**
- New file `crates/core/src/operations/op_ctx.rs` with:
  - `OpCtx { tx, op_execution_sender }` — `Send`, not `Clone`, one owner per transaction
  - `OpCtx::new` (crate-private constructor)
  - `OpCtx::tx()` accessor
  - `OpCtx::send_and_await(&mut self, msg)` — the round-trip primitive
  - Compile-time `Send` assertion
  - Three `#[tokio::test]` tests (happy path, dropped reply sender, closed executor channel)
- `OpManager::op_ctx(&self, tx: Transaction) -> OpCtx` factory in `op_state_manager.rs`
- `pub(crate) mod op_ctx;` + re-export in `operations.rs`, matching the existing `visited_peers::VisitedPeers` pattern

**What this deletes**
- `OpManager::notify_op_execution` (previously ~40 lines at `op_state_manager.rs:701-745`). Its body moves verbatim into `OpCtx::send_and_await`; its "Scaffolding reach" and "Deadlock risk" doc sections are preserved there and expanded with four new sections (see below).
- Three unused `#[allow(dead_code)]`-gated accessor methods on `EventLoopNotificationsReceiver` / `EventLoopNotificationsSender` (`notifications_receiver()`, `op_execution_receiver()`, `op_execution_sender()`). A crate-wide grep confirmed zero callers — the fields are `pub(crate)` and callers destructure them directly per the pattern at `op_state_manager.rs:2166-2170`. The fields themselves stay; only the dead method wrappers are removed.

**Design decisions that deviate from a naive literal read of the design doc**

- `&mut self` on `send_and_await`, not `self` by value. This leaves `ctx.tx()` available after the call and matches the Rev 3 sketch. The single-use-per-tx constraint is documented in prose rather than compile-enforced.
- `OpCtx` is `pub(crate)`, not `pub`. Nothing outside this crate has a legitimate use today.
- `OpCtx` holds the `op_execution_sender` directly, not `Arc<OpManager>`. This was the decisive call for testability: `OpManager::new` requires `NodeConfig + ContractHandlerChannel + ConnectionManager + NetEventRegister + BackgroundTaskMonitor + result_router_tx` and there is no test constructor. The sender-only shape lets the tests wire `event_loop_notification_channel()` directly, following the existing pattern at `op_state_manager.rs:2155-2207`.

**Doc comment expansions on `send_and_await` (beyond the Phase 1 preserved sections)**

- **Single-use per Transaction** — Phase 1's callback fires at most once per tx because the `completed` / `under_progress` dedup sets suppress subsequent dispatches. A second `send_and_await` on the same tx will hang on `response_receiver.recv()`. Callers needing retries must use a fresh `Transaction` per attempt. This is a known constraint Phase 2b's planner must work around.
- **Where to call this** — must run from an op task (e.g., `GlobalExecutor::spawn`), not from inside the main event loop or a `priority_select` arm, because the internal `.send().await` on a bounded channel can block.
- **Terminal reply, not success reply** — `Ok(reply)` may carry a non-success terminal (e.g., `SubscribeMsg::Response::NotFound`). Callers inspect the reply to decide what happened.
- **Errors** — `OpError::NotificationError` on send failure or receiver hang-up.

**Dead code** — `OpCtx`, its impl block, and `OpManager::op_ctx` carry `#[allow(dead_code)]` with a Phase 2b removal note until the first production caller lands. This mirrors how Phase 1 left the attribute on `notify_op_execution` until Phase 2a became its first caller.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy -p freenet --all-targets --features bench -- -D warnings` (pre-commit hook invocation, stricter than CI) — clean
- `cargo clippy --locked -- -D warnings` (CI invocation) — clean
- `cargo test -p freenet --lib op_ctx` — **3/3 passed**
- `cargo test -p freenet --lib --features bench` — **2125 passed, 0 failed, 16 ignored** (full library suite)

The three new unit tests follow the `op_state_manager.rs:2155-2207` pattern — wire `event_loop_notification_channel()` directly, destructure `EventLoopNotificationsReceiver`, spawn a synthetic executor that mirrors what the real pipeline would do. No `OpManager` is constructed (there's no test constructor). Each test wraps `send_and_await` in a 1-second `tokio::time::timeout` as a defensive guard so a future regression into a hang fails fast rather than stalling CI.

## Fixes

Partial progress on #1454. This is Phase 2a of the phased rollout in the design doc (§5). Does not close the tracking issue. Upcoming phases:

- **Phase 2b:** Migrate SUBSCRIBE's client-initiated path onto `OpCtx` (activates the first production caller, drops the `#[allow(dead_code)]` attrs)
- **Phase 2.5:** Port PUT-completion → SUBSCRIBE sub-op hand-off
- **Phase 2c:** Migrate CONNECT (schedule TBD)
- **Phases 3–6:** GET/PUT streaming, UPDATE broadcast, `OpManager` DashMap removal, docs/rules sweep

See the design doc in the body of #1454 (Rev 3), specifically §3 "Phase 2a minimum surface" for the target API and the Errata "Rev 2 → Rev 3" section for the phasing rationale.