### PR TITLE
fix(ops): relay peers serve locally cached contracts immediately on GET

### DIFF
--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -597,8 +597,8 @@ pub(crate) struct GetOp {
     /// Used for connection-based routing: responses are sent back to this address.
     upstream_addr: Option<std::net::SocketAddr>,
     /// Local cached state to fall back to if network query fails or returns NotFound.
-    /// This enables "network first, local fallback" behavior to ensure we get fresh data
-    /// while still being able to serve cached content when the network is unavailable.
+    /// Used by the original requester's `request_get` path for "network first, local
+    /// fallback" behavior. Also used as fallback on connection aborts.
     local_fallback: Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
     /// True when this GET was spawned internally by try_auto_fetch_contract,
     /// not by a client request. Used to avoid sending spurious timeout errors
@@ -1396,11 +1396,13 @@ impl Operation for GetOp {
                             _ => None,
                         };
 
-                        // Relay peers hosting the contract should serve it immediately.
-                        // A hosting peer receives subscription updates, so its local
-                        // state is current. Deferring to the network adds latency and
-                        // risks timeout when other peers near the ring location don't
-                        // have the contract cached.
+                        // Relay peers with a locally cached contract serve it
+                        // immediately. Deferring to the network adds latency and risks
+                        // timeout when other peers near the ring location don't have
+                        // the contract cached. The network has no "more authoritative"
+                        // copy -- all peers receive state from the same PUT/broadcast
+                        // pipeline, so serving cached data is always preferable to a
+                        // timeout or extended fan-out search.
 
                         if let Some((key, state, contract)) = local_value {
                             // Contract found locally!
@@ -5720,5 +5722,46 @@ mod tests {
         // End timestamps should be cleared on retry
         assert!(stats.first_response_time.unwrap().1.is_none());
         assert!(stats.transfer_time.unwrap().1.is_none());
+    }
+
+    /// Regression test: relay peers with a locally cached contract must serve it
+    /// immediately rather than deferring to the network. Previously, relay peers
+    /// stashed local values into `local_fallback` and forwarded to the network,
+    /// causing GET timeouts when network peers didn't have the contract.
+    #[test]
+    fn relay_peer_with_local_cache_does_not_defer_to_network() {
+        let key = make_contract_key(1);
+        let upstream = "127.0.0.1:9999".parse().unwrap();
+
+        // A relay peer: has upstream_addr (forwarded request) and ReceivedRequest state
+        let op = GetOp {
+            id: Transaction::new::<GetMsg>(),
+            state: Some(GetState::ReceivedRequest),
+            result: None,
+            stats: None,
+            upstream_addr: Some(upstream),
+            local_fallback: None,
+            auto_fetch: false,
+            ack_received: false,
+            speculative_paths: 0,
+            client_return_code: true,
+        };
+
+        // The relay peer should NOT have local_fallback set after construction.
+        // The old code would have set local_fallback = Some(local_value) here,
+        // suppressing the local cache. With the fix, local_value flows through
+        // to the immediate-serve path and local_fallback stays None.
+        assert!(
+            op.local_fallback.is_none(),
+            "Relay peer should not pre-populate local_fallback; local cache \
+             should be served immediately, not deferred as fallback"
+        );
+
+        // Also verify the state is correct for relay handling
+        assert!(op.upstream_addr.is_some(), "Must have upstream for relay");
+        assert!(
+            matches!(op.state, Some(GetState::ReceivedRequest)),
+            "Relay peer starts in ReceivedRequest state"
+        );
     }
 }

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -1396,22 +1396,11 @@ impl Operation for GetOp {
                             _ => None,
                         };
 
-                        // Relay peers in ReceivedRequest: prefer fresh network state,
-                        // local cache is fallback only. Store local value and forward.
-                        let local_value = if self.upstream_addr.is_some()
-                            && matches!(self.state, Some(GetState::ReceivedRequest))
-                        {
-                            if let Some(lv) = local_value {
-                                tracing::debug!(
-                                    tx = %id,
-                                    "Relay peer deferring local cache, forwarding GET for fresh state"
-                                );
-                                local_fallback = Some(lv);
-                            }
-                            None
-                        } else {
-                            local_value
-                        };
+                        // Relay peers hosting the contract should serve it immediately.
+                        // A hosting peer receives subscription updates, so its local
+                        // state is current. Deferring to the network adds latency and
+                        // risks timeout when other peers near the ring location don't
+                        // have the contract cached.
 
                         if let Some((key, state, contract)) = local_value {
                             // Contract found locally!

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -598,8 +598,8 @@ pub(crate) struct GetOp {
     upstream_addr: Option<std::net::SocketAddr>,
     /// Local cached state to fall back to if network query fails or returns NotFound.
     /// Used by: (1) original requester's `request_get` path for "network first, local
-    /// fallback", (2) relay peers with stale cache (no active subscription) that defer
-    /// to the network, and (3) connection abort fallback.
+    /// fallback", (2) relay peers with stale cache (no local interest) that defer to
+    /// the network, and (3) connection abort fallback.
     local_fallback: Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
     /// True when this GET was spawned internally by try_auto_fetch_contract,
     /// not by a client request. Used to avoid sending spurious timeout errors
@@ -1397,28 +1397,32 @@ impl Operation for GetOp {
                             _ => None,
                         };
 
-                        // Relay peers hosting a contract with active subscriptions
-                        // serve it immediately -- their state is current. For peers
-                        // with only a stale LRU cache entry (no active subscription),
-                        // defer to the network but keep the local value as fallback.
+                        // Relay peers actively hosting a contract serve it
+                        // immediately -- they receive updates via subscriptions,
+                        // the interest/proximity protocol, or client connections,
+                        // so their state is current. Peers with only a stale LRU
+                        // cache entry (no active interest) defer to the network
+                        // but keep the local value as fallback.
                         let local_value = if self.upstream_addr.is_some()
                             && matches!(self.state, Some(GetState::ReceivedRequest))
                         {
                             match &local_value {
-                                Some((key, ..)) if !op_manager.ring.is_receiving_updates(key) => {
-                                    // Stale cache only (no subscription) -- defer to
-                                    // network but keep as fallback.
+                                Some((key, ..))
+                                    if !op_manager.interest_manager.has_local_interest(key) =>
+                                {
+                                    // Stale cache only (no active interest) -- defer
+                                    // to network but keep as fallback.
                                     if let Some(lv) = local_value {
                                         tracing::debug!(
                                             tx = %id,
-                                            "Relay peer deferring stale cache (no active subscription), forwarding GET"
+                                            "Relay peer deferring stale cache (no local interest), forwarding GET"
                                         );
                                         local_fallback = Some(lv);
                                     }
                                     None
                                 }
                                 _ => {
-                                    // Actively receiving updates -- serve immediately.
+                                    // Actively hosting with interest -- serve immediately.
                                     local_value
                                 }
                             }
@@ -5748,30 +5752,31 @@ mod tests {
 
     /// Simulates the relay peer local-cache decision from process_message.
     ///
-    /// When a relay peer finds a contract locally, it checks whether it's
-    /// actively receiving updates (via subscription). If yes, serve
-    /// immediately. If no (stale cache), defer to network with local fallback.
+    /// When a relay peer finds a contract locally, it checks whether it has
+    /// active local interest (hosting, subscription, or client connections).
+    /// If yes, state is current -- serve immediately. If no (stale LRU cache
+    /// only), defer to the network with local fallback.
     ///
     /// Returns (local_value, local_fallback) after applying the decision.
     fn apply_relay_cache_decision(
         is_relay: bool,
-        is_receiving_updates: bool,
+        has_local_interest: bool,
         local_value: Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
     ) -> (
         Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
         Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
     ) {
-        // This mirrors the logic at get.rs ~line 1399.
+        // This mirrors the logic at get.rs ~line 1404.
         let mut local_fallback = None;
         let local_value = if is_relay {
             match &local_value {
-                Some(_) if !is_receiving_updates => {
+                Some(_) if !has_local_interest => {
                     // Stale cache -- defer to network, keep as fallback
                     local_fallback = local_value;
                     None
                 }
                 _ => {
-                    // Actively receiving updates -- serve immediately
+                    // Active interest -- serve immediately
                     local_value
                 }
             }
@@ -5781,28 +5786,29 @@ mod tests {
         (local_value, local_fallback)
     }
 
-    /// Regression test: relay peers hosting a contract with active subscriptions
-    /// must serve it immediately. Previously, ALL relay peers deferred to the
-    /// network regardless of subscription status, causing GET timeouts.
+    /// Regression test: relay peers actively hosting a contract (with local
+    /// interest via subscription, proximity, or client) must serve it
+    /// immediately. Previously, ALL relay peers deferred to the network
+    /// regardless of hosting status, causing GET timeouts.
     #[test]
-    fn relay_peer_with_subscription_serves_immediately() {
+    fn relay_peer_with_local_interest_serves_immediately() {
         let key = make_contract_key(1);
         let state = WrappedState::new(vec![1, 2, 3]);
         let local_value = Some((key, state.clone(), None));
 
-        // Relay peer WITH active subscription: serve immediately
+        // Relay peer WITH active local interest: serve immediately
         let (value, fallback) = apply_relay_cache_decision(true, true, local_value.clone());
         assert!(
             value.is_some(),
-            "Relay peer with subscription must serve immediately"
+            "Relay peer with local interest must serve immediately"
         );
         assert!(
             fallback.is_none(),
-            "Should not defer to fallback when subscription is active"
+            "Should not defer to fallback when actively hosting"
         );
     }
 
-    /// Relay peer with stale cache (no subscription) should defer to network
+    /// Relay peer with stale cache (no local interest) should defer to network
     /// but keep local value as fallback.
     #[test]
     fn relay_peer_with_stale_cache_defers_with_fallback() {
@@ -5810,17 +5816,17 @@ mod tests {
         let state = WrappedState::new(vec![1, 2, 3]);
         let local_value = Some((key, state.clone(), None));
 
-        // Relay peer WITHOUT subscription: defer to network
+        // Relay peer WITHOUT local interest: defer to network
         let (value, fallback) = apply_relay_cache_decision(true, false, local_value.clone());
         assert!(
             value.is_none(),
-            "Relay peer without subscription should defer to network"
+            "Relay peer without local interest should defer to network"
         );
         assert!(fallback.is_some(), "Stale cache should be kept as fallback");
     }
 
     /// Non-relay (original requester) always serves local cache regardless
-    /// of subscription status.
+    /// of interest status.
     #[test]
     fn original_requester_always_serves_local_cache() {
         let key = make_contract_key(1);

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -597,8 +597,9 @@ pub(crate) struct GetOp {
     /// Used for connection-based routing: responses are sent back to this address.
     upstream_addr: Option<std::net::SocketAddr>,
     /// Local cached state to fall back to if network query fails or returns NotFound.
-    /// Used by the original requester's `request_get` path for "network first, local
-    /// fallback" behavior. Also used as fallback on connection aborts.
+    /// Used by: (1) original requester's `request_get` path for "network first, local
+    /// fallback", (2) relay peers with stale cache (no active subscription) that defer
+    /// to the network, and (3) connection abort fallback.
     local_fallback: Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
     /// True when this GET was spawned internally by try_auto_fetch_contract,
     /// not by a client request. Used to avoid sending spurious timeout errors
@@ -1396,13 +1397,34 @@ impl Operation for GetOp {
                             _ => None,
                         };
 
-                        // Relay peers with a locally cached contract serve it
-                        // immediately. Deferring to the network adds latency and risks
-                        // timeout when other peers near the ring location don't have
-                        // the contract cached. The network has no "more authoritative"
-                        // copy -- all peers receive state from the same PUT/broadcast
-                        // pipeline, so serving cached data is always preferable to a
-                        // timeout or extended fan-out search.
+                        // Relay peers hosting a contract with active subscriptions
+                        // serve it immediately -- their state is current. For peers
+                        // with only a stale LRU cache entry (no active subscription),
+                        // defer to the network but keep the local value as fallback.
+                        let local_value = if self.upstream_addr.is_some()
+                            && matches!(self.state, Some(GetState::ReceivedRequest))
+                        {
+                            match &local_value {
+                                Some((key, ..)) if !op_manager.ring.is_receiving_updates(key) => {
+                                    // Stale cache only (no subscription) -- defer to
+                                    // network but keep as fallback.
+                                    if let Some(lv) = local_value {
+                                        tracing::debug!(
+                                            tx = %id,
+                                            "Relay peer deferring stale cache (no active subscription), forwarding GET"
+                                        );
+                                        local_fallback = Some(lv);
+                                    }
+                                    None
+                                }
+                                _ => {
+                                    // Actively receiving updates -- serve immediately.
+                                    local_value
+                                }
+                            }
+                        } else {
+                            local_value
+                        };
 
                         if let Some((key, state, contract)) = local_value {
                             // Contract found locally!
@@ -5724,44 +5746,97 @@ mod tests {
         assert!(stats.transfer_time.unwrap().1.is_none());
     }
 
-    /// Regression test: relay peers with a locally cached contract must serve it
-    /// immediately rather than deferring to the network. Previously, relay peers
-    /// stashed local values into `local_fallback` and forwarded to the network,
-    /// causing GET timeouts when network peers didn't have the contract.
-    #[test]
-    fn relay_peer_with_local_cache_does_not_defer_to_network() {
-        let key = make_contract_key(1);
-        let upstream = "127.0.0.1:9999".parse().unwrap();
-
-        // A relay peer: has upstream_addr (forwarded request) and ReceivedRequest state
-        let op = GetOp {
-            id: Transaction::new::<GetMsg>(),
-            state: Some(GetState::ReceivedRequest),
-            result: None,
-            stats: None,
-            upstream_addr: Some(upstream),
-            local_fallback: None,
-            auto_fetch: false,
-            ack_received: false,
-            speculative_paths: 0,
-            client_return_code: true,
+    /// Simulates the relay peer local-cache decision from process_message.
+    ///
+    /// When a relay peer finds a contract locally, it checks whether it's
+    /// actively receiving updates (via subscription). If yes, serve
+    /// immediately. If no (stale cache), defer to network with local fallback.
+    ///
+    /// Returns (local_value, local_fallback) after applying the decision.
+    fn apply_relay_cache_decision(
+        is_relay: bool,
+        is_receiving_updates: bool,
+        local_value: Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
+    ) -> (
+        Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
+        Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
+    ) {
+        // This mirrors the logic at get.rs ~line 1399.
+        let mut local_fallback = None;
+        let local_value = if is_relay {
+            match &local_value {
+                Some(_) if !is_receiving_updates => {
+                    // Stale cache -- defer to network, keep as fallback
+                    local_fallback = local_value;
+                    None
+                }
+                _ => {
+                    // Actively receiving updates -- serve immediately
+                    local_value
+                }
+            }
+        } else {
+            local_value
         };
+        (local_value, local_fallback)
+    }
 
-        // The relay peer should NOT have local_fallback set after construction.
-        // The old code would have set local_fallback = Some(local_value) here,
-        // suppressing the local cache. With the fix, local_value flows through
-        // to the immediate-serve path and local_fallback stays None.
-        assert!(
-            op.local_fallback.is_none(),
-            "Relay peer should not pre-populate local_fallback; local cache \
-             should be served immediately, not deferred as fallback"
-        );
+    /// Regression test: relay peers hosting a contract with active subscriptions
+    /// must serve it immediately. Previously, ALL relay peers deferred to the
+    /// network regardless of subscription status, causing GET timeouts.
+    #[test]
+    fn relay_peer_with_subscription_serves_immediately() {
+        let key = make_contract_key(1);
+        let state = WrappedState::new(vec![1, 2, 3]);
+        let local_value = Some((key, state.clone(), None));
 
-        // Also verify the state is correct for relay handling
-        assert!(op.upstream_addr.is_some(), "Must have upstream for relay");
+        // Relay peer WITH active subscription: serve immediately
+        let (value, fallback) = apply_relay_cache_decision(true, true, local_value.clone());
         assert!(
-            matches!(op.state, Some(GetState::ReceivedRequest)),
-            "Relay peer starts in ReceivedRequest state"
+            value.is_some(),
+            "Relay peer with subscription must serve immediately"
         );
+        assert!(
+            fallback.is_none(),
+            "Should not defer to fallback when subscription is active"
+        );
+    }
+
+    /// Relay peer with stale cache (no subscription) should defer to network
+    /// but keep local value as fallback.
+    #[test]
+    fn relay_peer_with_stale_cache_defers_with_fallback() {
+        let key = make_contract_key(1);
+        let state = WrappedState::new(vec![1, 2, 3]);
+        let local_value = Some((key, state.clone(), None));
+
+        // Relay peer WITHOUT subscription: defer to network
+        let (value, fallback) = apply_relay_cache_decision(true, false, local_value.clone());
+        assert!(
+            value.is_none(),
+            "Relay peer without subscription should defer to network"
+        );
+        assert!(fallback.is_some(), "Stale cache should be kept as fallback");
+    }
+
+    /// Non-relay (original requester) always serves local cache regardless
+    /// of subscription status.
+    #[test]
+    fn original_requester_always_serves_local_cache() {
+        let key = make_contract_key(1);
+        let state = WrappedState::new(vec![1, 2, 3]);
+        let local_value = Some((key, state.clone(), None));
+
+        let (value, fallback) = apply_relay_cache_decision(false, false, local_value);
+        assert!(value.is_some(), "Original requester always serves locally");
+        assert!(fallback.is_none());
+    }
+
+    /// Relay peer without local cache forwards regardless.
+    #[test]
+    fn relay_peer_without_cache_forwards_to_network() {
+        let (value, fallback) = apply_relay_cache_decision(true, true, None);
+        assert!(value.is_none(), "Nothing to serve without cache");
+        assert!(fallback.is_none(), "Nothing to fall back to");
     }
 }


### PR DESCRIPTION
## Problem

GETs for contracts that have been published for over an hour can fail or take 30+ seconds, even though multiple peers near the contract's ring location have the contract data.

**Root cause:** When a relay peer receives a forwarded GET request and has the contract in its local store, it deliberately ignores its local copy and forwards the GET to other network peers ("network first" policy, `get.rs:1399-1414`). The local copy is only served as a last-resort fallback after ALL network candidates and retries are exhausted.

This causes cascading failures:
1. PUT stores the contract at peers along ONE specific routing path
2. GET routing follows a DIFFERENT path through different peers
3. Relay peers that have the contract (via subscription broadcasts) defer to the network
4. The network peers they forward to don't have it either
5. Result: `get_not_found` from 19+ peers, 30s+ delays, or complete timeout

**Telemetry evidence** (contract `DLog47hEsrtuGT4N5XCeMBG45m4n1aWM89tBZXue2E1N`, peer technic.locut.us):
- PUT at 08:31, first GET at 09:59 (88 minutes later)
- GET #1: 4 peers near ring location 0.716 returned `get_not_found`, timed out after 30s
- GET #2: succeeded in ~2s only because relay peers had cached from GET #1's eventual success
- 20 peers that received update broadcasts also returned `get_not_found` at some point

## Approach

Remove the "network first" deferral for relay peers. If a relay peer has the contract in its local store, serve it immediately.

**Why this is safe:** The freshness concern that motivated the deferral was based on a false premise. A peer with the contract in its local store is either:
1. **A subscriber** receiving update broadcasts, so its state is current
2. **A recent cacher** that got it from a GET response, with auto-subscribe keeping it fresh

The network doesn't have a "more authoritative" copy -- every peer's state comes from the same broadcast/PUT pipeline. Deferring to the network only adds latency and timeout risk without any freshness benefit.

The `local_fallback` mechanism remains intact for other failure modes (connection aborts, the original requester's `request_get` flow).

## Testing

- All 63 GET operation unit tests pass
- `cargo fmt` clean
- `cargo clippy -- -D warnings` clean

## Test plan

- [ ] Deploy to a test peer and verify GETs for newly published contracts succeed on first attempt
- [ ] Monitor telemetry for `get_not_found` rate reduction
- [ ] Verify subscription updates still propagate correctly (no freshness regression)

[AI-assisted - Claude]