### PR TITLE
refactor(ops): migrate client-initiated SUBSCRIBE to OpCtx (#1454 phase 2b)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -6,9 +6,27 @@ paths:
 
 # Operations Module Rules
 
-## Critical Invariant: Push-Before-Send
+> **Path-scoped rule, legacy state-machine path.** As of #1454 Phase 2b
+> (PR #3806) the first operation (client-initiated SUBSCRIBE via
+> `subscribe_with_id`) has been migrated off the legacy re-entry loop
+> onto a task-per-transaction model in
+> `operations/subscribe/op_ctx_task.rs`. On that path, op state lives in
+> task locals and is never pushed into `OpManager.ops.*`, so rules below
+> that talk about "pushing state" / `load_or_init` / `handle_op_result`
+> apply only to the **legacy state-machine path** (still used by GET,
+> PUT, UPDATE, CONNECT, and by SUBSCRIBE's renewal / PUT-sub-op /
+> executor / intermediate-peer entry points).
+>
+> Task-per-tx drivers have their own invariants documented in the
+> `op_ctx_task.rs` module doc and in `OpCtx::send_and_await`'s rustdoc.
+> The spirit of push-before-send is preserved (initialize task-local
+> state before calling `send_and_await`), but the mechanical
+> `op_manager.push(...)` call is absent. Phase 6 of #1454 will rewrite
+> this rules file in full once all ops have migrated.
 
-**This is the most important rule in this module.**
+## Critical Invariant: Push-Before-Send (legacy path)
+
+**This is the most important rule for code on the legacy state-machine path.**
 
 ```
 ALWAYS save state BEFORE sending network message:
@@ -23,6 +41,13 @@ WRONG:
 ```
 
 **Why:** If response arrives before state is saved, `load_or_init` will fail because the operation doesn't exist in storage.
+
+**Task-per-tx equivalent (#1454 Phase 2b+):** callers of
+`OpCtx::send_and_await` must have all fields the reply handler will read
+(retry counters, visited-peers filter, routing state) set in task locals
+BEFORE calling `send_and_await`. State is never published to the
+`OpManager` DashMap; the conceptual ordering rule is the same. See the
+`OpCtx::send_and_await` docstring for the full reasoning.
 
 ## State Machine Rules
 
@@ -171,6 +196,16 @@ This is usually benign (duplicate message, already completed)
 → Return Ok(None)
 → Do NOT treat as error
 ```
+
+**Note (#1454 Phase 2b):** For op kinds with a task-per-tx driver
+(currently SUBSCRIBE client-initiated), the pure-network-message
+handler checks `pending_op_results` FIRST and forwards the reply to
+the awaiting task via `node::try_forward_task_per_tx_reply` before
+reaching `load_or_init`. Do NOT "fix" `load_or_init`'s `OpNotPresent`
+handling by trying to look up a task-owned tx there — it will never
+find one, and it shouldn't. The bypass is the load-bearing piece;
+confirm by reading the SUBSCRIBE branch of
+`handle_pure_network_message_v1` in `node.rs`.
 
 ### WHEN encountering InvalidStateTransition
 

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -45,11 +45,17 @@ Key decision points:
 
 ```
 Each file is a state machine:
-  connect.rs → CONNECT operation
-  get.rs     → GET operation
-  put.rs     → PUT operation
-  update.rs  → UPDATE operation
-  subscribe.rs → SUBSCRIBE operation
+  connect.rs    → CONNECT operation
+  get.rs        → GET operation
+  put.rs        → PUT operation
+  update.rs     → UPDATE operation
+  subscribe.rs  → SUBSCRIBE operation (legacy state-machine path)
+
+Plus task-per-transaction drivers from #1454 Phase 2b onwards:
+  subscribe/op_ctx_task.rs → client-initiated SUBSCRIBE driver
+    (first production consumer of `OpCtx::send_and_await`;
+     bypasses OpManager.ops.subscribe DashMap entirely and
+     owns retry state in task locals)
 ```
 
 ## Module Map

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -1707,14 +1707,14 @@ async fn process_open_request(
                                     );
                                 })?;
 
-                            // Start dedicated operation for this client AFTER registration
-                            // is_renewal: false - client-initiated subscriptions are new
+                            // Start dedicated operation for this client AFTER registration.
+                            // `subscribe_with_id` is client-initiated-only since #1454 Phase 2b;
+                            // no `is_renewal` parameter.
                             let _result_tx = crate::node::subscribe_with_id(
                                 op_manager.clone(),
                                 key,
                                 None, // No legacy registration
                                 Some(tx),
-                                false,
                             )
                             .await
                             .inspect_err(|err| {
@@ -1758,26 +1758,21 @@ async fn process_open_request(
                                     );
                                 })?;
 
-                            // is_renewal: false - client-initiated subscriptions are new
-                            crate::node::subscribe_with_id(
-                                op_manager.clone(),
-                                key,
-                                None,
-                                Some(tx),
-                                false,
-                            )
-                            .await
-                            .inspect_err(|err| {
-                                tracing::error!(
-                                    client_id = %client_id,
-                                    request_id = %request_id,
-                                    tx = %tx,
-                                    contract = %key,
-                                    error = %err,
-                                    phase = "error",
-                                    "SUBSCRIBE operation failed"
-                                );
-                            })?;
+                            // `subscribe_with_id` is client-initiated-only since #1454 Phase 2b;
+                            // no `is_renewal` parameter.
+                            crate::node::subscribe_with_id(op_manager.clone(), key, None, Some(tx))
+                                .await
+                                .inspect_err(|err| {
+                                    tracing::error!(
+                                        client_id = %client_id,
+                                        request_id = %request_id,
+                                        tx = %tx,
+                                        contract = %key,
+                                        error = %err,
+                                        phase = "error",
+                                        "SUBSCRIBE operation failed"
+                                    );
+                                })?;
 
                             tracing::debug!(
                                 request_id = %request_id,

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -224,6 +224,7 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
     pub async fn new_mock_wasm(
         _identifier: &str,
         shared_storage: MockStateStorage,
+        contract_store: Option<InMemoryContractStore>,
         op_sender: Option<OpRequestSender>,
         op_manager: Option<std::sync::Arc<crate::node::OpManager>>,
     ) -> anyhow::Result<Self> {
@@ -231,7 +232,7 @@ impl Executor<MockWasmRuntime, MockStateStorage> {
             crate::wasm_runtime::StateStore::new(shared_storage.clone(), 10_000_000).unwrap();
 
         let runtime = MockWasmRuntime {
-            contract_store: InMemoryContractStore::new(),
+            contract_store: contract_store.unwrap_or_default(),
             validate_overrides: HashMap::new(),
         };
 

--- a/crates/core/src/contract/executor/pool_tests/conformance_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/conformance_tests.rs
@@ -52,7 +52,7 @@ async fn create_mock_runtime_executor() -> Executor<MockRuntime, MockStateStorag
 /// Helper to create a MockWasmRuntime executor.
 async fn create_mock_wasm_executor() -> Executor<MockWasmRuntime, MockStateStorage> {
     let storage = MockStateStorage::new();
-    Executor::new_mock_wasm("conformance_wasm", storage, None, None)
+    Executor::new_mock_wasm("conformance_wasm", storage, None, None, None)
         .await
         .expect("create MockWasmRuntime executor")
 }

--- a/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/related_contract_tests.rs
@@ -18,7 +18,7 @@ use crate::wasm_runtime::MockStateStorage;
 /// Create a MockWasmRuntime executor.
 async fn create_executor() -> Executor<MockWasmRuntime, MockStateStorage> {
     let storage = MockStateStorage::new();
-    Executor::new_mock_wasm("related_test", storage, None, None)
+    Executor::new_mock_wasm("related_test", storage, None, None, None)
         .await
         .expect("create MockWasmRuntime executor")
 }

--- a/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_limit_tests.rs
@@ -19,7 +19,7 @@ use crate::wasm_runtime::MockStateStorage;
 /// Helper to create a MockWasmRuntime executor (uses production bridged_* paths).
 async fn create_executor() -> Executor<MockWasmRuntime, MockStateStorage> {
     let storage = MockStateStorage::new();
-    Executor::new_mock_wasm("subscriber_limit_test", storage, None, None)
+    Executor::new_mock_wasm("subscriber_limit_test", storage, None, None, None)
         .await
         .expect("create executor")
 }

--- a/crates/core/src/contract/executor/pool_tests/subscriber_stress_tests.rs
+++ b/crates/core/src/contract/executor/pool_tests/subscriber_stress_tests.rs
@@ -24,7 +24,7 @@ use crate::wasm_runtime::MockStateStorage;
 /// Helper to create a MockWasmRuntime executor.
 async fn create_executor() -> Executor<MockWasmRuntime, MockStateStorage> {
     let storage = MockStateStorage::new();
-    Executor::new_mock_wasm("subscriber_stress_test", storage, None, None)
+    Executor::new_mock_wasm("subscriber_stress_test", storage, None, None, None)
         .await
         .expect("create executor")
 }

--- a/crates/core/src/contract/handler.rs
+++ b/crates/core/src/contract/handler.rs
@@ -1272,6 +1272,8 @@ pub(super) mod in_memory {
     pub struct MockWasmHandlerBuilder {
         pub identifier: String,
         pub shared_storage: MockStateStorage,
+        /// Pre-seeded contract store. If `None`, a fresh empty store is created.
+        pub contract_store: Option<crate::wasm_runtime::InMemoryContractStore>,
     }
 
     impl ContractHandler for MockWasmContractHandler {
@@ -1290,6 +1292,7 @@ pub(super) mod in_memory {
             let runtime = Executor::new_mock_wasm(
                 &builder.identifier,
                 builder.shared_storage,
+                builder.contract_store,
                 Some(op_sender),
                 Some(op_manager),
             )

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1945,21 +1945,21 @@ fn get_peer_key_from_addr(
         .map(|pkl| crate::ring::interest::PeerKey::from(pkl.pub_key.clone()))
 }
 
-/// Attempts to subscribe to a contract
+/// Attempts to subscribe to a contract. Thin wrapper around
+/// [`subscribe_with_id`] that allocates a fresh transaction.
 #[allow(dead_code)]
 pub async fn subscribe(
     op_manager: Arc<OpManager>,
     instance_id: ContractInstanceId,
     client_id: Option<ClientId>,
 ) -> Result<Transaction, OpError> {
-    // Client-initiated subscriptions are never renewals
-    subscribe_with_id(op_manager, instance_id, client_id, None, false).await
+    subscribe_with_id(op_manager, instance_id, client_id, None).await
 }
 
 /// Attempts to subscribe to a contract with a specific transaction ID (for deduplication).
 ///
-/// Since #1454 Phase 2b, this function is the entry point for client-initiated
-/// SUBSCRIBE only — it spawns a task-per-tx driver via
+/// Since #1454 Phase 2b, this function is the entry point for
+/// **client-initiated** SUBSCRIBE only — it spawns a task-per-tx driver via
 /// [`crate::operations::subscribe::start_client_subscribe`] rather than going
 /// through the legacy `request_subscribe` + `handle_op_result` re-entry loop.
 ///
@@ -1968,6 +1968,14 @@ pub async fn subscribe(
 /// executor/WASM-initiated path (`contract::executor::SubscribeContract::resume_op`)
 /// all call `subscribe::request_subscribe` directly and bypass this function,
 /// so they continue on the legacy path unchanged.
+///
+/// The legacy `is_renewal` parameter has been removed in Phase 2b: no live
+/// caller passes `true`, and the task-per-tx path does not carry renewal
+/// jitter / spam-prevention semantics (those are owned by
+/// `ring::connection_maintenance` and are load-bearing there). Accepting
+/// `is_renewal=true` here would silently route a renewal through the wrong
+/// code path — removing the parameter makes the misuse a compile error
+/// instead of a runtime footgun (review finding L1).
 ///
 /// # Parameters
 ///
@@ -1978,25 +1986,12 @@ pub async fn subscribe(
 /// - `transaction_id`: The client-visible transaction id. If `None`, a fresh
 ///   one is allocated — currently only the dead-code wrapper `subscribe()`
 ///   does this.
-/// - `is_renewal`: Historical parameter. All live call sites pass `false`.
-///   Phase 2b's task-per-tx path is scoped to client-initiated (non-renewal)
-///   subscribes; if a future caller passes `true` through this function the
-///   debug assert below will fire during development so the renewal case
-///   can be re-evaluated (it belongs on the legacy path with jitter +
-///   spam-prevention handling).
 pub async fn subscribe_with_id(
     op_manager: Arc<OpManager>,
     instance_id: ContractInstanceId,
     client_id: Option<ClientId>,
     transaction_id: Option<Transaction>,
-    is_renewal: bool,
 ) -> Result<Transaction, OpError> {
-    debug_assert!(
-        !is_renewal,
-        "subscribe_with_id is client-initiated-only since #1454 Phase 2b; \
-         renewal callers must go through ring::connection_maintenance directly"
-    );
-
     let client_tx = match transaction_id {
         Some(id) => id,
         None => Transaction::new::<subscribe::SubscribeMsg>(),
@@ -2860,6 +2855,63 @@ mod tests {
             assert!(
                 taken,
                 "callback present but receiver dropped → bypass still taken"
+            );
+        }
+
+        /// Pin the bypass call site. Without this regression guard a
+        /// future refactor could delete the
+        /// `try_forward_task_per_tx_reply` invocation in the SUBSCRIBE
+        /// branch of `handle_pure_network_message_v1` and the unit tests
+        /// on the helper itself would still pass — because unit coverage
+        /// on the helper only proves the helper works, not that it's
+        /// wired in. Integration (simulation) failures would catch it
+        /// eventually but as end-to-end hangs, which is a noisy signal.
+        ///
+        /// This test reads the `node.rs` source at compile time via
+        /// `include_str!` and asserts that the SUBSCRIBE branch of
+        /// `handle_pure_network_message_v1` invokes
+        /// `try_forward_task_per_tx_reply` before running
+        /// `handle_op_request`. A refactor that deletes the bypass call
+        /// will fail this test at the unit-test level (review finding
+        /// Testing #1).
+        ///
+        /// If the match arm structure changes (e.g. SUBSCRIBE branch
+        /// moves or is renamed), the string patterns below need to be
+        /// updated to match. That's a load-bearing but intentional
+        /// coupling — the whole point is to fail loudly when the wiring
+        /// changes so the change is noticed.
+        #[test]
+        fn bypass_is_wired_into_subscribe_branch_regression_guard() {
+            // Full file text, read at compile time.
+            const SOURCE: &str = include_str!("node.rs");
+
+            // Locate the SUBSCRIBE branch of handle_pure_network_message_v1.
+            let subscribe_branch_anchor = "NetMessageV1::Subscribe(ref op) => {";
+            let branch_start = SOURCE.find(subscribe_branch_anchor).expect(
+                "SUBSCRIBE branch of handle_pure_network_message_v1 not found; \
+                         the match arm has been renamed or moved — update this regression guard",
+            );
+
+            // Slice a window large enough to contain the branch body up
+            // to (and including) the first `handle_op_request` call.
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<subscribe::SubscribeOp, _>")
+                .expect("SUBSCRIBE branch no longer calls handle_op_request — update guard")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+
+            // The bypass helper MUST be invoked BEFORE the legacy
+            // handle_op_request call. If this assertion fails, either:
+            //   (a) the bypass was removed (regression — re-add it), or
+            //   (b) the branch was restructured (update this guard).
+            assert!(
+                window.contains("try_forward_task_per_tx_reply("),
+                "SUBSCRIBE branch no longer calls try_forward_task_per_tx_reply \
+                 before handle_op_request. This is the bypass Phase 2b (#1454) \
+                 added to prevent task-per-tx callers from hanging on replies \
+                 that load_or_init would drop as OpNotPresent. Either restore \
+                 the bypass invocation or update this regression guard if the \
+                 branch has been legitimately refactored."
             );
         }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2920,6 +2920,18 @@ mod tests {
                  the bypass invocation or update this regression guard if the \
                  branch has been legitimately refactored."
             );
+
+            // The bypass MUST be gated on Response-only. Without this
+            // filter, non-terminal messages like ForwardingAck fill the
+            // capacity-1 reply channel and cause UnexpectedOpState
+            // (commit 5cb6f37c).
+            assert!(
+                window.contains("matches!(op, subscribe::SubscribeMsg::Response { .. })"),
+                "SUBSCRIBE branch bypass is not gated on Response-only. \
+                 Non-terminal messages (ForwardingAck, Unsubscribe) must NOT \
+                 be forwarded to the task-per-tx channel — they would fill \
+                 the capacity-1 reply slot and block the real Response."
+            );
         }
 
         #[tokio::test]
@@ -2962,5 +2974,137 @@ mod tests {
         // end-to-end integration test that spins up a node and exercises
         // `OpCtx::send_and_await` for each op kind belongs in Phase 2b,
         // where the first real production caller is added.
+
+        // ───────────────────────────────────────────────────────────
+        // Regression tests for the subscribe-branch message-type
+        // filter added in the ForwardingAck fix (5cb6f37c).
+        //
+        // The bug: `try_forward_task_per_tx_reply` was called for ALL
+        // subscribe message types (including ForwardingAck). A relay
+        // peer's ForwardingAck would fill the capacity-1 reply
+        // channel, causing the task to receive it instead of the
+        // real Response and fail with UnexpectedOpState.
+        //
+        // These tests verify the filtering logic that
+        // `handle_pure_network_message_v1` applies BEFORE calling the
+        // bypass helper: only `SubscribeMsg::Response` is forwarded.
+        // ───────────────────────────────────────────────────────────
+
+        use crate::operations::VisitedPeers;
+        use crate::operations::subscribe::{SubscribeMsg, SubscribeMsgResult};
+
+        /// Helper: simulate the filtering logic from the SUBSCRIBE
+        /// branch of `handle_pure_network_message_v1`. Returns
+        /// `true` if the message would be forwarded to the
+        /// task-per-tx channel (and the branch would return early).
+        fn subscribe_branch_would_forward(
+            op: &SubscribeMsg,
+            callback: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
+        ) -> bool {
+            matches!(op, SubscribeMsg::Response { .. })
+                && try_forward_task_per_tx_reply(
+                    callback,
+                    NetMessage::V1(NetMessageV1::Subscribe(op.clone())),
+                    "subscribe",
+                )
+        }
+
+        #[tokio::test]
+        async fn subscribe_response_is_forwarded_to_task() {
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let sub_tx = Transaction::new::<SubscribeMsg>();
+            let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([1u8; 32]);
+            let key = freenet_stdlib::prelude::ContractKey::from_id_and_code(
+                instance_id,
+                freenet_stdlib::prelude::CodeHash::new([2u8; 32]),
+            );
+            let op = SubscribeMsg::Response {
+                id: sub_tx,
+                instance_id,
+                result: SubscribeMsgResult::Subscribed { key },
+            };
+
+            let taken = subscribe_branch_would_forward(&op, Some(&tx));
+            assert!(taken, "Response with callback → must be forwarded");
+
+            let received = rx.try_recv().expect("Response should be in channel");
+            assert_eq!(*received.id(), sub_tx);
+        }
+
+        #[tokio::test]
+        async fn forwarding_ack_is_not_forwarded_to_task() {
+            // ForwardingAck is non-terminal: relay peers send it to
+            // signal "I'm working on it". Forwarding it would fill
+            // the capacity-1 channel and block the real Response.
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let sub_tx = Transaction::new::<SubscribeMsg>();
+            let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([3u8; 32]);
+            let op = SubscribeMsg::ForwardingAck {
+                id: sub_tx,
+                instance_id,
+            };
+
+            let taken = subscribe_branch_would_forward(&op, Some(&tx));
+            assert!(
+                !taken,
+                "ForwardingAck must NOT be forwarded to task channel"
+            );
+            assert!(
+                rx.try_recv().is_err(),
+                "channel must remain empty after ForwardingAck"
+            );
+        }
+
+        #[tokio::test]
+        async fn unsubscribe_is_not_forwarded_to_task() {
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let sub_tx = Transaction::new::<SubscribeMsg>();
+            let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([4u8; 32]);
+            let op = SubscribeMsg::Unsubscribe {
+                id: sub_tx,
+                instance_id,
+            };
+
+            let taken = subscribe_branch_would_forward(&op, Some(&tx));
+            assert!(!taken, "Unsubscribe must NOT be forwarded to task channel");
+            assert!(rx.try_recv().is_err(), "channel must remain empty");
+        }
+
+        #[tokio::test]
+        async fn request_is_not_forwarded_to_task() {
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let sub_tx = Transaction::new::<SubscribeMsg>();
+            let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([5u8; 32]);
+            let op = SubscribeMsg::Request {
+                id: sub_tx,
+                instance_id,
+                htl: 5,
+                visited: VisitedPeers::new(&sub_tx),
+                is_renewal: false,
+            };
+
+            let taken = subscribe_branch_would_forward(&op, Some(&tx));
+            assert!(!taken, "Request must NOT be forwarded to task channel");
+            assert!(rx.try_recv().is_err(), "channel must remain empty");
+        }
+
+        #[tokio::test]
+        async fn response_without_callback_falls_through() {
+            // No callback registered (legacy path) — filter must
+            // return false so handle_op_request runs.
+            let sub_tx = Transaction::new::<SubscribeMsg>();
+            let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([6u8; 32]);
+            let op = SubscribeMsg::Response {
+                id: sub_tx,
+                instance_id,
+                result: SubscribeMsgResult::NotFound,
+            };
+
+            let taken = subscribe_branch_would_forward(&op, None);
+            assert!(
+                !taken,
+                "Response without callback → must fall through to legacy path"
+            );
+        }
     }
 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1142,6 +1142,14 @@ where
                 // 1's forwarding hook and task-per-tx callers who never
                 // push an op into the OpManager DashMap).
                 //
+                // Only forward **terminal** Response messages to the
+                // task-per-tx channel. Non-terminal messages like
+                // ForwardingAck (sent by relay peers to signal "I'm working
+                // on it") must NOT be forwarded: they would fill the
+                // capacity-1 reply channel before the real Response arrives,
+                // causing the task to classify the ForwardingAck as
+                // Unexpected and fail with UnexpectedOpState.
+                //
                 // Once this returns `true` we exit the branch entirely, so
                 // the legacy `forward_pending_op_result_if_completed` call
                 // that follows the other op branches is DELIBERATELY
@@ -1150,11 +1158,13 @@ where
                 // by the time we reach `handle_op_request` we are
                 // guaranteed `pending_op_result.is_none()`. Adding the
                 // legacy forward call would be pure no-op noise.
-                if try_forward_task_per_tx_reply(
-                    pending_op_result.as_ref(),
-                    NetMessage::V1(NetMessageV1::Subscribe((*op).clone())),
-                    "subscribe",
-                ) {
+                if matches!(op, subscribe::SubscribeMsg::Response { .. })
+                    && try_forward_task_per_tx_reply(
+                        pending_op_result.as_ref(),
+                        NetMessage::V1(NetMessageV1::Subscribe((*op).clone())),
+                        "subscribe",
+                    )
+                {
                     return Ok(None);
                 }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1150,14 +1150,14 @@ where
                 // causing the task to classify the ForwardingAck as
                 // Unexpected and fail with UnexpectedOpState.
                 //
-                // Once this returns `true` we exit the branch entirely, so
-                // the legacy `forward_pending_op_result_if_completed` call
-                // that follows the other op branches is DELIBERATELY
-                // ABSENT below: the bypass covers every case where
-                // `pending_op_result` is `Some` for a SUBSCRIBE tx, and
-                // by the time we reach `handle_op_request` we are
-                // guaranteed `pending_op_result.is_none()`. Adding the
-                // legacy forward call would be pure no-op noise.
+                // When a Response IS present and a callback is registered,
+                // the bypass returns Ok(None) and skips handle_op_request.
+                // For non-Response messages (Request, ForwardingAck, etc.)
+                // with a pending callback, the bypass doesn't fire and we
+                // fall through to handle_op_request. If handle_op_request
+                // completes the operation (e.g., local subscribe completion),
+                // forward_pending_op_result_if_completed below delivers
+                // the result to the OpCtx::send_and_await callback.
                 if matches!(op, subscribe::SubscribeMsg::Response { .. })
                     && try_forward_task_per_tx_reply(
                         pending_op_result.as_ref(),
@@ -1175,6 +1175,50 @@ where
                     source_addr,
                 )
                 .await;
+
+                // Forward result to OpCtx::send_and_await callback when
+                // the operation completes. This path fires when the
+                // originator processes its own Request locally via
+                // handle_op_execution (pending_op_result is Some) and
+                // the subscribe completes without needing the network
+                // (e.g., contract available locally). Without this,
+                // the response_sender in pending_op_results is dropped
+                // without a reply, causing send_and_await to fail.
+                //
+                // We synthesize a Response (not forward the original
+                // Request) because classify_reply in op_ctx_task expects
+                // a SubscribeMsg::Response variant.
+                if let Some(ref callback) = pending_op_result {
+                    if is_operation_completed(&op_result) {
+                        let instance_id = match op {
+                            subscribe::SubscribeMsg::Request { instance_id, .. }
+                            | subscribe::SubscribeMsg::Response { instance_id, .. }
+                            | subscribe::SubscribeMsg::Unsubscribe { instance_id, .. }
+                            | subscribe::SubscribeMsg::ForwardingAck { instance_id, .. } => {
+                                *instance_id
+                            }
+                        };
+                        let result = match &op_result {
+                            Ok(Some(OpEnum::Subscribe(sub_op))) => match sub_op.completed_key() {
+                                Some(key) => subscribe::SubscribeMsgResult::Subscribed { key },
+                                None => subscribe::SubscribeMsgResult::NotFound,
+                            },
+                            _ => subscribe::SubscribeMsgResult::NotFound,
+                        };
+                        let reply = NetMessage::from(subscribe::SubscribeMsg::Response {
+                            id: *op.id(),
+                            instance_id,
+                            result,
+                        });
+                        if let Err(err) = callback.try_send(reply) {
+                            tracing::debug!(
+                                %err,
+                                "subscribe local-completion: callback send failed \
+                                 (task may have timed out)"
+                            );
+                        }
+                    }
+                }
 
                 if let Err(OpError::OpNotAvailable(state)) = &op_result {
                     match state {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -773,8 +773,8 @@ fn op_retry_backoff(attempt: usize) -> Duration {
 }
 
 /// Route an inbound task-per-tx reply directly to an awaiting
-/// [`OpCtx::send_and_await`][ocx] caller, bypassing the legacy op state
-/// machine entirely.
+/// [`OpCtx::send_and_await`][ocxawait] caller, bypassing the legacy op
+/// state machine entirely.
 ///
 /// Returns `true` if a callback was registered and the message was forwarded
 /// (or dropped due to a closed receiver, which is also a successful
@@ -812,20 +812,30 @@ fn op_retry_backoff(attempt: usize) -> Duration {
 /// # Safety argument for the bypass
 ///
 /// `p2p_protoc::pending_op_results` is only populated via
-/// `p2p_protoc::handle_op_execution`, which is only driven by
-/// [`OpCtx::send_and_await`][ocx]. Legacy paths (SUBSCRIBE renewals, PUT
-/// sub-op subscribes, intermediate-peer forwarding) never call it, so the
-/// bypass never triggers for them and their behavior is unchanged.
+/// `p2p_protoc::handle_op_execution`, which is only driven by the
+/// `op_execution_sender` channel. The only way to obtain a clone of that
+/// sender is through [`crate::node::OpManager::op_ctx`] (production
+/// factory) or the in-module `OpCtx` unit tests — both of which construct
+/// an [`OpCtx`][ocx] whose only round-trip method is
+/// [`OpCtx::send_and_await`][ocxawait]. This is a **structural
+/// invariant**, not a convention: the sender field is `pub(crate)` and
+/// there is no other `pub` accessor on `EventLoopNotificationsSender`.
+///
+/// Consequence: legacy paths (SUBSCRIBE renewals, PUT sub-op subscribes,
+/// contract-executor-initiated subscribes, intermediate-peer forwarding)
+/// never appear in `pending_op_results` for their own txs, so the bypass
+/// never triggers for them and their behavior is unchanged.
+///
+/// [ocx]: crate::operations::OpCtx
+/// [ocxawait]: crate::operations::OpCtx::send_and_await
 ///
 /// # Channel safety
 ///
 /// Uses `try_send` on the bounded capacity-1 channel created by
-/// [`OpCtx::send_and_await`][ocx]. On a closed receiver (e.g., caller
+/// [`OpCtx::send_and_await`][ocxawait]. On a closed receiver (e.g., caller
 /// timed out or was cancelled) the send fails and is logged; the
 /// pure-network-message handler still makes progress. See
 /// `.claude/rules/channel-safety.md`.
-///
-/// [ocx]: crate::operations::OpCtx::send_and_await
 fn try_forward_task_per_tx_reply(
     pending_op_result: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
     reply: NetMessage,

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1137,10 +1137,19 @@ where
             }
             NetMessageV1::Subscribe(ref op) => {
                 // Phase 2b (#1454): task-per-tx bypass for client-initiated
-                // SUBSCRIBE. See `try_forward_task_per_tx_reply` for the full
-                // reasoning (reply-side structural gap between Phase 1's
-                // forwarding hook and task-per-tx callers who never push an
-                // op into the OpManager DashMap).
+                // SUBSCRIBE. See `try_forward_task_per_tx_reply` for the
+                // full reasoning (reply-side structural gap between Phase
+                // 1's forwarding hook and task-per-tx callers who never
+                // push an op into the OpManager DashMap).
+                //
+                // Once this returns `true` we exit the branch entirely, so
+                // the legacy `forward_pending_op_result_if_completed` call
+                // that follows the other op branches is DELIBERATELY
+                // ABSENT below: the bypass covers every case where
+                // `pending_op_result` is `Some` for a SUBSCRIBE tx, and
+                // by the time we reach `handle_op_request` we are
+                // guaranteed `pending_op_result.is_none()`. Adding the
+                // legacy forward call would be pure no-op noise.
                 if try_forward_task_per_tx_reply(
                     pending_op_result.as_ref(),
                     NetMessage::V1(NetMessageV1::Subscribe((*op).clone())),
@@ -1156,18 +1165,6 @@ where
                     source_addr,
                 )
                 .await;
-
-                // Legacy-path forwarding: no-op for SUBSCRIBE now that the
-                // task-per-tx bypass above handles every case where a
-                // callback is registered. Kept here for structural parity
-                // with the other op branches and to catch any future
-                // case where a legacy-path caller registers a callback
-                // without going through `OpCtx`.
-                forward_pending_op_result_if_completed(
-                    &op_result,
-                    pending_op_result.as_ref(),
-                    NetMessage::V1(NetMessageV1::Subscribe((*op).clone())),
-                );
 
                 if let Err(OpError::OpNotAvailable(state)) = &op_result {
                     match state {

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -772,6 +772,80 @@ fn op_retry_backoff(attempt: usize) -> Duration {
     Duration::from_millis((5u64 << attempt.min(8)).min(1_000))
 }
 
+/// Route an inbound task-per-tx reply directly to an awaiting
+/// [`OpCtx::send_and_await`][ocx] caller, bypassing the legacy op state
+/// machine entirely.
+///
+/// Returns `true` if a callback was registered and the message was forwarded
+/// (or dropped due to a closed receiver, which is also a successful
+/// "bypass taken" from the pipeline's point of view — the legacy path must
+/// not run). Returns `false` if no callback is registered; the caller then
+/// falls through to the legacy `handle_op_request` path.
+///
+/// # Why this exists
+///
+/// Phase 1 (#3802) wired [`forward_pending_op_result_if_completed`] to fire
+/// the callback after the legacy state machine classified the reply as
+/// completed. That only works when a [`crate::operations::OpEnum`] was
+/// previously pushed into [`crate::node::OpManager`]'s per-op DashMap:
+/// `load_or_init` pops it, `process_message` produces
+/// [`crate::operations::OperationResult::SendAndComplete`], and
+/// `is_operation_completed` returns `true`.
+///
+/// Phase 2b's task-per-tx callers (starting with client-initiated SUBSCRIBE,
+/// #1454) never push an op into that DashMap: state lives in the task's
+/// locals. When a reply arrives, `load_or_init` sees an empty slot and
+/// returns [`crate::operations::OpError::OpNotPresent`] (this is the
+/// legacy guard against stale responses arriving after GC cleanup, e.g.
+/// `operations/subscribe.rs:1181-1192`). `handle_op_result` swallows
+/// `OpNotPresent` as benign and returns `Ok(None)`, so
+/// `forward_pending_op_result_if_completed` short-circuits and the
+/// awaiting task hangs forever.
+///
+/// This helper is the fix: any branch of
+/// [`handle_pure_network_message_v1`] that wants to support a task-per-tx
+/// caller checks this first, and on a hit returns without ever touching
+/// `handle_op_request`. Phase 2b adds this guard to the SUBSCRIBE branch
+/// only; Phases 2c/3/4 will add it to their own branches when they
+/// introduce their first task-per-tx callers.
+///
+/// # Safety argument for the bypass
+///
+/// `p2p_protoc::pending_op_results` is only populated via
+/// `p2p_protoc::handle_op_execution`, which is only driven by
+/// [`OpCtx::send_and_await`][ocx]. Legacy paths (SUBSCRIBE renewals, PUT
+/// sub-op subscribes, intermediate-peer forwarding) never call it, so the
+/// bypass never triggers for them and their behavior is unchanged.
+///
+/// # Channel safety
+///
+/// Uses `try_send` on the bounded capacity-1 channel created by
+/// [`OpCtx::send_and_await`][ocx]. On a closed receiver (e.g., caller
+/// timed out or was cancelled) the send fails and is logged; the
+/// pure-network-message handler still makes progress. See
+/// `.claude/rules/channel-safety.md`.
+///
+/// [ocx]: crate::operations::OpCtx::send_and_await
+fn try_forward_task_per_tx_reply(
+    pending_op_result: Option<&tokio::sync::mpsc::Sender<NetMessage>>,
+    reply: NetMessage,
+    op_label: &'static str,
+) -> bool {
+    let Some(callback) = pending_op_result else {
+        return false;
+    };
+    let tx_id = *reply.id();
+    if let Err(err) = callback.try_send(reply) {
+        tracing::error!(
+            %err,
+            %tx_id,
+            op = op_label,
+            "Failed to forward task-per-tx reply to OpCtx task"
+        );
+    }
+    true
+}
+
 /// If `op_result` indicates the operation completed and a `pending_op_result`
 /// callback is wired, forward `reply` to the awaiting caller of
 /// [`crate::operations::OpCtx::send_and_await`].
@@ -1052,6 +1126,19 @@ where
                 .await;
             }
             NetMessageV1::Subscribe(ref op) => {
+                // Phase 2b (#1454): task-per-tx bypass for client-initiated
+                // SUBSCRIBE. See `try_forward_task_per_tx_reply` for the full
+                // reasoning (reply-side structural gap between Phase 1's
+                // forwarding hook and task-per-tx callers who never push an
+                // op into the OpManager DashMap).
+                if try_forward_task_per_tx_reply(
+                    pending_op_result.as_ref(),
+                    NetMessage::V1(NetMessageV1::Subscribe((*op).clone())),
+                    "subscribe",
+                ) {
+                    return Ok(None);
+                }
+
                 let op_result = handle_op_request::<subscribe::SubscribeOp, _>(
                     &op_manager,
                     &mut conn_manager,
@@ -1060,17 +1147,12 @@ where
                 )
                 .await;
 
-                // Handle pending operation results (network concern).
-                //
-                // Phase 2b deferred: `subscribe::complete_local_subscription`
-                // (operations/subscribe.rs) finishes a subscription without
-                // any network round-trip, so an `OpCtx::send_and_await`
-                // caller targeting a locally-completed SUBSCRIBE would still
-                // hang because no `NetMessage` ever reaches this branch.
-                // Handling the local-completion path requires either a
-                // synthetic "locally completed" reply at the task layer or
-                // a change to `OpCtx::send_and_await`'s contract. See
-                // #1454 §5 Phase 2b.
+                // Legacy-path forwarding: no-op for SUBSCRIBE now that the
+                // task-per-tx bypass above handles every case where a
+                // callback is registered. Kept here for structural parity
+                // with the other op branches and to catch any future
+                // case where a legacy-path caller registers a callback
+                // without going through `OpCtx`.
                 forward_pending_op_result_if_completed(
                     &op_result,
                     pending_op_result.as_ref(),
@@ -1864,10 +1946,34 @@ pub async fn subscribe(
     subscribe_with_id(op_manager, instance_id, client_id, None, false).await
 }
 
-/// Attempts to subscribe to a contract with a specific transaction ID (for deduplication)
+/// Attempts to subscribe to a contract with a specific transaction ID (for deduplication).
 ///
-/// `is_renewal` indicates whether this is a renewal (requester already has the contract).
-/// If true, the responder will skip sending state to save bandwidth.
+/// Since #1454 Phase 2b, this function is the entry point for client-initiated
+/// SUBSCRIBE only — it spawns a task-per-tx driver via
+/// [`crate::operations::subscribe::start_client_subscribe`] rather than going
+/// through the legacy `request_subscribe` + `handle_op_result` re-entry loop.
+///
+/// The renewal-initiated path (`ring::connection_maintenance`), the PUT
+/// sub-op path (`operations::start_subscription_request_internal`), and the
+/// executor/WASM-initiated path (`contract::executor::SubscribeContract::resume_op`)
+/// all call `subscribe::request_subscribe` directly and bypass this function,
+/// so they continue on the legacy path unchanged.
+///
+/// # Parameters
+///
+/// - `client_id`: If set, registers a legacy subscription-result waiter via
+///   `ch_outbound.waiting_for_subscription_result`. Both WS call sites in
+///   `client_events.rs` leave this `None` because they pre-register a
+///   transaction-result waiter via `waiting_for_transaction_result`.
+/// - `transaction_id`: The client-visible transaction id. If `None`, a fresh
+///   one is allocated — currently only the dead-code wrapper `subscribe()`
+///   does this.
+/// - `is_renewal`: Historical parameter. All live call sites pass `false`.
+///   Phase 2b's task-per-tx path is scoped to client-initiated (non-renewal)
+///   subscribes; if a future caller passes `true` through this function the
+///   debug assert below will fire during development so the renewal case
+///   can be re-evaluated (it belongs on the legacy path with jitter +
+///   spam-prevention handling).
 pub async fn subscribe_with_id(
     op_manager: Arc<OpManager>,
     instance_id: ContractInstanceId,
@@ -1875,31 +1981,37 @@ pub async fn subscribe_with_id(
     transaction_id: Option<Transaction>,
     is_renewal: bool,
 ) -> Result<Transaction, OpError> {
-    let op = match transaction_id {
-        Some(id) => subscribe::start_op_with_id(instance_id, id, is_renewal),
-        None => subscribe::start_op(instance_id, is_renewal),
+    debug_assert!(
+        !is_renewal,
+        "subscribe_with_id is client-initiated-only since #1454 Phase 2b; \
+         renewal callers must go through ring::connection_maintenance directly"
+    );
+
+    let client_tx = match transaction_id {
+        Some(id) => id,
+        None => Transaction::new::<subscribe::SubscribeMsg>(),
     };
-    let id = op.id;
+
     if let Some(client_id) = client_id {
         use crate::client_events::RequestId;
-        // Generate a default RequestId for internal subscription operations
+        // Generate a default RequestId for internal subscription operations.
+        // Legacy behaviour preserved: callers that pass a `client_id` expect
+        // the subscription-result waiter to be registered here. The WS path
+        // does not hit this branch (it pre-registers its own waiter).
         let request_id = RequestId::new();
         if let Err(e) = op_manager
             .ch_outbound
-            .waiting_for_subscription_result(id, instance_id, client_id, request_id)
+            .waiting_for_subscription_result(client_tx, instance_id, client_id, request_id)
             .await
         {
-            tracing::warn!(tx = %id, error = %e, "failed to register subscription result waiter");
+            tracing::warn!(tx = %client_tx, error = %e, "failed to register subscription result waiter");
         }
     }
-    // Initialize a subscribe op.
-    match subscribe::request_subscribe(&op_manager, op).await {
-        Err(err) => {
-            tracing::error!("{}", err);
-            Err(err)
-        }
-        Ok(()) => Ok(id),
-    }
+
+    // Task-per-tx: spawn the driver and return the client-visible tx
+    // immediately. The spawned task owns retries, peer selection, local
+    // completion, and result delivery via `result_router_tx`.
+    subscribe::start_client_subscribe(op_manager, instance_id, client_tx).await
 }
 
 async fn handle_aborted_op(
@@ -2554,7 +2666,10 @@ mod tests {
     // used to live on `OpManager::notify_op_execution`, which Phase 2a
     // replaced with `OpCtx::send_and_await` — see #1454.)
     mod callback_forward_tests {
-        use super::super::{OpError, OpNotAvailable, forward_pending_op_result_if_completed};
+        use super::super::{
+            OpError, OpNotAvailable, forward_pending_op_result_if_completed,
+            try_forward_task_per_tx_reply,
+        };
         use crate::message::{MessageStats, NetMessage, NetMessageV1, Transaction};
         use crate::operations::OpEnum;
         use crate::operations::connect::{ConnectMsg, ConnectOp, ConnectState};
@@ -2675,6 +2790,93 @@ mod tests {
 
             forward_pending_op_result_if_completed(&op_result, Some(&tx), dummy_reply());
             // Returning at all is the assertion.
+        }
+
+        // ───────────────────────────────────────────────────────────
+        // Phase 2b (#1454) task-per-tx bypass tests for
+        // `try_forward_task_per_tx_reply`.
+        //
+        // The bypass routes a reply directly to an awaiting
+        // `OpCtx::send_and_await` caller, skipping the legacy
+        // `handle_op_request` path entirely. These tests cover the
+        // helper's contract; end-to-end "the SUBSCRIBE branch of
+        // `handle_pure_network_message_v1` actually invokes the helper"
+        // coverage comes from the `run_client_subscribe` tests added
+        // alongside the Phase 2b migration.
+        // ───────────────────────────────────────────────────────────
+
+        #[tokio::test]
+        async fn bypass_forwards_when_callback_registered() {
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            let reply = dummy_reply();
+            let expected_id = *reply.id();
+
+            let taken = try_forward_task_per_tx_reply(Some(&tx), reply, "subscribe");
+            assert!(taken, "callback present → bypass must be taken");
+
+            let received = rx
+                .try_recv()
+                .expect("helper should forward the reply to the callback");
+            assert_eq!(*received.id(), expected_id);
+        }
+
+        #[tokio::test]
+        async fn bypass_returns_false_when_no_callback() {
+            // No callback registered → caller must fall through to legacy
+            // `handle_op_request`. The helper must not panic and must
+            // return `false`.
+            let taken = try_forward_task_per_tx_reply(None, dummy_reply(), "subscribe");
+            assert!(!taken, "no callback → bypass must not be taken");
+        }
+
+        #[tokio::test]
+        async fn bypass_returns_true_even_when_receiver_dropped() {
+            // Structural rule: once a callback is registered, the bypass
+            // is taken — the legacy path must NOT run regardless of
+            // whether the task-side receiver is still alive. If the task
+            // was cancelled and dropped its receiver, `try_send` fails
+            // with `Closed` and we log, but we still return `true` so
+            // the caller returns `Ok(None)` from the pipeline.
+            //
+            // Running `handle_op_request` in this case would call
+            // `load_or_init` on an empty DashMap and return
+            // `OpNotPresent`, which is meaningless for a tx owned by a
+            // (now-dead) task and pointlessly wastes a pipeline
+            // iteration.
+            let (tx, rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            drop(rx);
+
+            let taken = try_forward_task_per_tx_reply(Some(&tx), dummy_reply(), "subscribe");
+            assert!(
+                taken,
+                "callback present but receiver dropped → bypass still taken"
+            );
+        }
+
+        #[tokio::test]
+        async fn bypass_does_not_block_when_channel_already_full() {
+            // Defensive regression: `try_send` on a full channel must
+            // fail without blocking the pure-network-message handler.
+            // Although Phase 1's dedup guarantees the callback fires at
+            // most once per tx (so a "full" capacity-1 channel
+            // shouldn't happen in practice), this test pins the
+            // non-blocking contract so future refactors can't
+            // accidentally switch to `.send().await` and reintroduce
+            // the class of bug documented in
+            // `.claude/rules/channel-safety.md`.
+            let (tx, _rx) = tokio::sync::mpsc::channel::<NetMessage>(1);
+            // Pre-fill the capacity-1 channel.
+            tx.try_send(dummy_reply())
+                .expect("capacity-1 channel should accept first message");
+
+            let taken = try_forward_task_per_tx_reply(Some(&tx), dummy_reply(), "subscribe");
+            assert!(
+                taken,
+                "callback present but channel full → bypass still taken"
+            );
+            // The test would hang on regression: blocking `send().await`
+            // on a full channel whose receiver is still alive would
+            // stall the `#[tokio::test]` runtime indefinitely.
         }
 
         // Note on per-variant coverage: Phase 1's point is that every op

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -899,6 +899,17 @@ impl OpManager {
     /// per client tx, so per-attempt cleanup can't go through
     /// `send_client_result` (that would publish N duplicate results to
     /// the client).
+    ///
+    /// # Side effects on other `TransactionCompleted` consumers
+    ///
+    /// The `p2p_protoc::handle_notification_message` branch for
+    /// `TransactionCompleted` (lines 2030–2036) also calls
+    /// `state.tx_to_client.remove(&tx)`. For task-per-tx attempt txs this
+    /// is a tolerated no-op: `tx_to_client` is only populated on
+    /// client-visible txs via `ch_outbound.waiting_for_subscription_result`
+    /// / `waiting_for_transaction_result`, never on per-attempt txs. If a
+    /// future change starts keying `tx_to_client` by attempt tx, this
+    /// eager cleanup will silently drop mappings and must be revisited.
     pub(crate) fn release_pending_op_slot(&self, tx: Transaction) {
         if let Err(err) = self
             .to_event_listener

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -873,6 +873,46 @@ impl OpManager {
         Ok(op)
     }
 
+    /// Returns `true` if `id` has already been marked completed via
+    /// [`Self::completed`]. Used by Phase 2b's task-per-tx subscribe path
+    /// (#1454) to detect that `complete_local_subscription` already
+    /// published a terminal result, so the driver task can avoid a
+    /// duplicate `result_router_tx` send.
+    pub fn is_completed(&self, id: &Transaction) -> bool {
+        self.ops.completed.contains(id)
+    }
+
+    /// Emit a `NodeEvent::TransactionCompleted(tx)` to the event loop,
+    /// triggering cleanup of any `pending_op_results` entry keyed by `tx`.
+    ///
+    /// Used by Phase 2b's task-per-tx subscribe path (#1454) to release
+    /// the per-attempt callback slot in `p2p_protoc::pending_op_results`
+    /// after each `OpCtx::send_and_await` round-trip finishes. Without
+    /// this emission the attempt-tx entries accumulate until either the
+    /// periodic 60 s cleanup sweeps closed senders or the node shuts
+    /// down — see `test_pending_op_results_bounded` for the regression
+    /// guard.
+    ///
+    /// Distinct from [`Self::send_client_result`] which also emits this
+    /// event but additionally pushes a `HostResult` through
+    /// `result_router_tx`. The task-per-tx path has many attempt txs
+    /// per client tx, so per-attempt cleanup can't go through
+    /// `send_client_result` (that would publish N duplicate results to
+    /// the client).
+    pub(crate) fn release_pending_op_slot(&self, tx: Transaction) {
+        if let Err(err) = self
+            .to_event_listener
+            .notifications_sender
+            .try_send(Either::Right(NodeEvent::TransactionCompleted(tx)))
+        {
+            tracing::debug!(
+                %tx,
+                error = %err,
+                "failed to emit TransactionCompleted for pending_op_results cleanup"
+            );
+        }
+    }
+
     pub fn completed(&self, id: Transaction) {
         self.ring.live_tx_tracker.remove_finished_transaction(id);
         self.ops.under_progress.remove(&id);

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -873,15 +873,6 @@ impl OpManager {
         Ok(op)
     }
 
-    /// Returns `true` if `id` has already been marked completed via
-    /// [`Self::completed`]. Used by Phase 2b's task-per-tx subscribe path
-    /// (#1454) to detect that `complete_local_subscription` already
-    /// published a terminal result, so the driver task can avoid a
-    /// duplicate `result_router_tx` send.
-    pub fn is_completed(&self, id: &Transaction) -> bool {
-        self.ops.completed.contains(id)
-    }
-
     /// Emit a `NodeEvent::TransactionCompleted(tx)` to the event loop,
     /// triggering cleanup of any `pending_op_results` entry keyed by `tx`.
     ///
@@ -900,6 +891,19 @@ impl OpManager {
     /// `send_client_result` (that would publish N duplicate results to
     /// the client).
     ///
+    /// # Blocking vs non-blocking send
+    ///
+    /// Uses `send().await` wrapped in [`Self::NOTIFICATION_SEND_TIMEOUT`]
+    /// rather than `try_send` because the cleanup is load-bearing: a
+    /// dropped `TransactionCompleted` on a transiently-full notification
+    /// channel would leave the `pending_op_results` slot in place until
+    /// the 60 s periodic sweep runs, which
+    /// `test_pending_op_results_bounded` is designed to catch. Since this
+    /// method is only called from spawned task bodies (never from an
+    /// event loop), `send().await` is within the `.claude/rules/channel-safety.md`
+    /// rules. The 30 s timeout guards against a genuinely wedged event
+    /// loop — the same timeout [`Self::notify_op_change`] uses.
+    ///
     /// # Side effects on other `TransactionCompleted` consumers
     ///
     /// The `p2p_protoc::handle_notification_message` branch for
@@ -910,17 +914,34 @@ impl OpManager {
     /// / `waiting_for_transaction_result`, never on per-attempt txs. If a
     /// future change starts keying `tx_to_client` by attempt tx, this
     /// eager cleanup will silently drop mappings and must be revisited.
-    pub(crate) fn release_pending_op_slot(&self, tx: Transaction) {
-        if let Err(err) = self
-            .to_event_listener
-            .notifications_sender
-            .try_send(Either::Right(NodeEvent::TransactionCompleted(tx)))
+    pub(crate) async fn release_pending_op_slot(&self, tx: Transaction) {
+        match tokio::time::timeout(
+            Self::NOTIFICATION_SEND_TIMEOUT,
+            self.to_event_listener
+                .notifications_sender()
+                .send(Either::Right(NodeEvent::TransactionCompleted(tx))),
+        )
+        .await
         {
-            tracing::debug!(
-                %tx,
-                error = %err,
-                "failed to emit TransactionCompleted for pending_op_results cleanup"
-            );
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => {
+                tracing::warn!(
+                    %tx,
+                    "release_pending_op_slot: notification channel closed; \
+                     pending_op_results entry will be reclaimed by 60s sweep"
+                );
+            }
+            Err(_) => {
+                tracing::error!(
+                    %tx,
+                    timeout_secs = Self::NOTIFICATION_SEND_TIMEOUT.as_secs(),
+                    channel_pending = self.to_event_listener.notification_channel_pending(),
+                    channel_remaining = self.to_event_listener.notifications_sender().capacity(),
+                    "release_pending_op_slot: notification channel full for too long; \
+                     event loop may be stuck; pending_op_results entry will be \
+                     reclaimed by 60s sweep"
+                );
+            }
         }
     }
 

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -915,34 +915,12 @@ impl OpManager {
     /// future change starts keying `tx_to_client` by attempt tx, this
     /// eager cleanup will silently drop mappings and must be revisited.
     pub(crate) async fn release_pending_op_slot(&self, tx: Transaction) {
-        match tokio::time::timeout(
+        release_pending_op_slot_on(
+            self.to_event_listener.notifications_sender(),
+            tx,
             Self::NOTIFICATION_SEND_TIMEOUT,
-            self.to_event_listener
-                .notifications_sender()
-                .send(Either::Right(NodeEvent::TransactionCompleted(tx))),
         )
         .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(_)) => {
-                tracing::warn!(
-                    %tx,
-                    "release_pending_op_slot: notification channel closed; \
-                     pending_op_results entry will be reclaimed by 60s sweep"
-                );
-            }
-            Err(_) => {
-                tracing::error!(
-                    %tx,
-                    timeout_secs = Self::NOTIFICATION_SEND_TIMEOUT.as_secs(),
-                    channel_pending = self.to_event_listener.notification_channel_pending(),
-                    channel_remaining = self.to_event_listener.notifications_sender().capacity(),
-                    "release_pending_op_slot: notification channel full for too long; \
-                     event loop may be stuck; pending_op_results entry will be \
-                     reclaimed by 60s sweep"
-                );
-            }
-        }
     }
 
     pub fn completed(&self, id: Transaction) {
@@ -1234,6 +1212,52 @@ impl OpManager {
         self.neighbor_hosting.on_peer_disconnected(pub_key);
         self.interest_manager
             .schedule_deferred_removal(&PeerKey::from(pub_key.clone()));
+    }
+}
+
+/// Emit `NodeEvent::TransactionCompleted(tx)` through a provided
+/// notification sender, timeout-wrapped so a wedged event loop does not
+/// hang the caller forever.
+///
+/// Extracted from [`OpManager::release_pending_op_slot`] so the channel
+/// interaction can be unit-tested in isolation without building a full
+/// `OpManager` (review finding T-3). The `OpManager` method is a thin
+/// wrapper around this free function.
+///
+/// Uses `send().await` (wrapped in `timeout`) rather than `try_send`
+/// because the caller is Phase 2b's task-per-tx subscribe driver
+/// spawned via `GlobalExecutor::spawn` — a short blocking wait is
+/// within the channel-safety rules for that context, and dropping the
+/// event on transient backpressure would re-introduce the
+/// `test_pending_op_results_bounded` leak.
+async fn release_pending_op_slot_on(
+    notifications_sender: &mpsc::Sender<Either<NetMessage, NodeEvent>>,
+    tx: Transaction,
+    timeout: Duration,
+) {
+    match tokio::time::timeout(
+        timeout,
+        notifications_sender.send(Either::Right(NodeEvent::TransactionCompleted(tx))),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(_)) => {
+            tracing::warn!(
+                %tx,
+                "release_pending_op_slot: notification channel closed; \
+                 pending_op_results entry will be reclaimed by 60s sweep"
+            );
+        }
+        Err(_) => {
+            tracing::error!(
+                %tx,
+                timeout_secs = timeout.as_secs(),
+                "release_pending_op_slot: notification channel full for too long; \
+                 event loop may be stuck; pending_op_results entry will be \
+                 reclaimed by 60s sweep"
+            );
+        }
     }
 }
 
@@ -2241,6 +2265,161 @@ mod tests {
         assert!(
             !delivered,
             "notification delivery should fail once receiver is dropped"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // `release_pending_op_slot_on` tests (#1454 Phase 2b,
+    // review finding T-3). Tests the extracted helper directly
+    // so we don't need to build a full OpManager.
+    // ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn release_pending_op_slot_emits_transaction_completed() {
+        // Happy path: the helper must emit exactly one
+        // `TransactionCompleted(tx)` on the notification channel.
+        let (receiver, notifier) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut notifications_receiver,
+            ..
+        } = receiver;
+
+        let tx = Transaction::ttl_transaction();
+
+        super::release_pending_op_slot_on(
+            notifier.notifications_sender(),
+            tx,
+            Duration::from_secs(1),
+        )
+        .await;
+
+        let received = timeout(Duration::from_millis(100), notifications_receiver.recv())
+            .await
+            .expect("timed out waiting for TransactionCompleted emission")
+            .expect("notification channel closed");
+
+        #[allow(clippy::wildcard_enum_match_arm)]
+        match received {
+            Either::Right(NodeEvent::TransactionCompleted(observed)) => {
+                assert_eq!(observed, tx, "emitted tx must match the argument");
+            }
+            other => panic!("expected TransactionCompleted, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn release_pending_op_slot_blocks_through_backpressure() {
+        // Regression guard for review finding M1: the earlier
+        // `try_send` implementation would silently drop the cleanup
+        // event when the notification channel was transiently full.
+        // The `send().await` implementation must block and deliver
+        // once the consumer drains one slot.
+        let (receiver, notifier) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut notifications_receiver,
+            ..
+        } = receiver;
+
+        // Saturate the channel up to its capacity. The channel
+        // capacity is whatever `event_loop_notification_channel`
+        // configures — we don't hard-code it. Pre-fill until
+        // `try_send` fails, then use that count.
+        let filler_tx = Transaction::ttl_transaction();
+        let mut pre_filled = 0usize;
+        loop {
+            match notifier
+                .notifications_sender()
+                .try_send(Either::Right(NodeEvent::TransactionCompleted(filler_tx)))
+            {
+                Ok(()) => pre_filled += 1,
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => break,
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    panic!("channel unexpectedly closed while pre-filling")
+                }
+            }
+            // Safety valve: don't loop forever if the channel is
+            // unbounded or absurdly large. Real channel is bounded
+            // at a few hundred entries — if we hit this cap it's a
+            // test-config change and deserves an explicit fix.
+            if pre_filled > 4096 {
+                panic!("channel did not backpressure after 4096 entries");
+            }
+        }
+        assert!(
+            pre_filled > 0,
+            "expected a bounded channel; got what appears to be unbounded"
+        );
+
+        // Spawn the drain side a moment later: it will consume one
+        // entry, unblocking the `send().await` inside the helper.
+        let release_tx = Transaction::ttl_transaction();
+        let consumer = tokio::spawn(async move {
+            // Sleep briefly so the helper's `send().await` is already
+            // pending when we start draining.
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            // Drain one entry to create room.
+            notifications_receiver
+                .recv()
+                .await
+                .expect("notification channel closed during drain");
+            // Keep draining until we see our release event. Additional
+            // pre-filled entries may sit ahead of it.
+            loop {
+                match notifications_receiver.recv().await {
+                    Some(Either::Right(NodeEvent::TransactionCompleted(observed)))
+                        if observed == release_tx =>
+                    {
+                        return;
+                    }
+                    Some(_) => continue,
+                    None => panic!("channel closed before release event observed"),
+                }
+            }
+        });
+
+        // The helper must not complete instantaneously (channel is
+        // saturated) but must complete once the consumer drains. Give
+        // it up to 2 s — plenty of slack for the 20 ms drain delay.
+        let release = timeout(
+            Duration::from_secs(2),
+            super::release_pending_op_slot_on(
+                notifier.notifications_sender(),
+                release_tx,
+                Duration::from_secs(30),
+            ),
+        )
+        .await;
+        release.expect("helper must complete once channel has room");
+
+        consumer
+            .await
+            .expect("consumer task should terminate cleanly");
+    }
+
+    #[tokio::test]
+    async fn release_pending_op_slot_returns_on_closed_channel() {
+        // If the notification channel is closed entirely (receiver
+        // dropped), the helper must return promptly (via the `Err`
+        // arm of the inner match) rather than hanging on
+        // `send().await`. The 60 s periodic sweep will still reclaim
+        // the slot eventually; this test pins "no hang."
+        let (receiver, notifier) = event_loop_notification_channel();
+        drop(receiver);
+
+        let tx = Transaction::ttl_transaction();
+
+        let result = timeout(
+            Duration::from_millis(200),
+            super::release_pending_op_slot_on(
+                notifier.notifications_sender(),
+                tx,
+                Duration::from_secs(30),
+            ),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "helper must return promptly on closed channel"
         );
     }
 

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -161,6 +161,22 @@ pub enum SimOperation {
         /// New state data
         data: Vec<u8>,
     },
+    /// Seed a contract into a node's local store WITHOUT network propagation.
+    ///
+    /// Unlike `Put`, this does not trigger a network PUT operation — the
+    /// contract is only stored in the target node's `MockStateStorage`.
+    /// This is useful for setting up test scenarios where specific nodes
+    /// must have (or not have) a contract before subscribe/get operations.
+    ///
+    /// Example: seed only on gateway, then subscribe from other nodes.
+    /// The subscribe will go through the network because other nodes lack
+    /// the contract, and relay peers will forward (generating ForwardingAck).
+    SeedContract {
+        /// The contract container (code + parameters)
+        contract: ContractContainer,
+        /// Initial state bytes
+        state: Vec<u8>,
+    },
 }
 
 impl SimOperation {
@@ -267,6 +283,12 @@ impl SimOperation {
                     key,
                     data: UpdateData::State(State::from(data)),
                 })
+            }
+            SimOperation::SeedContract { .. } => {
+                panic!(
+                    "SeedContract is not a client request — it must be handled \
+                     by run_controlled_simulation before event dispatch"
+                )
             }
         }
     }
@@ -3372,12 +3394,31 @@ impl SimNetwork {
             .rng_seed(seed)
             .build();
 
+        // Separate SeedContract operations (pre-simulation storage seeding)
+        // from event operations (dispatched during simulation).
+        let mut seed_ops: Vec<(NodeLabel, ContractContainer, Vec<u8>)> = Vec::new();
+        let mut event_ops: Vec<ScheduledOperation> = Vec::new();
+        for scheduled_op in operations {
+            match scheduled_op.operation {
+                SimOperation::SeedContract {
+                    ref contract,
+                    ref state,
+                } => {
+                    seed_ops.push((scheduled_op.node, contract.clone(), state.clone()));
+                }
+                SimOperation::Put { .. }
+                | SimOperation::Get { .. }
+                | SimOperation::Subscribe { .. }
+                | SimOperation::Update { .. } => event_ops.push(scheduled_op),
+            }
+        }
+
         // Build a map of label -> list of (event_id, operation)
         let mut operations_by_node: HashMap<NodeLabel, Vec<(EventId, SimOperation)>> =
             HashMap::new();
         let mut operation_sequence: Vec<(EventId, NodeLabel)> = Vec::new();
 
-        for (event_id, scheduled_op) in operations.into_iter().enumerate() {
+        for (event_id, scheduled_op) in event_ops.into_iter().enumerate() {
             let event_id = event_id as EventId;
             operation_sequence.push((event_id, scheduled_op.node.clone()));
             operations_by_node
@@ -3390,6 +3431,12 @@ impl SimNetwork {
         // gives tests access to the same data written during the simulation.
         let mut node_storages: HashMap<NodeLabel, crate::wasm_runtime::MockStateStorage> =
             HashMap::new();
+        // Pre-seeded contract stores for nodes with SeedContract operations.
+        // Wrapped in Arc<Mutex> so closures can look up their store at
+        // startup (after seed_ops populates the map, before sim.run()).
+        let contract_stores: Arc<
+            Mutex<HashMap<NodeLabel, crate::wasm_runtime::InMemoryContractStore>>,
+        > = Arc::new(Mutex::new(HashMap::new()));
 
         let use_mock_wasm = self.use_mock_wasm;
 
@@ -3429,12 +3476,16 @@ impl SimNetwork {
             let user_events = Arc::new(Mutex::new(Some(user_events)));
             let span = Arc::new(Mutex::new(Some(span)));
             let shared_storage = Arc::new(Mutex::new(Some(shared_storage)));
+            let contract_stores = contract_stores.clone();
+            let label_for_closure = label.clone();
 
             sim.host(host_name, move || {
                 let node = node.clone();
                 let user_events = user_events.clone();
                 let span = span.clone();
                 let shared_storage = shared_storage.clone();
+                let contract_stores = contract_stores.clone();
+                let label = label_for_closure.clone();
 
                 async move {
                     let node = node
@@ -3457,9 +3508,10 @@ impl SimNetwork {
                         .unwrap()
                         .take()
                         .expect("Turmoil host should only be called once");
+                    let cs = contract_stores.lock().unwrap().remove(&label);
 
                     if use_mock_wasm {
-                        node.run_node_with_mock_wasm(user_events, span, shared_storage)
+                        node.run_node_with_mock_wasm(user_events, span, shared_storage, cs)
                             .await
                             .map_err(|e| {
                                 Box::new(std::io::Error::other(e.to_string()))
@@ -3512,12 +3564,16 @@ impl SimNetwork {
             let user_events = Arc::new(Mutex::new(Some(user_events)));
             let span = Arc::new(Mutex::new(Some(span)));
             let shared_storage = Arc::new(Mutex::new(Some(shared_storage)));
+            let contract_stores = contract_stores.clone();
+            let label_for_closure = label.clone();
 
             sim.host(host_name, move || {
                 let node = node.clone();
                 let user_events = user_events.clone();
                 let span = span.clone();
                 let shared_storage = shared_storage.clone();
+                let contract_stores = contract_stores.clone();
+                let label = label_for_closure.clone();
 
                 async move {
                     let node = node
@@ -3540,9 +3596,10 @@ impl SimNetwork {
                         .unwrap()
                         .take()
                         .expect("Turmoil host should only be called once");
+                    let cs = contract_stores.lock().unwrap().remove(&label);
 
                     if use_mock_wasm {
-                        node.run_node_with_mock_wasm(user_events, span, shared_storage)
+                        node.run_node_with_mock_wasm(user_events, span, shared_storage, cs)
                             .await
                             .map_err(|e| {
                                 Box::new(std::io::Error::other(e.to_string()))
@@ -3558,6 +3615,33 @@ impl SimNetwork {
                     }
                 }
             });
+        }
+
+        // Apply SeedContract operations: pre-populate specific nodes'
+        // contract stores and state storage. This bypasses network PUT
+        // so the contract exists only on the seeded nodes.
+        for (label, contract, state) in seed_ops {
+            let storage = node_storages
+                .get(&label)
+                .unwrap_or_else(|| panic!("SeedContract: node {label:?} not found in storages"));
+            let key = contract.key();
+            storage.seed_state(key, WrappedState::new(state));
+            storage.seed_params(key, contract.params().clone());
+            // Also seed into the contract store (WASM code + params).
+            // Without this, the WASM cache check in client_events.rs
+            // rejects subscribes with "contract WASM not cached locally".
+            let mut stores = contract_stores.lock().unwrap();
+            let contract_store = stores.entry(label.clone()).or_default();
+            contract_store
+                .store_contract(contract.clone())
+                .unwrap_or_else(|e| {
+                    panic!("SeedContract: failed to store contract for {label:?}: {e}")
+                });
+            tracing::debug!(
+                node = %label,
+                contract = %key,
+                "SeedContract: pre-populated contract in node storage"
+            );
         }
 
         // Take the event controller and labels for triggering events
@@ -3987,7 +4071,7 @@ impl SimNetwork {
 
                 let handle = if use_mock_wasm {
                     tokio::spawn(async move {
-                        node.run_node_with_mock_wasm(user_events, span, shared_storage)
+                        node.run_node_with_mock_wasm(user_events, span, shared_storage, None)
                             .await
                     })
                 } else {
@@ -4042,7 +4126,7 @@ impl SimNetwork {
                 let handle = if use_mock_wasm {
                     tokio::spawn(async move {
                         tokio::time::sleep(backoff).await;
-                        node.run_node_with_mock_wasm(user_events, span, shared_storage)
+                        node.run_node_with_mock_wasm(user_events, span, shared_storage, None)
                             .await
                     })
                 } else {

--- a/crates/core/src/node/testing_impl/in_memory.rs
+++ b/crates/core/src/node/testing_impl/in_memory.rs
@@ -332,6 +332,7 @@ impl<ER> Builder<ER> {
         user_events: UsrEv,
         parent_span: tracing::Span,
         shared_storage: MockStateStorage,
+        contract_store: Option<crate::wasm_runtime::InMemoryContractStore>,
     ) -> anyhow::Result<()>
     where
         UsrEv: ClientEventsProxy + Send + 'static,
@@ -385,6 +386,7 @@ impl<ER> Builder<ER> {
             MockWasmHandlerBuilder {
                 identifier: self.contract_handler_name,
                 shared_storage,
+                contract_store,
             },
         )
         .await

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -1,8 +1,11 @@
 //! Per-transaction execution context for the task-per-tx model (#1454).
 //!
 //! This module ships the `OpCtx` struct and its `send_and_await` round-trip
-//! primitive as dormant scaffolding. See the struct-level docs for the Phase
-//! 2a scope boundary.
+//! primitive. Phase 2a (PR #3803) landed `OpCtx` as dormant scaffolding
+//! with only unit-test callers; Phase 2b wires in the first production
+//! caller (client-initiated SUBSCRIBE, via
+//! [`crate::operations::subscribe::start_client_subscribe`]) so the
+//! `#[allow(dead_code)]` attributes from Phase 2a have been lifted.
 
 use tokio::sync::mpsc;
 
@@ -16,21 +19,20 @@ use crate::operations::OpError;
 /// driven by a single task; the context is [`Send`] but intentionally not
 /// [`Clone`].
 ///
-/// # Phase 2a scope
+/// # Phase 2a / 2b scope
 ///
-/// Phase 2a (#1454) ships this type as scaffolding only. The wider API
-/// sketched in the design doc (`spawn_sub`, per-tx WS fanout via `notify`,
-/// per-tx inbox, `OpRegistry`, and so on) is deferred. The only caller in
-/// Phase 2a is the unit tests in this module — no op in `operations/` has
-/// been migrated yet. Phase 2b will add the first production caller by
-/// migrating SUBSCRIBE's client-initiated path.
-#[allow(dead_code)] // Phase 2a scaffolding: first production caller lands in Phase 2b (#1454).
+/// Phase 2a (#1454) shipped this type with only the round-trip primitive
+/// `send_and_await`. The wider API sketched in the design doc
+/// (`spawn_sub`, per-tx WS fanout via `notify`, per-tx inbox,
+/// `OpRegistry`, and so on) is still deferred to later phases. Phase 2b
+/// activated the primitive by migrating SUBSCRIBE's client-initiated path
+/// onto it (see
+/// [`crate::operations::subscribe::start_client_subscribe`]).
 pub(crate) struct OpCtx {
     tx: Transaction,
     op_execution_sender: mpsc::Sender<(mpsc::Sender<NetMessage>, NetMessage)>,
 }
 
-#[allow(dead_code)] // Phase 2a scaffolding: first production caller lands in Phase 2b (#1454).
 impl OpCtx {
     /// Construct a new context bound to `tx`.
     ///
@@ -47,6 +49,14 @@ impl OpCtx {
     }
 
     /// The transaction this context is bound to.
+    ///
+    /// Unused by the Phase 2b production caller (the task holds the
+    /// attempt tx in a local), but kept on the API because later phases
+    /// (per-tx inbox, `OpRegistry`) will need the identity accessor to
+    /// look up per-tx state owned by other components. Dropping and
+    /// re-adding the getter would churn the public surface of `OpCtx`
+    /// without benefit.
+    #[allow(dead_code)] // Kept as stable API surface for later task-per-tx phases (#1454).
     pub fn tx(&self) -> Transaction {
         self.tx
     }

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -307,24 +307,165 @@ pub(crate) async fn request_subscribe(
     let SubscribeState::PrepareRequest(ref data) = sub_op.state else {
         return Err(OpError::UnexpectedOpState);
     };
-    let id = &data.id;
-    let instance_id = &data.instance_id;
+    let id = data.id;
+    let instance_id = data.instance_id;
     let is_renewal = data.is_renewal;
 
     tracing::debug!(tx = %id, contract = %instance_id, is_renewal, "subscribe: request_subscribe invoked");
 
+    match prepare_initial_request(op_manager, id, instance_id, is_renewal).await? {
+        InitialRequest::LocallyComplete { key } => {
+            complete_local_subscription(op_manager, id, key, is_renewal).await
+        }
+        InitialRequest::NoHostingPeers => Err(RingError::NoHostingPeers(instance_id).into()),
+        InitialRequest::PeerNotJoined => Err(RingError::PeerNotJoined.into()),
+        InitialRequest::NetworkRequest {
+            target,
+            target_addr,
+            visited,
+            alternatives,
+            htl,
+        } => {
+            let msg = SubscribeMsg::Request {
+                id,
+                instance_id,
+                htl,
+                visited: visited.clone(),
+                is_renewal,
+            };
+
+            let mut tried_peers = HashSet::new();
+            tried_peers.insert(target_addr);
+
+            let op = SubscribeOp {
+                id,
+                state: SubscribeState::AwaitingResponse(AwaitingResponseData {
+                    next_hop: Some(target_addr),
+                    instance_id,
+                    retries: 0,
+                    current_hop: htl,
+                    tried_peers,
+                    alternatives, // remaining candidates after remove(0)
+                    attempts_at_hop: 1,
+                    visited,
+                }),
+                requester_addr: None, // We're the originator
+                requester_pub_key: None,
+                is_renewal,
+                stats: Some(SubscribeStats {
+                    target_peer: target,
+                    contract_location: Location::from(&instance_id),
+                    request_sent_at: Instant::now(),
+                }),
+                ack_received: false,
+                speculative_paths: 0,
+            };
+
+            // Renewals use non-blocking send to fail fast under congestion rather
+            // than blocking 30 s and compounding it. Client subscribes use the
+            // blocking path for a definitive success/failure response.
+            if is_renewal {
+                op_manager
+                    .notify_op_change_nonblocking(NetMessage::from(msg), OpEnum::Subscribe(op))
+                    .await?;
+            } else {
+                op_manager
+                    .notify_op_change(NetMessage::from(msg), OpEnum::Subscribe(op))
+                    .await?;
+            }
+
+            Ok(())
+        }
+    }
+}
+
+/// Outcome of [`prepare_initial_request`]: the decision about how to originate
+/// a subscribe request based on the node's current ring state and contract
+/// availability.
+///
+/// This type exists so both the legacy state-machine path (`request_subscribe`)
+/// and the task-per-tx path (`op_ctx_task::run_client_subscribe`, #1454 Phase
+/// 2b) can share the "which peer, or local-complete, or give up?" decision
+/// logic without duplicating `k_closest_potentially_hosting` + fallback +
+/// local-completion handling.
+///
+/// The returned values describe what the caller should do; the helper does
+/// NOT mutate `op_manager` or push state. Any side-effects (emitting
+/// telemetry via `NetEventLog::subscribe_request`, calling
+/// `complete_local_subscription`, pushing state, sending the wire message)
+/// are the caller's responsibility.
+#[derive(Debug)]
+pub(super) enum InitialRequest {
+    /// Contract is available locally and no network round-trip is required.
+    /// Caller should call [`complete_local_subscription`] with the original
+    /// transaction id and propagate its result.
+    LocallyComplete { key: ContractKey },
+    /// No remote peers could be found and the contract is not available
+    /// locally. Caller should return `RingError::NoHostingPeers`.
+    NoHostingPeers,
+    /// Peer has not joined the ring yet (no own location) and the contract is
+    /// not available locally. Caller should return `RingError::PeerNotJoined`.
+    PeerNotJoined,
+    /// A target peer was selected and the caller should send a
+    /// `SubscribeMsg::Request` to it. `visited` and `alternatives` carry the
+    /// routing state the caller must thread into its retry logic.
+    NetworkRequest {
+        /// The chosen target peer (already removed from `alternatives`).
+        target: PeerKeyLocation,
+        /// Socket address of `target`; pre-resolved for convenience.
+        target_addr: std::net::SocketAddr,
+        /// Bloom filter of visited peers, already including `own_addr` and
+        /// `target_addr`. Callers should clone this into the outgoing
+        /// `SubscribeMsg::Request.visited`.
+        visited: super::VisitedPeers,
+        /// Remaining k_closest candidates not yet tried at this hop.
+        alternatives: Vec<PeerKeyLocation>,
+        /// Initial HTL for the request (= `op_manager.ring.max_hops_to_live`).
+        htl: usize,
+    },
+}
+
+/// Compute the initial "where do we send this subscribe, or do we complete
+/// locally?" decision for a subscribe request.
+///
+/// Factored out of [`request_subscribe`] so the task-per-tx client-initiated
+/// path (`op_ctx_task::run_client_subscribe`, #1454 Phase 2b) can reuse the
+/// exact same ring lookup / fallback / local-completion logic without
+/// duplicating it. The helper is pure modulo telemetry emission: it calls
+/// `NetEventLog::subscribe_request` on the `NetworkRequest` branch so both
+/// callers get identical event logs, but it does not mutate `op_manager`
+/// state and does not push any `SubscribeOp` into the per-op DashMap.
+///
+/// The decision branches exactly mirror the pre-extraction body of
+/// `request_subscribe`:
+///
+/// 1. If the peer has no ring location (hasn't joined), check local contract
+///    availability and either complete locally or return `PeerNotJoined`.
+/// 2. Query `k_closest_potentially_hosting` with `own_addr` already visited.
+///    If it returns candidates, take the first as the target.
+/// 3. If `k_closest` returned empty, fall back to any connected peer that
+///    hasn't been visited (sorted by location for determinism).
+/// 4. If no fallback is available either, check local contract availability
+///    one more time (standalone node / sole holder case) and either complete
+///    locally or return `NoHostingPeers`.
+pub(super) async fn prepare_initial_request(
+    op_manager: &OpManager,
+    id: Transaction,
+    instance_id: ContractInstanceId,
+    is_renewal: bool,
+) -> Result<InitialRequest, OpError> {
     let own_addr = match op_manager.ring.connection_manager.peer_addr() {
         Ok(addr) => addr,
         Err(_) => {
             // Peer hasn't joined the network yet - check if contract is available locally
-            if let Some(key) = super::has_contract(op_manager, *instance_id).await? {
+            if let Some(key) = super::has_contract(op_manager, instance_id).await? {
                 tracing::info!(
                     tx = %id,
                     contract = %key,
                     phase = "local_complete",
                     "Peer not joined, but contract available locally - completing subscription locally"
                 );
-                return complete_local_subscription(op_manager, *id, key, is_renewal).await;
+                return Ok(InitialRequest::LocallyComplete { key });
             }
             tracing::warn!(
                 tx = %id,
@@ -332,7 +473,7 @@ pub(crate) async fn request_subscribe(
                 phase = "peer_not_joined",
                 "Cannot subscribe: peer has not joined network yet and contract not available locally"
             );
-            return Err(RingError::PeerNotJoined.into());
+            return Ok(InitialRequest::PeerNotJoined);
         }
     };
 
@@ -346,13 +487,13 @@ pub(crate) async fn request_subscribe(
     // This ensures proper subscription tree management for update propagation.
 
     // Find a peer to forward the request to (needed even if we have contract locally)
-    let mut visited = super::VisitedPeers::new(id);
+    let mut visited = super::VisitedPeers::new(&id);
     visited.mark_visited(own_addr);
 
     let mut candidates =
         op_manager
             .ring
-            .k_closest_potentially_hosting(instance_id, &visited, MAX_BREADTH);
+            .k_closest_potentially_hosting(&instance_id, &visited, MAX_BREADTH);
 
     // First try the best candidates from k_closest_potentially_hosting.
     // If that returns empty, fall back to any available connection.
@@ -396,17 +537,17 @@ pub(crate) async fn request_subscribe(
             None => {
                 // Truly no connections available - fall back to local completion only if isolated.
                 // This handles the case of a standalone node or when we're the only node with the contract.
-                if let Some(key) = super::has_contract(op_manager, *instance_id).await? {
+                if let Some(key) = super::has_contract(op_manager, instance_id).await? {
                     tracing::info!(
                         tx = %id,
                         contract = %key,
                         phase = "local_complete",
                         "Contract available locally and no network connections, completing subscription locally"
                     );
-                    return complete_local_subscription(op_manager, *id, key, is_renewal).await;
+                    return Ok(InitialRequest::LocallyComplete { key });
                 }
                 tracing::warn!(tx = %id, contract = %instance_id, phase = "error", "No remote peers available for subscription");
-                return Err(RingError::NoHostingPeers(*instance_id).into());
+                return Ok(InitialRequest::NoHostingPeers);
             }
         }
     };
@@ -419,71 +560,31 @@ pub(crate) async fn request_subscribe(
     tracing::debug!(
         tx = %id,
         contract = %instance_id,
+        is_renewal,
         target_peer = %target_addr,
         "subscribe: forwarding Request to target peer"
     );
 
-    let msg = SubscribeMsg::Request {
-        id: *id,
-        instance_id: *instance_id,
-        htl: op_manager.ring.max_hops_to_live,
-        visited: visited.clone(),
-        is_renewal,
-    };
-
-    // Emit telemetry for subscribe request initiation
+    // Emit telemetry for subscribe request initiation. Placed inside the
+    // helper so both the legacy and task-per-tx paths produce identical
+    // `NetEventLog::subscribe_request` events.
     if let Some(event) = NetEventLog::subscribe_request(
-        id,
+        &id,
         &op_manager.ring,
-        *instance_id,
+        instance_id,
         target.clone(),
         op_manager.ring.max_hops_to_live,
     ) {
         op_manager.ring.register_events(Either::Left(event)).await;
     }
 
-    let htl = op_manager.ring.max_hops_to_live;
-    let mut tried_peers = HashSet::new();
-    tried_peers.insert(target_addr);
-
-    let op = SubscribeOp {
-        id: *id,
-        state: SubscribeState::AwaitingResponse(AwaitingResponseData {
-            next_hop: Some(target_addr),
-            instance_id: *instance_id,
-            retries: 0,
-            current_hop: htl,
-            tried_peers,
-            alternatives: candidates, // remaining candidates after remove(0)
-            attempts_at_hop: 1,
-            visited,
-        }),
-        requester_addr: None, // We're the originator
-        requester_pub_key: None,
-        is_renewal,
-        stats: Some(SubscribeStats {
-            target_peer: target.clone(),
-            contract_location: Location::from(instance_id),
-            request_sent_at: Instant::now(),
-        }),
-        ack_received: false,
-        speculative_paths: 0,
-    };
-
-    // Renewals use non-blocking send to fail fast under congestion rather
-    // than blocking 30 s and compounding it. Client subscribes use the
-    // blocking path for a definitive success/failure response.
-    if is_renewal {
-        op_manager
-            .notify_op_change_nonblocking(NetMessage::from(msg), OpEnum::Subscribe(op))
-            .await?;
-    } else {
-        op_manager
-            .notify_op_change(NetMessage::from(msg), OpEnum::Subscribe(op))
-            .await?;
-    }
-
-    Ok(())
+    Ok(InitialRequest::NetworkRequest {
+        target,
+        target_addr,
+        visited,
+        alternatives: candidates,
+        htl: op_manager.ring.max_hops_to_live,
+    })
 }
 
 /// Complete a **standalone** local subscription by notifying the client layer.
@@ -2104,6 +2205,12 @@ impl IsOperationCompleted for SubscribeOp {
 
 #[cfg(test)]
 mod tests;
+
+/// Task-per-transaction client-initiated SUBSCRIBE path (#1454 Phase 2b).
+/// First production consumer of `OpCtx::send_and_await`.
+mod op_ctx_task;
+
+pub(crate) use op_ctx_task::start_client_subscribe;
 
 mod messages {
     use std::fmt::Display;

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -682,6 +682,16 @@ impl SubscribeOp {
         }
     }
 
+    /// Extract the contract key from a completed subscribe operation.
+    pub(crate) fn completed_key(&self) -> Option<ContractKey> {
+        match &self.state {
+            SubscribeState::Completed(data) => Some(data.key),
+            SubscribeState::PrepareRequest(_)
+            | SubscribeState::AwaitingResponse(_)
+            | SubscribeState::Failed => None,
+        }
+    }
+
     /// Whether this is a subscription renewal (node-internal, no client waiting).
     pub(crate) fn is_renewal(&self) -> bool {
         self.is_renewal

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -447,9 +447,15 @@ async fn advance_to_next_peer(
     retries: &mut usize,
     attempts_at_hop: &mut usize,
 ) -> Option<(PeerKeyLocation, std::net::SocketAddr)> {
-    // 1. Breadth retry at the same hop.
+    // 1. Breadth retry at the same hop. Use FIFO (`remove(0)`) to match the
+    //    legacy `handle_op_response` ordering (`subscribe.rs:949, 1821`).
+    //    `alternatives` is built in closest-first order by
+    //    `k_closest_potentially_hosting`, so FIFO means we try the best
+    //    candidate we have not yet tried. LIFO (`pop()`) would iterate in
+    //    reverse-distance order and diverge from legacy routing behaviour.
     if *attempts_at_hop < MAX_BREADTH {
-        while let Some(candidate) = alternatives.pop() {
+        while !alternatives.is_empty() {
+            let candidate = alternatives.remove(0);
             if let Some(addr) = candidate.socket_addr() {
                 if tried_peers.contains(&addr) || visited.probably_visited(addr) {
                     continue;

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -113,13 +113,38 @@ pub(crate) async fn start_client_subscribe(
     // `notify_op_change` and returns `Ok(())` immediately, letting the
     // event loop drive the rest).
     //
-    // Not registered with BackgroundTaskMonitor: like legacy subscribe
-    // work, this task is scoped to a single transaction and terminates
-    // on its own either on success, error, or the OPERATION_TTL-wrapped
-    // timeout path in the retry loop. A leaked task here would cost one
-    // tx slot in `pending_op_results` and one spawned future — bounded
-    // by the client-side rate-limiting on SUBSCRIBE requests, not
-    // unbounded amplification.
+    // Not registered with `BackgroundTaskMonitor`: per the decision tree
+    // in `.claude/rules/code-style.md` under "WHEN spawning tasks with
+    // `GlobalExecutor::spawn`", the monitor is for tasks that must run
+    // for the node's lifetime. This driver is per-transaction and
+    // terminates on its own via one of:
+    //
+    //   1. Happy path: `send_and_await` returns a terminal reply, loop exits.
+    //   2. Exhaustion path: `advance_to_next_peer` returns `None`, loop exits.
+    //   3. Per-attempt timeout: each `send_and_await` is wrapped in
+    //      `tokio::time::timeout(OPERATION_TTL, ...)`; a timed-out attempt
+    //      advances to the next peer or falls into the exhaustion path.
+    //   4. `OpCtx::send_and_await` infrastructure error (executor channel
+    //      closed / receiver dropped): surfaces as `DriverOutcome::InfrastructureError`
+    //      and exits via `deliver_outcome`.
+    //
+    // Amplification ceiling: the WS SUBSCRIBE request path enforces
+    // `MAX_SUBSCRIPTIONS_PER_CLIENT = 50` upstream via
+    // `notify_contract_handler(RegisterSubscriberListener)` →
+    // `runtime.rs:623` (Executor::register_subscription), which rejects
+    // the registration BEFORE `subscribe_with_id` is called. A client
+    // that tries to open more than 50 in-flight subscribes gets a
+    // `SubscriberLimit` error from the contract handler and never
+    // reaches this spawn site. In-flight task count is therefore
+    // bounded by `num_clients * 50`, not unbounded.
+    //
+    // Leak detection: if the driver somehow gets stuck without exiting
+    // any of the four paths above, `test_pending_op_results_bounded`
+    // (which watches `pending_op_inserts - pending_op_removes`) will
+    // flag the leak during simulation tests. Because every
+    // `send_and_await` attempt both inserts (via `handle_op_execution`)
+    // and removes (via `release_pending_op_slot`) a `pending_op_results`
+    // slot, a stuck task would show up as a widening insert/remove gap.
     GlobalExecutor::spawn(run_client_subscribe(op_manager, instance_id, client_tx));
 
     Ok(client_tx)
@@ -315,16 +340,24 @@ async fn drive_client_subscribe_inner(
         let reply = match round_trip {
             Ok(Ok(reply)) => reply,
             Ok(Err(err)) => {
+                // `send_and_await` infrastructure failure (executor
+                // channel closed, receiver dropped). Distinct from a
+                // wire-level `NotFound` for observability purposes:
+                // emit a structured `outcome=wire_error` field so log
+                // analytics can tell them apart. Retry behaviour is
+                // the same as NotFound — from "should we try another
+                // peer?" the answer is yes — so the downstream logic
+                // is shared (review finding T-4).
                 tracing::warn!(
                     tx = %client_tx,
                     attempt_tx = %attempt_tx,
+                    target = %current_target_addr,
+                    retries,
+                    attempts_at_hop,
+                    outcome = "wire_error",
                     error = %err,
-                    "subscribe (task-per-tx): send_and_await failed; treating as peer timeout"
+                    "subscribe (task-per-tx): send_and_await failed; advancing to next peer"
                 );
-                // Fall through to the "peer timeout / try next" branch.
-                // We don't distinguish infrastructure failure from a
-                // wire-level NotFound here — from "should we retry on a
-                // different peer?" the answer is the same.
                 match advance_to_next_peer(
                     op_manager,
                     &instance_id,
@@ -354,11 +387,20 @@ async fn drive_client_subscribe_inner(
                 }
             }
             Err(_) => {
+                // OPERATION_TTL elapsed without the peer producing a
+                // terminal reply. Distinct from `wire_error` (which is
+                // an infrastructure failure on the executor/send side)
+                // and from `not_found` (a legitimate wire-level
+                // response). `outcome=timeout` (review finding T-4).
                 tracing::warn!(
                     tx = %client_tx,
                     attempt_tx = %attempt_tx,
                     target = %current_target_addr,
-                    "subscribe (task-per-tx): attempt timed out after OPERATION_TTL; trying next peer"
+                    retries,
+                    attempts_at_hop,
+                    outcome = "timeout",
+                    timeout_secs = OPERATION_TTL.as_secs(),
+                    "subscribe (task-per-tx): attempt timed out; advancing to next peer"
                 );
                 match advance_to_next_peer(
                     op_manager,
@@ -397,6 +439,10 @@ async fn drive_client_subscribe_inner(
                     tx = %client_tx,
                     attempt_tx = %attempt_tx,
                     contract = %key,
+                    target = %current_target_addr,
+                    retries,
+                    attempts_at_hop,
+                    outcome = "subscribed",
                     "subscribe (task-per-tx): subscribed"
                 );
                 return Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
@@ -407,10 +453,20 @@ async fn drive_client_subscribe_inner(
                 ))));
             }
             ReplyClass::NotFound => {
+                // Wire-level NotFound from a legitimate peer response.
+                // Distinct from `wire_error` (executor/send failure)
+                // and `timeout` (no terminal reply at all), so log
+                // analytics can count "contract not found at this
+                // peer" separately from infrastructure issues (review
+                // finding T-4).
                 tracing::debug!(
                     tx = %client_tx,
                     attempt_tx = %attempt_tx,
-                    "subscribe (task-per-tx): NotFound, trying next peer"
+                    target = %current_target_addr,
+                    retries,
+                    attempts_at_hop,
+                    outcome = "not_found",
+                    "subscribe (task-per-tx): NotFound from peer; advancing to next peer"
                 );
                 match advance_to_next_peer(
                     op_manager,
@@ -480,15 +536,11 @@ fn classify_reply(msg: &NetMessage) -> ReplyClass {
 /// the legacy `subscribe::handle_op_response` NotFound + alternatives-exhausted
 /// logic (`subscribe.rs` ~1675–1842 before Phase 2b).
 ///
-/// Priority:
-/// 1. If `attempts_at_hop < MAX_BREADTH` and `alternatives` is non-empty,
-///    take the next alternative (breadth retry at the same hop).
-/// 2. Otherwise, if `retries < MAX_RETRIES`, run a fresh
-///    `k_closest_potentially_hosting` round with the accumulated `visited`
-///    filter, reset `attempts_at_hop` to 1, and increment `retries`.
-/// 3. Otherwise, return `None` (exhausted).
-///
-/// Mutates all state references on a successful advance.
+/// Thin wrapper around [`advance_to_next_peer_impl`] that binds the
+/// `fresh_candidates` hook to `op_manager.ring.k_closest_potentially_hosting`.
+/// Splitting the bind out keeps the retry decision logic unit-testable
+/// without needing a full `OpManager` + `Ring` setup (review finding
+/// Testing #2).
 async fn advance_to_next_peer(
     op_manager: &OpManager,
     instance_id: &ContractInstanceId,
@@ -498,6 +550,50 @@ async fn advance_to_next_peer(
     retries: &mut usize,
     attempts_at_hop: &mut usize,
 ) -> Option<(PeerKeyLocation, std::net::SocketAddr)> {
+    advance_to_next_peer_impl(
+        instance_id,
+        visited,
+        tried_peers,
+        alternatives,
+        retries,
+        attempts_at_hop,
+        |instance_id, visited| {
+            op_manager
+                .ring
+                .k_closest_potentially_hosting(instance_id, visited, MAX_BREADTH)
+        },
+    )
+}
+
+/// Core decision logic, parameterized on a `fresh_candidates` hook so
+/// tests can drive it without a real `Ring`.
+///
+/// Priority:
+/// 1. If `attempts_at_hop < MAX_BREADTH` and `alternatives` is non-empty,
+///    take the next alternative (breadth retry at the same hop, FIFO
+///    order to match legacy `handle_op_response`).
+/// 2. Otherwise, if `retries < MAX_RETRIES`, call `fresh_candidates` with
+///    the accumulated `visited` filter, reset `attempts_at_hop` to 1,
+///    and increment `retries`.
+/// 3. Otherwise, return `None` (exhausted).
+///
+/// Mutates all state references on a successful advance. The hook is a
+/// synchronous `Fn` rather than `async fn` because the real
+/// `k_closest_potentially_hosting` is also synchronous; this keeps the
+/// signature simple and `impl`-backed. No `.await` inside the body means
+/// the whole decision function can be a plain (non-async) fn.
+fn advance_to_next_peer_impl<F>(
+    instance_id: &ContractInstanceId,
+    visited: &mut VisitedPeers,
+    tried_peers: &mut HashSet<std::net::SocketAddr>,
+    alternatives: &mut Vec<PeerKeyLocation>,
+    retries: &mut usize,
+    attempts_at_hop: &mut usize,
+    mut fresh_candidates: F,
+) -> Option<(PeerKeyLocation, std::net::SocketAddr)>
+where
+    F: FnMut(&ContractInstanceId, &VisitedPeers) -> Vec<PeerKeyLocation>,
+{
     // 1. Breadth retry at the same hop. Use FIFO (`remove(0)`) to match the
     //    legacy `handle_op_response` ordering (`subscribe.rs:949, 1821`).
     //    `alternatives` is built in closest-first order by
@@ -529,11 +625,9 @@ async fn advance_to_next_peer(
     if *retries < MAX_RETRIES {
         *retries += 1;
         *attempts_at_hop = 1;
-        let mut fresh =
-            op_manager
-                .ring
-                .k_closest_potentially_hosting(instance_id, &*visited, MAX_BREADTH);
-        while let Some(candidate) = (!fresh.is_empty()).then(|| fresh.remove(0)) {
+        let mut fresh = fresh_candidates(instance_id, visited);
+        while !fresh.is_empty() {
+            let candidate = fresh.remove(0);
             if let Some(addr) = candidate.socket_addr() {
                 if tried_peers.contains(&addr) || visited.probably_visited(addr) {
                     continue;
@@ -687,21 +781,284 @@ mod tests {
         assert!(matches!(classify_reply(&msg), ReplyClass::Unexpected));
     }
 
-    // Note on retry-logic coverage: `advance_to_next_peer` is the core
-    // decision helper. Pure unit-testing it requires constructing a
-    // minimal `OpManager` with a stubbed `Ring::k_closest_potentially_hosting`
-    // — heavier than the existing per-op unit-test harness supports out
-    // of the box. The legacy logic it mirrors is already covered by the
-    // integration tests in `subscribe/tests.rs`:
-    //
-    // - `test_subscription_routing_calls_k_closest_with_skip_list`
-    // - the alternatives/bloom-filter retry tests
-    //
-    // Those tests exercise the equivalent legacy code paths. The
-    // task-per-tx path is validated end-to-end by the
-    // `simulation_integration` subscribe scenarios, which run through
-    // `subscribe_with_id` → `start_client_subscribe` after Phase 2b
-    // lands. If `advance_to_next_peer` grows more logic in the future
-    // (e.g., when Phase 2.5 adds sub-op interactions), a `MockRing`-
-    // backed unit test should be added here.
+    // ──────────────────────────────────────────────────────────────
+    // Retry-logic coverage for `advance_to_next_peer_impl` (review
+    // finding Testing #2). The impl is parameterized on a
+    // `fresh_candidates` closure so these tests can drive it without
+    // building a full `OpManager` + `Ring`. Each test pins one
+    // distinct transition in the retry decision tree.
+    // ──────────────────────────────────────────────────────────────
+
+    /// Helper: construct a synthetic `PeerKeyLocation` with a
+    /// predictable socket address. Uses `PeerKeyLocation::random()` for
+    /// the `pub_key` (cached per-thread so it's cheap) and then
+    /// overrides the address with one we control so test assertions
+    /// can match on it. The actual location is derived from the
+    /// address by the ring code, which is irrelevant for these tests —
+    /// `advance_to_next_peer_impl` only looks at `socket_addr()`.
+    fn peer_at(addr: &str) -> PeerKeyLocation {
+        let mut p = PeerKeyLocation::random();
+        p.set_addr(addr.parse().expect("valid socket addr"));
+        p
+    }
+
+    fn contract_id() -> ContractInstanceId {
+        ContractInstanceId::new([9u8; 32])
+    }
+
+    #[test]
+    fn advance_breadth_retry_returns_next_alternative_fifo() {
+        // Setup: three alternatives, none tried yet, attempts_at_hop
+        // below MAX_BREADTH, retries at 0. The helper should pop the
+        // FIRST alternative (FIFO — closest-first) and return it.
+        let id = contract_id();
+        let tx = fresh_tx();
+        let mut visited = VisitedPeers::new(&tx);
+        let mut tried_peers: HashSet<std::net::SocketAddr> = HashSet::new();
+        let a = peer_at("10.0.0.1:1001");
+        let b = peer_at("10.0.0.2:1002");
+        let c = peer_at("10.0.0.3:1003");
+        let a_addr = a.socket_addr().unwrap();
+        let mut alternatives = vec![a.clone(), b.clone(), c.clone()];
+        let mut retries = 0usize;
+        let mut attempts_at_hop = 1usize;
+
+        let result = advance_to_next_peer_impl(
+            &id,
+            &mut visited,
+            &mut tried_peers,
+            &mut alternatives,
+            &mut retries,
+            &mut attempts_at_hop,
+            |_, _| panic!("breadth retry path must not call fresh_candidates"),
+        );
+
+        let (picked, picked_addr) = result.expect("breadth retry should return an alternative");
+        assert_eq!(picked_addr, a_addr, "must pick FIRST alternative (FIFO)");
+        assert_eq!(picked.socket_addr(), Some(a_addr));
+        assert_eq!(attempts_at_hop, 2, "attempts_at_hop must increment");
+        assert_eq!(retries, 0, "retries must not change on breadth retry");
+        assert_eq!(alternatives.len(), 2, "one alternative consumed");
+        assert!(tried_peers.contains(&a_addr));
+        assert!(visited.probably_visited(a_addr));
+    }
+
+    #[test]
+    fn advance_breadth_retry_skips_already_visited() {
+        // Setup: first alternative is already in visited bloom; helper
+        // must skip it and take the next one.
+        let id = contract_id();
+        let tx = fresh_tx();
+        let mut visited = VisitedPeers::new(&tx);
+        let a = peer_at("10.0.0.1:1001");
+        let b = peer_at("10.0.0.2:1002");
+        let a_addr = a.socket_addr().unwrap();
+        let b_addr = b.socket_addr().unwrap();
+        visited.mark_visited(a_addr); // A was already tried earlier
+        let mut tried_peers: HashSet<std::net::SocketAddr> = HashSet::new();
+        tried_peers.insert(a_addr);
+        let mut alternatives = vec![a, b];
+        let mut retries = 0usize;
+        let mut attempts_at_hop = 1usize;
+
+        let result = advance_to_next_peer_impl(
+            &id,
+            &mut visited,
+            &mut tried_peers,
+            &mut alternatives,
+            &mut retries,
+            &mut attempts_at_hop,
+            |_, _| panic!("should find B before falling through"),
+        );
+
+        let (_, picked_addr) = result.expect("should pick B after skipping A");
+        assert_eq!(picked_addr, b_addr);
+        assert!(alternatives.is_empty(), "both A and B consumed");
+    }
+
+    #[test]
+    fn advance_fresh_round_triggered_when_alternatives_exhausted() {
+        // Setup: alternatives empty, attempts_at_hop below MAX_BREADTH.
+        // The impl should bypass the breadth branch (nothing to pop)
+        // and call `fresh_candidates`, resetting attempts_at_hop to 1
+        // and incrementing retries.
+        let id = contract_id();
+        let tx = fresh_tx();
+        let mut visited = VisitedPeers::new(&tx);
+        let mut tried_peers: HashSet<std::net::SocketAddr> = HashSet::new();
+        let mut alternatives: Vec<PeerKeyLocation> = Vec::new();
+        let mut retries = 0usize;
+        let mut attempts_at_hop = 1usize;
+
+        let fresh_peer = peer_at("10.0.0.5:1005");
+        let fresh_addr = fresh_peer.socket_addr().unwrap();
+        let mut fresh_calls = 0;
+
+        let result = advance_to_next_peer_impl(
+            &id,
+            &mut visited,
+            &mut tried_peers,
+            &mut alternatives,
+            &mut retries,
+            &mut attempts_at_hop,
+            |got_id, _got_visited| {
+                fresh_calls += 1;
+                assert_eq!(got_id, &contract_id(), "passes through instance_id");
+                vec![fresh_peer.clone()]
+            },
+        );
+
+        assert_eq!(
+            fresh_calls, 1,
+            "fresh_candidates must be called exactly once"
+        );
+        let (_, picked_addr) = result.expect("fresh round should find a peer");
+        assert_eq!(picked_addr, fresh_addr);
+        assert_eq!(retries, 1, "retries incremented on fresh round");
+        assert_eq!(
+            attempts_at_hop, 1,
+            "attempts_at_hop reset to 1 on fresh round"
+        );
+    }
+
+    #[test]
+    fn advance_fresh_round_after_max_breadth_hit() {
+        // Setup: attempts_at_hop at MAX_BREADTH (the breadth guard
+        // rejects further breadth retries even with alternatives
+        // available). The impl must immediately fall through to the
+        // fresh_candidates branch.
+        let id = contract_id();
+        let tx = fresh_tx();
+        let mut visited = VisitedPeers::new(&tx);
+        let mut tried_peers: HashSet<std::net::SocketAddr> = HashSet::new();
+        // Alternatives are present, but breadth is already exhausted.
+        let unused_alt = peer_at("10.0.0.1:1001");
+        let mut alternatives = vec![unused_alt.clone()];
+        let mut retries = 0usize;
+        let mut attempts_at_hop = MAX_BREADTH;
+
+        let fresh_peer = peer_at("10.0.0.5:1005");
+        let fresh_addr = fresh_peer.socket_addr().unwrap();
+
+        let result = advance_to_next_peer_impl(
+            &id,
+            &mut visited,
+            &mut tried_peers,
+            &mut alternatives,
+            &mut retries,
+            &mut attempts_at_hop,
+            |_, _| vec![fresh_peer.clone()],
+        );
+
+        let (_, picked_addr) = result.expect("fresh round should run");
+        assert_eq!(picked_addr, fresh_addr);
+        // The unused alt must still be in `alternatives` OR have been
+        // replaced by the remainder of `fresh` — check that we did NOT
+        // consume it via the breadth branch.
+        assert_eq!(retries, 1, "went through fresh round, not breadth");
+        assert_eq!(attempts_at_hop, 1, "attempts_at_hop reset by fresh round");
+    }
+
+    #[test]
+    fn advance_exhausted_after_max_retries() {
+        // Setup: retries at MAX_RETRIES, no alternatives. Both guards
+        // reject; helper must return None.
+        let id = contract_id();
+        let tx = fresh_tx();
+        let mut visited = VisitedPeers::new(&tx);
+        let mut tried_peers: HashSet<std::net::SocketAddr> = HashSet::new();
+        let mut alternatives: Vec<PeerKeyLocation> = Vec::new();
+        let mut retries = MAX_RETRIES;
+        let mut attempts_at_hop = 1usize;
+
+        let result = advance_to_next_peer_impl(
+            &id,
+            &mut visited,
+            &mut tried_peers,
+            &mut alternatives,
+            &mut retries,
+            &mut attempts_at_hop,
+            |_, _| panic!("fresh_candidates must not be called when retries == MAX"),
+        );
+
+        assert!(result.is_none(), "exhausted case returns None");
+        assert_eq!(retries, MAX_RETRIES, "retries unchanged when exhausted");
+    }
+
+    #[test]
+    fn advance_exhausted_when_fresh_round_returns_empty() {
+        // Setup: below MAX_RETRIES, alternatives empty. fresh_candidates
+        // returns empty Vec (e.g., the ring has no candidates left after
+        // accounting for visited filter). Helper must return None AND
+        // have incremented retries.
+        let id = contract_id();
+        let tx = fresh_tx();
+        let mut visited = VisitedPeers::new(&tx);
+        let mut tried_peers: HashSet<std::net::SocketAddr> = HashSet::new();
+        let mut alternatives: Vec<PeerKeyLocation> = Vec::new();
+        let mut retries = 0usize;
+        let mut attempts_at_hop = 1usize;
+
+        let result = advance_to_next_peer_impl(
+            &id,
+            &mut visited,
+            &mut tried_peers,
+            &mut alternatives,
+            &mut retries,
+            &mut attempts_at_hop,
+            |_, _| Vec::new(),
+        );
+
+        assert!(result.is_none());
+        assert_eq!(
+            retries, 1,
+            "retries incremented even though fresh round was empty \
+             — the round was 'attempted', it just found nothing"
+        );
+    }
+
+    #[test]
+    fn advance_fresh_round_leftover_becomes_new_alternatives() {
+        // Setup: fresh_candidates returns 3 peers; helper picks the
+        // first, and the remaining 2 MUST be written back to
+        // `alternatives` so subsequent breadth retries can use them.
+        let id = contract_id();
+        let tx = fresh_tx();
+        let mut visited = VisitedPeers::new(&tx);
+        let mut tried_peers: HashSet<std::net::SocketAddr> = HashSet::new();
+        let mut alternatives: Vec<PeerKeyLocation> = Vec::new();
+        let mut retries = 0usize;
+        let mut attempts_at_hop = 1usize;
+
+        let p1 = peer_at("10.0.0.1:1001");
+        let p2 = peer_at("10.0.0.2:1002");
+        let p3 = peer_at("10.0.0.3:1003");
+        let p1_addr = p1.socket_addr().unwrap();
+        let p2_addr = p2.socket_addr().unwrap();
+        let p3_addr = p3.socket_addr().unwrap();
+
+        let result = advance_to_next_peer_impl(
+            &id,
+            &mut visited,
+            &mut tried_peers,
+            &mut alternatives,
+            &mut retries,
+            &mut attempts_at_hop,
+            |_, _| vec![p1.clone(), p2.clone(), p3.clone()],
+        );
+
+        let (_, picked) = result.expect("fresh round returns first candidate");
+        assert_eq!(picked, p1_addr);
+        assert_eq!(
+            alternatives.len(),
+            2,
+            "rest of fresh becomes new alternatives"
+        );
+        let alt_addrs: Vec<_> = alternatives
+            .iter()
+            .filter_map(|p| p.socket_addr())
+            .collect();
+        assert!(alt_addrs.contains(&p2_addr));
+        assert!(alt_addrs.contains(&p3_addr));
+    }
 }

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -1,0 +1,643 @@
+//! Task-per-transaction client-initiated SUBSCRIBE (#1454 Phase 2b).
+//!
+//! This module hosts the first production consumer of [`OpCtx::send_and_await`][ocx],
+//! driving a client-initiated SUBSCRIBE end-to-end inside a single spawned
+//! task instead of the legacy re-entry loop through `handle_op_result` +
+//! `OpManager.ops.subscribe` DashMap.
+//!
+//! # Scope (Phase 2b)
+//!
+//! Only the **client-initiated** SUBSCRIBE entry point (via
+//! [`crate::node::subscribe_with_id`]) runs through this module. The other
+//! three entry points stay on the legacy path for reasons documented on
+//! issue #1454 Phase 2b:
+//!
+//! - **Renewals** (`ring.rs::connection_maintenance` loop) — their jitter
+//!   and spam-prevention in `can_request_subscription()` are load-bearing.
+//! - **PUT sub-ops** (`start_subscription_request_internal`) — blocking
+//!   semantics with `SubOperationTracker`; migrated in Phase 2.5.
+//! - **Intermediate-peer forwarding** (`SubscribeOp::load_or_init` on
+//!   incoming `Request`) — server-side response role; migrated in Phase 5.
+//!
+//! Only the **client-initiated** path goes through `subscribe_with_id`;
+//! the three legacy paths never call it, so migrating the body of
+//! `subscribe_with_id` wholesale is sufficient to gate the new path.
+//!
+//! # Architecture
+//!
+//! The task owns all routing state in its locals — there is no
+//! `SubscribeOp` in the `OpManager.ops.subscribe` DashMap for any attempt
+//! this task makes. The task:
+//!
+//! 1. Calls [`super::prepare_initial_request`] to decide target peer vs
+//!    local-completion vs give-up.
+//! 2. If network target: loops, calling [`OpCtx::send_and_await`][ocx]
+//!    with a **fresh `Transaction` per attempt** (required by
+//!    `send_and_await`'s single-use-per-tx contract). Each attempt
+//!    inserts a capacity-1 reply channel into `p2p_protoc::pending_op_results`
+//!    keyed by the attempt tx; the pure-network-message handler routes
+//!    replies via the SUBSCRIBE bypass added in Phase 2b (see
+//!    `node::try_forward_task_per_tx_reply`).
+//! 3. On `Subscribed`: delivers via `result_router_tx` keyed by the
+//!    **client-visible** `Transaction` (the one returned to the caller
+//!    and registered with `ch_outbound.waiting_for_transaction_result`).
+//! 4. On `NotFound`: applies breadth retry → fresh k_closest round →
+//!    exhaustion, mirroring the legacy retry logic in
+//!    `subscribe::handle_op_response`.
+//! 5. On `send_and_await` timeout: treats the attempt as a peer timeout
+//!    and applies the same retry logic.
+//!
+//! # Client-visible tx vs per-attempt tx
+//!
+//! Legacy SUBSCRIBE reuses one `Transaction` end-to-end. Phase 2b splits
+//! this into two tx lifetimes:
+//!
+//! - **`client_tx`**: allocated once by the WS handler, registered with
+//!   `ch_outbound.waiting_for_transaction_result`, delivered to via
+//!   `result_router_tx`. Never passed to `send_and_await`.
+//! - **`attempt_tx`**: fresh per retry. Used for the wire Request, the
+//!   `OpCtx`, and the `pending_op_results` callback slot. Never surfaced
+//!   to the client.
+//!
+//! The split is mandatory: `OpCtx::send_and_await` can only fire once per
+//! Transaction (the `completed` / `under_progress` dedup sets in
+//! `OpManager` suppress second callbacks). Attempt isolation is the
+//! simplest reconciliation with that constraint.
+//!
+//! [ocx]: crate::operations::OpCtx::send_and_await
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use freenet_stdlib::client_api::{ContractResponse, ErrorKind, HostResponse};
+use freenet_stdlib::prelude::ContractInstanceId;
+
+use crate::client_events::HostResult;
+use crate::config::{GlobalExecutor, OPERATION_TTL};
+use crate::message::{NetMessage, NetMessageV1, Transaction};
+use crate::node::OpManager;
+use crate::operations::{OpError, VisitedPeers};
+use crate::ring::{PeerKeyLocation, RingError};
+
+use super::{
+    InitialRequest, MAX_BREADTH, MAX_RETRIES, SubscribeMsg, SubscribeMsgResult,
+    complete_local_subscription, prepare_initial_request,
+};
+
+/// Start a client-initiated subscribe, returning as soon as the task has
+/// been spawned (mirrors legacy `subscribe_with_id` timing).
+///
+/// The caller must have already registered a result waiter for `client_tx`
+/// via `op_manager.ch_outbound.waiting_for_transaction_result` or
+/// `waiting_for_subscription_result`. This function does NOT touch the
+/// waiter; it only drives the ring/network side and publishes the terminal
+/// result to `result_router_tx` keyed by `client_tx`.
+///
+/// Returns `Ok(client_tx)` once the task has been spawned. The spawned task
+/// owns the rest of the subscribe lifetime.
+pub(crate) async fn start_client_subscribe(
+    op_manager: Arc<OpManager>,
+    instance_id: ContractInstanceId,
+    client_tx: Transaction,
+) -> Result<Transaction, OpError> {
+    tracing::debug!(
+        tx = %client_tx,
+        contract = %instance_id,
+        "subscribe (task-per-tx): spawning client-initiated task"
+    );
+
+    // Spawn the driver. The task is fire-and-forget from this function's
+    // perspective — failures are delivered to the client via
+    // `result_router_tx`, not via the return value of this function, to
+    // match legacy `request_subscribe` behaviour (it pushes the op via
+    // `notify_op_change` and returns `Ok(())` immediately, letting the
+    // event loop drive the rest).
+    //
+    // Not registered with BackgroundTaskMonitor: like legacy subscribe
+    // work, this task is scoped to a single transaction and terminates
+    // on its own either on success, error, or the OPERATION_TTL-wrapped
+    // timeout path in the retry loop. A leaked task here would cost one
+    // tx slot in `pending_op_results` and one spawned future — bounded
+    // by the client-side rate-limiting on SUBSCRIBE requests, not
+    // unbounded amplification.
+    GlobalExecutor::spawn(run_client_subscribe(op_manager, instance_id, client_tx));
+
+    Ok(client_tx)
+}
+
+/// Drive a client-initiated subscribe to completion and publish the result
+/// to `result_router_tx` keyed by `client_tx`.
+///
+/// Runs inside a spawned task. Never panics — any error is converted into
+/// a `HostResult::Err` and delivered through `result_router_tx`.
+async fn run_client_subscribe(
+    op_manager: Arc<OpManager>,
+    instance_id: ContractInstanceId,
+    client_tx: Transaction,
+) {
+    let outcome = match drive_client_subscribe(op_manager.clone(), instance_id, client_tx).await {
+        Ok(result) => result,
+        Err(err) => {
+            tracing::warn!(
+                tx = %client_tx,
+                contract = %instance_id,
+                error = %err,
+                "subscribe (task-per-tx): task failed"
+            );
+            Err(ErrorKind::OperationError {
+                cause: format!("subscribe failed: {err}").into(),
+            }
+            .into())
+        }
+    };
+
+    deliver_result(&op_manager, client_tx, outcome);
+}
+
+/// The inner driver: returns `Ok(HostResult)` where the `HostResult` itself
+/// may be `Ok(Subscribed)` or `Err(...)` depending on how the subscribe
+/// terminated. Returning `Err(OpError)` from this function is reserved for
+/// genuine infrastructure failures (e.g., executor channel closed) that
+/// can't be expressed as a client-facing error.
+async fn drive_client_subscribe(
+    op_manager: Arc<OpManager>,
+    instance_id: ContractInstanceId,
+    client_tx: Transaction,
+) -> Result<HostResult, OpError> {
+    // Decide: local-completion, give up, or send to the network.
+    // `prepare_initial_request` uses `client_tx` for its visited-peers
+    // bloom filter seed and telemetry; this is fine because the bloom
+    // filter is per-attempt-first-peer only and telemetry correlates on
+    // the client-visible tx (matching legacy behaviour for the first
+    // attempt).
+    let initial = prepare_initial_request(
+        &op_manager,
+        client_tx,
+        instance_id,
+        /* is_renewal */ false,
+    )
+    .await?;
+
+    let (target_peer, target_addr, mut visited, mut alternatives, htl) = match initial {
+        InitialRequest::LocallyComplete { key } => {
+            // Local completion reuses the existing helper. It publishes
+            // via `NodeEvent::LocalSubscribeComplete` → `result_router_tx`,
+            // so this path does NOT deliver a second time through
+            // `deliver_result` — return with a sentinel that skips delivery.
+            complete_local_subscription(&op_manager, client_tx, key, /* is_renewal */ false)
+                .await?;
+            return Ok(locally_completed_marker(key));
+        }
+        InitialRequest::NoHostingPeers => {
+            return Ok(Err(ErrorKind::OperationError {
+                cause: format!("no remote peers available for subscription to {instance_id}")
+                    .into(),
+            }
+            .into()));
+        }
+        InitialRequest::PeerNotJoined => {
+            return Err(RingError::PeerNotJoined.into());
+        }
+        InitialRequest::NetworkRequest {
+            target,
+            target_addr,
+            visited,
+            alternatives,
+            htl,
+        } => (target, target_addr, visited, alternatives, htl),
+    };
+
+    tracing::debug!(
+        tx = %client_tx,
+        contract = %instance_id,
+        target = %target_addr,
+        "subscribe (task-per-tx): initial target selected, entering retry loop"
+    );
+
+    // Initial state for the retry loop. The first attempt uses the target
+    // returned by `prepare_initial_request`; subsequent attempts pull from
+    // `advance_to_next_peer`. `target_peer` is bound for its side effect
+    // of selecting the initial address only and is not used beyond the
+    // first iteration.
+    let _ = target_peer;
+    let mut tried_peers: HashSet<std::net::SocketAddr> = HashSet::new();
+    tried_peers.insert(target_addr);
+    let mut retries: usize = 0;
+    let mut attempts_at_hop: usize = 1;
+    let mut current_target_addr: std::net::SocketAddr = target_addr;
+
+    loop {
+        // Fresh attempt tx: single-use-per-tx for send_and_await.
+        let attempt_tx = Transaction::new::<SubscribeMsg>();
+
+        tracing::debug!(
+            tx = %client_tx,
+            attempt_tx = %attempt_tx,
+            target = %current_target_addr,
+            retries,
+            attempts_at_hop,
+            "subscribe (task-per-tx): sending attempt"
+        );
+
+        let request = SubscribeMsg::Request {
+            id: attempt_tx,
+            instance_id,
+            htl,
+            visited: visited.clone(),
+            is_renewal: false,
+        };
+
+        let mut ctx = op_manager.op_ctx(attempt_tx);
+        let round_trip =
+            tokio::time::timeout(OPERATION_TTL, ctx.send_and_await(NetMessage::from(request)))
+                .await;
+
+        // Release the per-attempt `pending_op_results` slot before any
+        // retry or return. Without this emission entries would only be
+        // reclaimed by the 60 s periodic sweep of closed senders
+        // (p2p_protoc.rs:960-987), which lags the real completion by
+        // several seconds per attempt and causes the
+        // `test_pending_op_results_bounded` regression guard to flag a
+        // leak. We emit the event regardless of outcome (success, wire
+        // error, timeout) because the inserted callback slot is keyed
+        // only on `attempt_tx` — its lifetime matches the attempt, not
+        // the reply classification.
+        op_manager.release_pending_op_slot(attempt_tx);
+
+        let reply = match round_trip {
+            Ok(Ok(reply)) => reply,
+            Ok(Err(err)) => {
+                tracing::warn!(
+                    tx = %client_tx,
+                    attempt_tx = %attempt_tx,
+                    error = %err,
+                    "subscribe (task-per-tx): send_and_await failed; treating as peer timeout"
+                );
+                // Fall through to the "peer timeout / try next" branch.
+                // We don't distinguish infrastructure failure from a
+                // wire-level NotFound here — from "should we retry on a
+                // different peer?" the answer is the same.
+                match advance_to_next_peer(
+                    &op_manager,
+                    &instance_id,
+                    &mut visited,
+                    &mut tried_peers,
+                    &mut alternatives,
+                    &mut retries,
+                    &mut attempts_at_hop,
+                )
+                .await
+                {
+                    Some((_next_target, next_addr)) => {
+                        current_target_addr = next_addr;
+                        continue;
+                    }
+                    None => {
+                        return Ok(Err(ErrorKind::OperationError {
+                            cause: format!(
+                                "subscribe to {instance_id} failed after {} rounds (last peer error: {err})",
+                                retries + 1
+                            )
+                            .into(),
+                        }
+                        .into()));
+                    }
+                }
+            }
+            Err(_) => {
+                tracing::warn!(
+                    tx = %client_tx,
+                    attempt_tx = %attempt_tx,
+                    target = %current_target_addr,
+                    "subscribe (task-per-tx): attempt timed out after OPERATION_TTL; trying next peer"
+                );
+                match advance_to_next_peer(
+                    &op_manager,
+                    &instance_id,
+                    &mut visited,
+                    &mut tried_peers,
+                    &mut alternatives,
+                    &mut retries,
+                    &mut attempts_at_hop,
+                )
+                .await
+                {
+                    Some((_next_target, next_addr)) => {
+                        current_target_addr = next_addr;
+                        continue;
+                    }
+                    None => {
+                        return Ok(Err(ErrorKind::OperationError {
+                            cause: format!(
+                                "subscribe to {instance_id} timed out after {} rounds",
+                                retries + 1
+                            )
+                            .into(),
+                        }
+                        .into()));
+                    }
+                }
+            }
+        };
+
+        // Classify the terminal reply.
+        match classify_reply(&reply) {
+            ReplyClass::Subscribed { key } => {
+                tracing::info!(
+                    tx = %client_tx,
+                    attempt_tx = %attempt_tx,
+                    contract = %key,
+                    "subscribe (task-per-tx): subscribed"
+                );
+                return Ok(Ok(HostResponse::ContractResponse(
+                    ContractResponse::SubscribeResponse {
+                        key,
+                        subscribed: true,
+                    },
+                )));
+            }
+            ReplyClass::NotFound => {
+                tracing::debug!(
+                    tx = %client_tx,
+                    attempt_tx = %attempt_tx,
+                    "subscribe (task-per-tx): NotFound, trying next peer"
+                );
+                match advance_to_next_peer(
+                    &op_manager,
+                    &instance_id,
+                    &mut visited,
+                    &mut tried_peers,
+                    &mut alternatives,
+                    &mut retries,
+                    &mut attempts_at_hop,
+                )
+                .await
+                {
+                    Some((_next_target, next_addr)) => {
+                        current_target_addr = next_addr;
+                        continue;
+                    }
+                    None => {
+                        return Ok(Err(ErrorKind::OperationError {
+                            cause: format!(
+                                "contract {instance_id} not found after exhaustive search"
+                            )
+                            .into(),
+                        }
+                        .into()));
+                    }
+                }
+            }
+            ReplyClass::Unexpected => {
+                tracing::warn!(
+                    tx = %client_tx,
+                    attempt_tx = %attempt_tx,
+                    "subscribe (task-per-tx): unexpected terminal reply"
+                );
+                return Err(OpError::UnexpectedOpState);
+            }
+        }
+    }
+}
+
+/// Classification of a terminal reply delivered to `send_and_await`.
+#[derive(Debug)]
+enum ReplyClass {
+    Subscribed {
+        key: freenet_stdlib::prelude::ContractKey,
+    },
+    NotFound,
+    /// Any reply that shouldn't be a terminal for the originator
+    /// (e.g., a `Request`, `Unsubscribe`, or `ForwardingAck`). These
+    /// indicate a classification bug upstream and are surfaced as errors.
+    Unexpected,
+}
+
+fn classify_reply(msg: &NetMessage) -> ReplyClass {
+    match msg {
+        NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response { result, .. })) => {
+            match result {
+                SubscribeMsgResult::Subscribed { key } => ReplyClass::Subscribed { key: *key },
+                SubscribeMsgResult::NotFound => ReplyClass::NotFound,
+            }
+        }
+        _ => ReplyClass::Unexpected,
+    }
+}
+
+/// Advance the task-local routing state to the next peer to try, mirroring
+/// the legacy `subscribe::handle_op_response` NotFound + alternatives-exhausted
+/// logic (`subscribe.rs` ~1675–1842 before Phase 2b).
+///
+/// Priority:
+/// 1. If `attempts_at_hop < MAX_BREADTH` and `alternatives` is non-empty,
+///    take the next alternative (breadth retry at the same hop).
+/// 2. Otherwise, if `retries < MAX_RETRIES`, run a fresh
+///    `k_closest_potentially_hosting` round with the accumulated `visited`
+///    filter, reset `attempts_at_hop` to 1, and increment `retries`.
+/// 3. Otherwise, return `None` (exhausted).
+///
+/// Mutates all state references on a successful advance.
+async fn advance_to_next_peer(
+    op_manager: &OpManager,
+    instance_id: &ContractInstanceId,
+    visited: &mut VisitedPeers,
+    tried_peers: &mut HashSet<std::net::SocketAddr>,
+    alternatives: &mut Vec<PeerKeyLocation>,
+    retries: &mut usize,
+    attempts_at_hop: &mut usize,
+) -> Option<(PeerKeyLocation, std::net::SocketAddr)> {
+    // 1. Breadth retry at the same hop.
+    if *attempts_at_hop < MAX_BREADTH {
+        while let Some(candidate) = alternatives.pop() {
+            if let Some(addr) = candidate.socket_addr() {
+                if tried_peers.contains(&addr) || visited.probably_visited(addr) {
+                    continue;
+                }
+                tried_peers.insert(addr);
+                visited.mark_visited(addr);
+                *attempts_at_hop += 1;
+                tracing::debug!(
+                    %instance_id,
+                    target = %addr,
+                    attempts_at_hop = *attempts_at_hop,
+                    "subscribe (task-per-tx): breadth retry with next alternative"
+                );
+                return Some((candidate, addr));
+            }
+        }
+    }
+
+    // 2. Fresh k_closest round.
+    if *retries < MAX_RETRIES {
+        *retries += 1;
+        *attempts_at_hop = 1;
+        let mut fresh =
+            op_manager
+                .ring
+                .k_closest_potentially_hosting(instance_id, &*visited, MAX_BREADTH);
+        while let Some(candidate) = (!fresh.is_empty()).then(|| fresh.remove(0)) {
+            if let Some(addr) = candidate.socket_addr() {
+                if tried_peers.contains(&addr) || visited.probably_visited(addr) {
+                    continue;
+                }
+                tried_peers.insert(addr);
+                visited.mark_visited(addr);
+                // Rest of `fresh` becomes the new alternatives pool for
+                // subsequent breadth retries at this new hop.
+                *alternatives = fresh;
+                tracing::debug!(
+                    %instance_id,
+                    target = %addr,
+                    retries = *retries,
+                    "subscribe (task-per-tx): fresh k_closest round found new target"
+                );
+                return Some((candidate, addr));
+            }
+            // Skip candidate without socket addr, try next from fresh.
+        }
+        tracing::debug!(
+            %instance_id,
+            retries = *retries,
+            "subscribe (task-per-tx): fresh k_closest round returned no usable candidates"
+        );
+    }
+
+    // 3. Exhausted.
+    None
+}
+
+/// Sentinel indicating local completion has already been published via
+/// `NodeEvent::LocalSubscribeComplete`. The caller uses this to skip a
+/// second delivery through `result_router_tx`.
+fn locally_completed_marker(key: freenet_stdlib::prelude::ContractKey) -> HostResult {
+    // The value here is what `complete_local_subscription` → `p2p_protoc`
+    // delivers to the router internally. We mirror it so
+    // `deliver_result`'s debug log is accurate, but the marker flag below
+    // is what actually suppresses the second send.
+    Ok(HostResponse::ContractResponse(
+        ContractResponse::SubscribeResponse {
+            key,
+            subscribed: true,
+        },
+    ))
+}
+
+/// Publish `result` to `result_router_tx` keyed by `client_tx`, unless the
+/// result was produced by the local-completion path (which already
+/// published via `NodeEvent::LocalSubscribeComplete`).
+///
+/// Uses [`OpManager::send_client_result`] so both the router publish and
+/// the follow-up `TransactionCompleted(client_tx)` notification (for
+/// `tx_to_client` cleanup in `p2p_protoc`) happen in one place.
+///
+/// We distinguish "already published locally" from "needs network publish"
+/// by checking whether the op was already marked completed:
+/// `complete_local_subscription` calls `op_manager.completed(tx)`, so a
+/// second `result_router_tx` send would be redundant and could race with
+/// the one from `p2p_protoc`. The `is_completed` guard is conservative —
+/// if in doubt we skip the second publish because the client cache in
+/// `SessionActor` tolerates missing results better than duplicates.
+fn deliver_result(op_manager: &OpManager, client_tx: Transaction, result: HostResult) {
+    // Skip publish if the local-completion path already marked this tx as
+    // completed. This handles both the standalone-node branch and the
+    // peer-not-joined-but-contract-available branch of
+    // `prepare_initial_request`.
+    if op_manager.is_completed(&client_tx) {
+        tracing::debug!(
+            tx = %client_tx,
+            "subscribe (task-per-tx): local completion already published; skipping result_router_tx"
+        );
+        return;
+    }
+    op_manager.send_client_result(client_tx, result);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::NetMessageV1;
+    use crate::operations::connect::ConnectMsg;
+
+    fn fresh_tx() -> Transaction {
+        Transaction::new::<SubscribeMsg>()
+    }
+
+    #[test]
+    fn classify_reply_subscribed() {
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+        let key = ContractKey::from_id_and_code(
+            ContractInstanceId::new([3u8; 32]),
+            CodeHash::new([4u8; 32]),
+        );
+        let tx = fresh_tx();
+        let msg = NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
+            id: tx,
+            instance_id: *key.id(),
+            result: SubscribeMsgResult::Subscribed { key },
+        }));
+        match classify_reply(&msg) {
+            ReplyClass::Subscribed { key: got } => assert_eq!(got, key),
+            other @ (ReplyClass::NotFound | ReplyClass::Unexpected) => {
+                panic!("expected Subscribed, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn classify_reply_not_found() {
+        let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([4u8; 32]);
+        let tx = fresh_tx();
+        let msg = NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
+            id: tx,
+            instance_id,
+            result: SubscribeMsgResult::NotFound,
+        }));
+        assert!(matches!(classify_reply(&msg), ReplyClass::NotFound));
+    }
+
+    #[test]
+    fn classify_reply_unexpected_for_request() {
+        // A `Request` arriving as a "reply" is structurally wrong — it's
+        // what the ORIGINATOR sends, not receives. The classifier must
+        // flag it so the caller can surface an error rather than silently
+        // retry.
+        let instance_id = freenet_stdlib::prelude::ContractInstanceId::new([5u8; 32]);
+        let tx = fresh_tx();
+        let msg = NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Request {
+            id: tx,
+            instance_id,
+            htl: 5,
+            visited: super::VisitedPeers::new(&tx),
+            is_renewal: false,
+        }));
+        assert!(matches!(classify_reply(&msg), ReplyClass::Unexpected));
+    }
+
+    #[test]
+    fn classify_reply_unexpected_for_non_subscribe_variant() {
+        // An arbitrary non-subscribe message in the reply slot indicates
+        // a routing bug upstream; classifier must surface it.
+        let tx = Transaction::new::<ConnectMsg>();
+        let msg = NetMessage::V1(NetMessageV1::Aborted(tx));
+        assert!(matches!(classify_reply(&msg), ReplyClass::Unexpected));
+    }
+
+    // Note on retry-logic coverage: `advance_to_next_peer` is the core
+    // decision helper. Pure unit-testing it requires constructing a
+    // minimal `OpManager` with a stubbed `Ring::k_closest_potentially_hosting`
+    // — heavier than the existing per-op unit-test harness supports out
+    // of the box. The legacy logic it mirrors is already covered by the
+    // integration tests in `subscribe/tests.rs`:
+    //
+    // - `test_subscription_routing_calls_k_closest_with_skip_list`
+    // - the alternatives/bloom-filter retry tests
+    //
+    // Those tests exercise the equivalent legacy code paths. The
+    // task-per-tx path is validated end-to-end by the
+    // `simulation_integration` subscribe scenarios, which run through
+    // `subscribe_with_id` → `start_client_subscribe` after Phase 2b
+    // lands. If `advance_to_next_peer` grows more logic in the future
+    // (e.g., when Phase 2.5 adds sub-op interactions), a `MockRing`-
+    // backed unit test should be added here.
+}

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -135,35 +135,52 @@ async fn run_client_subscribe(
     instance_id: ContractInstanceId,
     client_tx: Transaction,
 ) {
-    let outcome = match drive_client_subscribe(op_manager.clone(), instance_id, client_tx).await {
-        Ok(result) => result,
-        Err(err) => {
-            tracing::warn!(
-                tx = %client_tx,
-                contract = %instance_id,
-                error = %err,
-                "subscribe (task-per-tx): task failed"
-            );
-            Err(ErrorKind::OperationError {
-                cause: format!("subscribe failed: {err}").into(),
-            }
-            .into())
-        }
-    };
-
-    deliver_result(&op_manager, client_tx, outcome);
+    let outcome = drive_client_subscribe(op_manager.clone(), instance_id, client_tx).await;
+    deliver_outcome(&op_manager, client_tx, instance_id, outcome);
 }
 
-/// The inner driver: returns `Ok(HostResult)` where the `HostResult` itself
-/// may be `Ok(Subscribed)` or `Err(...)` depending on how the subscribe
-/// terminated. Returning `Err(OpError)` from this function is reserved for
-/// genuine infrastructure failures (e.g., executor channel closed) that
-/// can't be expressed as a client-facing error.
+/// Outcome of the driver, carrying an explicit signal for "local completion
+/// already published to the router, no follow-up `result_router_tx` send
+/// needed". Using an enum here instead of piggybacking on `OpManager::is_completed`
+/// makes the skip condition explicit and unshareable with any other path
+/// that might happen to mark the same tx completed (review finding M3).
+#[derive(Debug)]
+enum DriverOutcome {
+    /// The driver produced a `HostResult` that must be published via
+    /// `result_router_tx`.
+    Publish(HostResult),
+    /// Local completion already published via
+    /// `NodeEvent::LocalSubscribeComplete` inside
+    /// `complete_local_subscription`. The driver must NOT publish a
+    /// second result for this tx — doing so would duplicate the
+    /// `HostResponse::ContractResponse(SubscribeResponse)` the
+    /// `LocalSubscribeComplete` handler already pushed.
+    SkipAlreadyDelivered,
+    /// A genuine infrastructure failure escaped the driver loop
+    /// (e.g., executor channel closed, unexpected reply variant).
+    /// `deliver_outcome` converts this into a synthesized client error.
+    InfrastructureError(OpError),
+}
+
+/// The inner driver: returns a [`DriverOutcome`] describing how the
+/// subscribe terminated and whether the delivery side-effect has already
+/// been applied.
 async fn drive_client_subscribe(
     op_manager: Arc<OpManager>,
     instance_id: ContractInstanceId,
     client_tx: Transaction,
-) -> Result<HostResult, OpError> {
+) -> DriverOutcome {
+    match drive_client_subscribe_inner(&op_manager, instance_id, client_tx).await {
+        Ok(outcome) => outcome,
+        Err(err) => DriverOutcome::InfrastructureError(err),
+    }
+}
+
+async fn drive_client_subscribe_inner(
+    op_manager: &Arc<OpManager>,
+    instance_id: ContractInstanceId,
+    client_tx: Transaction,
+) -> Result<DriverOutcome, OpError> {
     // Decide: local-completion, give up, or send to the network.
     // `prepare_initial_request` uses `client_tx` for its visited-peers
     // bloom filter seed and telemetry; this is fine because the bloom
@@ -171,7 +188,7 @@ async fn drive_client_subscribe(
     // the client-visible tx (matching legacy behaviour for the first
     // attempt).
     let initial = prepare_initial_request(
-        &op_manager,
+        op_manager,
         client_tx,
         instance_id,
         /* is_renewal */ false,
@@ -182,18 +199,18 @@ async fn drive_client_subscribe(
         InitialRequest::LocallyComplete { key } => {
             // Local completion reuses the existing helper. It publishes
             // via `NodeEvent::LocalSubscribeComplete` → `result_router_tx`,
-            // so this path does NOT deliver a second time through
-            // `deliver_result` — return with a sentinel that skips delivery.
-            complete_local_subscription(&op_manager, client_tx, key, /* is_renewal */ false)
-                .await?;
-            return Ok(locally_completed_marker(key));
+            // so the driver MUST NOT deliver a second time — return
+            // `SkipAlreadyDelivered` to explicitly signal that to
+            // `deliver_outcome`.
+            complete_local_subscription(op_manager, client_tx, key, /* is_renewal */ false).await?;
+            return Ok(DriverOutcome::SkipAlreadyDelivered);
         }
         InitialRequest::NoHostingPeers => {
-            return Ok(Err(ErrorKind::OperationError {
+            return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
                 cause: format!("no remote peers available for subscription to {instance_id}")
                     .into(),
             }
-            .into()));
+            .into())));
         }
         InitialRequest::PeerNotJoined => {
             return Err(RingError::PeerNotJoined.into());
@@ -214,17 +231,22 @@ async fn drive_client_subscribe(
         "subscribe (task-per-tx): initial target selected, entering retry loop"
     );
 
-    // Initial state for the retry loop. The first attempt uses the target
-    // returned by `prepare_initial_request`; subsequent attempts pull from
-    // `advance_to_next_peer`. `target_peer` is bound for its side effect
-    // of selecting the initial address only and is not used beyond the
-    // first iteration.
-    let _ = target_peer;
+    // Initial state for the retry loop. The first iteration uses
+    // `target_peer` (as the current target) from `prepare_initial_request`;
+    // subsequent attempts pull from `advance_to_next_peer`.
+    //
+    // `prepare_initial_request` has already emitted a
+    // `NetEventLog::subscribe_request` event keyed on `client_tx` for the
+    // first attempt (mirroring legacy behaviour). Subsequent attempts
+    // re-emit inside the loop using the per-attempt tx so retries are
+    // visible in the event log (review finding L4).
     let mut tried_peers: HashSet<std::net::SocketAddr> = HashSet::new();
     tried_peers.insert(target_addr);
     let mut retries: usize = 0;
     let mut attempts_at_hop: usize = 1;
+    let mut current_target: PeerKeyLocation = target_peer;
     let mut current_target_addr: std::net::SocketAddr = target_addr;
+    let mut is_first_attempt = true;
 
     loop {
         // Fresh attempt tx: single-use-per-tx for send_and_await.
@@ -238,6 +260,26 @@ async fn drive_client_subscribe(
             attempts_at_hop,
             "subscribe (task-per-tx): sending attempt"
         );
+
+        // Per-attempt telemetry (review finding L4). `prepare_initial_request`
+        // emits the first-attempt event on `client_tx`; every retry after
+        // that emits on the fresh `attempt_tx` so the event log captures
+        // the full retry chain.
+        if !is_first_attempt {
+            if let Some(event) = crate::tracing::NetEventLog::subscribe_request(
+                &attempt_tx,
+                &op_manager.ring,
+                instance_id,
+                current_target.clone(),
+                htl,
+            ) {
+                op_manager
+                    .ring
+                    .register_events(either::Either::Left(event))
+                    .await;
+            }
+        }
+        is_first_attempt = false;
 
         let request = SubscribeMsg::Request {
             id: attempt_tx,
@@ -262,7 +304,13 @@ async fn drive_client_subscribe(
         // error, timeout) because the inserted callback slot is keyed
         // only on `attempt_tx` — its lifetime matches the attempt, not
         // the reply classification.
-        op_manager.release_pending_op_slot(attempt_tx);
+        //
+        // `release_pending_op_slot` uses a timeout-wrapped `send().await`
+        // rather than `try_send` so the cleanup survives transient
+        // notification-channel backpressure (review finding M1). We are
+        // inside a spawned task, not an event loop, so `send().await` is
+        // within the channel-safety rules.
+        op_manager.release_pending_op_slot(attempt_tx).await;
 
         let reply = match round_trip {
             Ok(Ok(reply)) => reply,
@@ -278,7 +326,7 @@ async fn drive_client_subscribe(
                 // wire-level NotFound here — from "should we retry on a
                 // different peer?" the answer is the same.
                 match advance_to_next_peer(
-                    &op_manager,
+                    op_manager,
                     &instance_id,
                     &mut visited,
                     &mut tried_peers,
@@ -288,19 +336,20 @@ async fn drive_client_subscribe(
                 )
                 .await
                 {
-                    Some((_next_target, next_addr)) => {
+                    Some((next_target, next_addr)) => {
+                        current_target = next_target;
                         current_target_addr = next_addr;
                         continue;
                     }
                     None => {
-                        return Ok(Err(ErrorKind::OperationError {
+                        return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
                             cause: format!(
                                 "subscribe to {instance_id} failed after {} rounds (last peer error: {err})",
                                 retries + 1
                             )
                             .into(),
                         }
-                        .into()));
+                        .into())));
                     }
                 }
             }
@@ -312,7 +361,7 @@ async fn drive_client_subscribe(
                     "subscribe (task-per-tx): attempt timed out after OPERATION_TTL; trying next peer"
                 );
                 match advance_to_next_peer(
-                    &op_manager,
+                    op_manager,
                     &instance_id,
                     &mut visited,
                     &mut tried_peers,
@@ -322,19 +371,20 @@ async fn drive_client_subscribe(
                 )
                 .await
                 {
-                    Some((_next_target, next_addr)) => {
+                    Some((next_target, next_addr)) => {
+                        current_target = next_target;
                         current_target_addr = next_addr;
                         continue;
                     }
                     None => {
-                        return Ok(Err(ErrorKind::OperationError {
+                        return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
                             cause: format!(
                                 "subscribe to {instance_id} timed out after {} rounds",
                                 retries + 1
                             )
                             .into(),
                         }
-                        .into()));
+                        .into())));
                     }
                 }
             }
@@ -349,12 +399,12 @@ async fn drive_client_subscribe(
                     contract = %key,
                     "subscribe (task-per-tx): subscribed"
                 );
-                return Ok(Ok(HostResponse::ContractResponse(
+                return Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
                     ContractResponse::SubscribeResponse {
                         key,
                         subscribed: true,
                     },
-                )));
+                ))));
             }
             ReplyClass::NotFound => {
                 tracing::debug!(
@@ -363,7 +413,7 @@ async fn drive_client_subscribe(
                     "subscribe (task-per-tx): NotFound, trying next peer"
                 );
                 match advance_to_next_peer(
-                    &op_manager,
+                    op_manager,
                     &instance_id,
                     &mut visited,
                     &mut tried_peers,
@@ -373,18 +423,19 @@ async fn drive_client_subscribe(
                 )
                 .await
                 {
-                    Some((_next_target, next_addr)) => {
+                    Some((next_target, next_addr)) => {
+                        current_target = next_target;
                         current_target_addr = next_addr;
                         continue;
                     }
                     None => {
-                        return Ok(Err(ErrorKind::OperationError {
+                        return Ok(DriverOutcome::Publish(Err(ErrorKind::OperationError {
                             cause: format!(
                                 "contract {instance_id} not found after exhaustive search"
                             )
                             .into(),
                         }
-                        .into()));
+                        .into())));
                     }
                 }
             }
@@ -513,50 +564,57 @@ async fn advance_to_next_peer(
     None
 }
 
-/// Sentinel indicating local completion has already been published via
-/// `NodeEvent::LocalSubscribeComplete`. The caller uses this to skip a
-/// second delivery through `result_router_tx`.
-fn locally_completed_marker(key: freenet_stdlib::prelude::ContractKey) -> HostResult {
-    // The value here is what `complete_local_subscription` → `p2p_protoc`
-    // delivers to the router internally. We mirror it so
-    // `deliver_result`'s debug log is accurate, but the marker flag below
-    // is what actually suppresses the second send.
-    Ok(HostResponse::ContractResponse(
-        ContractResponse::SubscribeResponse {
-            key,
-            subscribed: true,
-        },
-    ))
-}
-
-/// Publish `result` to `result_router_tx` keyed by `client_tx`, unless the
-/// result was produced by the local-completion path (which already
-/// published via `NodeEvent::LocalSubscribeComplete`).
+/// Publish the driver's outcome to the client, routing on the explicit
+/// [`DriverOutcome`] variant rather than inferring delivery state from
+/// [`OpManager::is_completed`].
 ///
-/// Uses [`OpManager::send_client_result`] so both the router publish and
-/// the follow-up `TransactionCompleted(client_tx)` notification (for
-/// `tx_to_client` cleanup in `p2p_protoc`) happen in one place.
-///
-/// We distinguish "already published locally" from "needs network publish"
-/// by checking whether the op was already marked completed:
-/// `complete_local_subscription` calls `op_manager.completed(tx)`, so a
-/// second `result_router_tx` send would be redundant and could race with
-/// the one from `p2p_protoc`. The `is_completed` guard is conservative —
-/// if in doubt we skip the second publish because the client cache in
-/// `SessionActor` tolerates missing results better than duplicates.
-fn deliver_result(op_manager: &OpManager, client_tx: Transaction, result: HostResult) {
-    // Skip publish if the local-completion path already marked this tx as
-    // completed. This handles both the standalone-node branch and the
-    // peer-not-joined-but-contract-available branch of
-    // `prepare_initial_request`.
-    if op_manager.is_completed(&client_tx) {
-        tracing::debug!(
-            tx = %client_tx,
-            "subscribe (task-per-tx): local completion already published; skipping result_router_tx"
-        );
-        return;
+/// - [`DriverOutcome::Publish`] routes the contained `HostResult` through
+///   [`OpManager::send_client_result`], which both pushes to
+///   `result_router_tx` and emits `NodeEvent::TransactionCompleted(client_tx)`
+///   so `p2p_protoc`'s `tx_to_client` table is reclaimed.
+/// - [`DriverOutcome::SkipAlreadyDelivered`] is a deliberate no-op:
+///   `complete_local_subscription` has already delivered the result via
+///   `NodeEvent::LocalSubscribeComplete`, and a second send would
+///   publish a duplicate `HostResponse::ContractResponse(SubscribeResponse)`
+///   to the client.
+/// - [`DriverOutcome::InfrastructureError`] is converted into a
+///   synthesized client-facing `HostResult::Err` and then published via
+///   `send_client_result`. This path is for errors that do not fit the
+///   user-visible error shape (e.g., `OpError::NotificationError` from
+///   `send_and_await`) — everything else the driver builds an explicit
+///   `DriverOutcome::Publish(Err(...))` for.
+fn deliver_outcome(
+    op_manager: &OpManager,
+    client_tx: Transaction,
+    instance_id: ContractInstanceId,
+    outcome: DriverOutcome,
+) {
+    match outcome {
+        DriverOutcome::Publish(result) => {
+            op_manager.send_client_result(client_tx, result);
+        }
+        DriverOutcome::SkipAlreadyDelivered => {
+            tracing::debug!(
+                tx = %client_tx,
+                "subscribe (task-per-tx): local completion already published; \
+                 skipping result_router_tx"
+            );
+        }
+        DriverOutcome::InfrastructureError(err) => {
+            tracing::warn!(
+                tx = %client_tx,
+                contract = %instance_id,
+                error = %err,
+                "subscribe (task-per-tx): infrastructure error; \
+                 publishing synthesized client error"
+            );
+            let synthesized: HostResult = Err(ErrorKind::OperationError {
+                cause: format!("subscribe failed: {err}").into(),
+            }
+            .into());
+            op_manager.send_client_result(client_tx, synthesized);
+        }
     }
-    op_manager.send_client_result(client_tx, result);
 }
 
 #[cfg(test)]

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2209,6 +2209,142 @@ fn test_full_state_send_no_incorrect_caching() {
 }
 
 // =============================================================================
+// Task-per-tx Subscribe ForwardingAck Regression Test (PR #3806)
+// =============================================================================
+
+/// Exercises the task-per-tx client-initiated subscribe path
+/// (`subscribe_with_id` → `start_client_subscribe`) in a multi-node
+/// simulation with network-routed subscribes.
+///
+/// ## Background (PR #3806, #1454 Phase 2b)
+///
+/// Phase 2b migrated client-initiated SUBSCRIBE to a task-per-tx driver.
+/// This test verifies the driver works end-to-end with network round-trips,
+/// retries, and peer selection.
+///
+/// ## ForwardingAck coverage
+///
+/// The ForwardingAck relay bug (commit 5cb6f37c) is covered by unit tests
+/// in `node.rs::callback_forward_tests`. Triggering it in simulation
+/// requires `SeedContract` + `use_mock_wasm=true` so that relay peers
+/// lack the contract. The `SeedContract` framework is in place but the
+/// mock WASM runtime has compatibility issues with `OpCtx::send_and_await`
+/// (separate from the local-completion fix below).
+///
+/// The task-per-tx `send_and_await` path IS exercised here: subscribes
+/// complete with `outcome="subscribed"` via the local-completion synthesis
+/// in the SUBSCRIBE branch of `handle_pure_network_message_v1`.
+#[test_log::test]
+fn test_subscribe_forwarding_ack_relay() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
+
+    const SEED: u64 = 0x5CB6_F37C_0001;
+    const NETWORK_NAME: &str = "subscribe-fwd-ack";
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let (sim, logs_handle) = rt.block_on(async {
+        let sim = SimNetwork::new(
+            NETWORK_NAME,
+            1, // 1 gateway
+            4, // 4 regular nodes
+            7, // ring_max_htl
+            3, // rnd_if_htl_above
+            5, // max_connections
+            2, // min_connections
+            SEED,
+        )
+        .await;
+        let logs_handle = sim.event_logs_handle();
+        (sim, logs_handle)
+    });
+
+    let contract = SimOperation::create_test_contract(0xAC);
+    let contract_id = *contract.key().id();
+    let initial_state = SimOperation::create_test_state(1);
+
+    // Gateway PUTs, then multiple nodes subscribe via the task-per-tx path.
+    //
+    // Note: SeedContract (no-propagation local store) is available for
+    // tests that need to control which nodes have the contract, but
+    // requires use_mock_wasm=true which has compatibility issues with
+    // OpCtx::send_and_await. For now, use regular PUT + Subscribe.
+    let operations = vec![
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: initial_state,
+                subscribe: true,
+            },
+        ),
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 1),
+            SimOperation::Subscribe { contract_id },
+        ),
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 2),
+            SimOperation::Subscribe { contract_id },
+        ),
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 3),
+            SimOperation::Subscribe { contract_id },
+        ),
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 4),
+            SimOperation::Subscribe { contract_id },
+        ),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(120),
+        Duration::from_secs(30),
+    );
+
+    // PRIMARY: simulation must complete without errors.
+    // Before the fix, ForwardingAck on the task-per-tx channel
+    // would cause UnexpectedOpState, crashing the simulation.
+    assert!(
+        result.turmoil_result.is_ok(),
+        "Simulation failed (ForwardingAck regression?): {:?}",
+        result.turmoil_result.err()
+    );
+
+    // Verify subscribes succeeded.
+    let (success_count, not_found_count) = rt.block_on(async {
+        let logs = logs_handle.lock().await;
+        let mut successes = 0usize;
+        let mut not_found = 0usize;
+        for log in logs.iter() {
+            match log.kind.subscribe_outcome() {
+                Some(true) => successes += 1,
+                Some(false) => not_found += 1,
+                None => {}
+            }
+        }
+        (successes, not_found)
+    });
+
+    tracing::info!(
+        success_count,
+        not_found_count,
+        "Subscribe telemetry summary"
+    );
+
+    // 4 explicit subscribes + 1 from gateway's put-with-subscribe.
+    assert!(
+        success_count >= 4,
+        "Expected at least 4 successful subscribes, got {} (not_found={})",
+        success_count,
+        not_found_count,
+    );
+}
+
+// =============================================================================
 // CRDT Emulation Mode Test (PR #2763 Bug Reproduction)
 // =============================================================================
 


### PR DESCRIPTION
## Problem

Phase 2a (#3803) landed `OpCtx::send_and_await` as scaffolding with only unit-test callers. Phase 2b needs to activate it by migrating a real operation onto the task-per-tx model, both as a working proof-of-concept for the new execution shape and to start shrinking the reach of `OpManager.ops.subscribe`.

Pre-implementation investigation also surfaced a structural gap in Phase 1's forwarding hook (`forward_pending_op_result_if_completed`): it assumes the legacy state machine successfully classifies the reply into a completed `OpEnum`, which is only true for paths that push state into the per-op DashMap. Task-per-tx callers never push, so `load_or_init` returns `OpNotPresent`, `handle_op_result` swallows it as benign (`Ok(None)`), and the callback never fires. The awaiting `send_and_await` hangs forever. See [#1454 (comment)](https://github.com/freenet/freenet-core/issues/1454#issuecomment-4215685695) for the full trace.

## Solution

Migrate the **client-initiated** SUBSCRIBE entry point (`node::subscribe_with_id`) to a task-per-tx driver. Renewal-initiated SUBSCRIBE (`ring::connection_maintenance`), PUT sub-op SUBSCRIBE (`operations::start_subscription_request_internal`), contract-executor-initiated SUBSCRIBE (`contract::executor::SubscribeContract::resume_op`), and intermediate-peer forwarding stay on the legacy path. None of those flow through `subscribe_with_id`, so its body can be migrated wholesale without a dispatch flag.

Key design decisions:

- **Fresh `Transaction` per attempt**: `OpCtx::send_and_await`'s single-use-per-tx contract (due to `completed` / `under_progress` dedup) is incompatible with legacy SUBSCRIBE reusing one tx across retries. The driver allocates a new attempt tx for each attempt and keeps a stable client-visible tx for result delivery. See module docs in `op_ctx_task.rs`.
- **Task-per-tx bypass in `handle_pure_network_message_v1`**: when `pending_op_result.is_some()`, the SUBSCRIBE branch forwards the raw inbound `NetMessage` directly to the awaiting callback and skips `handle_op_request` entirely. Factored into `try_forward_task_per_tx_reply` for reuse in Phases 2c/3/4 when they add their own first callers.
- **Shared `prepare_initial_request` helper**: extracted from `request_subscribe` so both legacy and new paths share the `k_closest_potentially_hosting` + fallback + local-completion decision logic without duplication. Telemetry emission lives inside the helper so both paths produce identical `NetEventLog::subscribe_request` events.
- **`OpManager::release_pending_op_slot`**: emits `NodeEvent::TransactionCompleted(attempt_tx)` after each `send_and_await` round-trip. Without this, `pending_op_results` entries only get reclaimed by the 60 s periodic sweep, and `test_pending_op_results_bounded` (explicitly scoped to Phase 2b activation) would flag a leak.
- **Peer timeout via `tokio::time::timeout(OPERATION_TTL, ...)`**: the driver wraps each `send_and_await` call. On timeout, it runs the same retry logic as `NotFound`, matching the legacy `handle_abort` behavior without needing a separate synthetic-reply mechanism.

The `#[allow(dead_code)]` attributes on `OpCtx` from Phase 2a are lifted now that the type has a real production caller.

## Testing

- **4 new unit tests in `node::callback_forward_tests`** cover the `try_forward_task_per_tx_reply` bypass helper: callback present → taken, callback absent → fall through, receiver dropped → still taken (legacy path must NOT run), channel full → non-blocking regression guard.
- **4 new unit tests in `operations::subscribe::op_ctx_task`** cover `classify_reply` for Subscribed / NotFound / Request (wrong direction, routing bug) / non-Subscribe variants.
- **`test_pending_op_results_bounded`** (previously documented as dormant pending Phase 2b activation) now exercises the full round-trip and verifies the cleanup path works.
- **Full legacy subscribe test suite** (`subscribe/tests.rs`, 45 tests) stays green: renewal / sub-op / executor / intermediate-peer paths still hit `request_subscribe` unchanged.
- **`cargo fmt && cargo clippy --all-targets -- -D warnings`** clean.
- **`cargo test -p freenet --lib`** — 2134 passed (including new unit tests).

End-to-end validation comes from the existing `simulation_integration` SUBSCRIBE scenarios, which transparently run through the new path now that `subscribe_with_id` dispatches to `start_client_subscribe`.

### Test plan

- [ ] `cargo fmt && cargo clippy --all-targets -- -D warnings` passes in CI
- [ ] `cargo test -p freenet --lib` passes in CI
- [ ] `cargo test -p freenet --features "simulation_tests,testing" --test simulation_integration` passes in CI (sequential/nextest-isolated)
- [ ] `test_pending_op_results_bounded` passes (regression guard for Phase 2b cleanup)
- [ ] Subscribe-related simulation integration tests pass

## Fixes

Part of #1454.