### PR TITLE
fix: release process should detect missing platform binaries

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -136,10 +136,6 @@ jobs:
     name: Build for x86_64-apple-darwin
     runs-on: macos-latest  # Cross-compile from Apple Silicon to x86_64
     timeout-minutes: 60
-    # Apple deprecated x86_64 macOS; this build is best-effort and should not
-    # block the attach-to-release job when it fails.
-    continue-on-error: true
-
     steps:
       - uses: actions/checkout@v6
 
@@ -265,17 +261,15 @@ jobs:
           name: binaries-arm64-macos-fdev
           path: artifacts/arm64-macos-fdev
 
-      # macOS x86_64 (best-effort — may not exist if build failed)
+      # macOS x86_64
       - name: Download x86_64 macOS freenet binary
         uses: actions/download-artifact@v8
-        continue-on-error: true
         with:
           name: binaries-x86_64-macos-freenet
           path: artifacts/x86_64-macos-freenet
 
       - name: Download x86_64 macOS fdev binary
         uses: actions/download-artifact@v8
-        continue-on-error: true
         with:
           name: binaries-x86_64-macos-fdev
           path: artifacts/x86_64-macos-fdev
@@ -308,13 +302,9 @@ jobs:
           cd artifacts/arm64-macos-freenet && tar -czvf ../../freenet-aarch64-apple-darwin.tar.gz freenet && cd ../..
           cd artifacts/arm64-macos-fdev && tar -czvf ../../fdev-aarch64-apple-darwin.tar.gz fdev && cd ../..
 
-          # macOS x86_64 (best-effort — may not exist)
-          if [ -d artifacts/x86_64-macos-freenet ]; then
-            cd artifacts/x86_64-macos-freenet && tar -czvf ../../freenet-x86_64-apple-darwin.tar.gz freenet && cd ../..
-          fi
-          if [ -d artifacts/x86_64-macos-fdev ]; then
-            cd artifacts/x86_64-macos-fdev && tar -czvf ../../fdev-x86_64-apple-darwin.tar.gz fdev && cd ../..
-          fi
+          # macOS x86_64
+          cd artifacts/x86_64-macos-freenet && tar -czvf ../../freenet-x86_64-apple-darwin.tar.gz freenet && cd ../..
+          cd artifacts/x86_64-macos-fdev && tar -czvf ../../fdev-x86_64-apple-darwin.tar.gz fdev && cd ../..
 
           # Windows x86_64 (zip for backwards compat + bare exe for direct download)
           cd artifacts/x86_64-windows-freenet && zip ../../freenet-x86_64-pc-windows-msvc.zip freenet.exe && cd ../..

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1132,12 +1132,14 @@ trigger_gateway_updates() {
 }
 
 publish_draft_release() {
-    # Publish the draft release (idempotent -- no-op if already published)
+    # Publish the draft release (idempotent -- no-op if already published).
+    # The cross-compile workflow also publishes via gh release edit --draft=false
+    # as a belt-and-suspenders measure (see cross-compile.yml).
     local is_draft
     is_draft=$(gh release view "v$VERSION" --repo freenet/freenet-core --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
     if [[ "$is_draft" == "true" ]]; then
         echo -n "  Publishing draft release... "
-        gh release edit "v$VERSION" --repo freenet/freenet-core --draft=false
+        gh release edit "v$VERSION" --repo freenet/freenet-core --draft=false > /dev/null
         echo "✓"
     fi
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1057,11 +1057,12 @@ create_github_release() {
     echo "✓"
 
     echo -n "  Creating GitHub release... "
-    release_url=$(gh release create "v$VERSION" --title "v$VERSION" --notes "$release_notes")
-    echo "✓"
+    release_url=$(gh release create "v$VERSION" --title "v$VERSION" --notes "$release_notes" --draft)
+    echo "✓ (draft)"
     mark_completed "RELEASE_CREATED"
 
-    echo "  Release created: $release_url"
+    echo "  Draft release created: $release_url"
+    echo "  Release will be published after cross-compile binaries are attached."
 }
 
 # Note: Cross-compilation is now triggered automatically when a version tag is pushed
@@ -1130,6 +1131,39 @@ trigger_gateway_updates() {
     fi
 }
 
+publish_draft_release() {
+    # Publish the draft release (idempotent -- no-op if already published)
+    local is_draft
+    is_draft=$(gh release view "v$VERSION" --repo freenet/freenet-core --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
+    if [[ "$is_draft" == "true" ]]; then
+        echo -n "  Publishing draft release... "
+        gh release edit "v$VERSION" --repo freenet/freenet-core --draft=false
+        echo "✓"
+    fi
+}
+
+verify_required_binaries() {
+    local required=("$@")
+    local assets
+    assets=$(gh release view "v$VERSION" --repo freenet/freenet-core --json assets --jq '.assets[].name' 2>/dev/null)
+    if [[ -z "$assets" ]]; then
+        return 1
+    fi
+    local missing=()
+    for bin in "${required[@]}"; do
+        if ! echo "$assets" | grep -qF "$bin"; then
+            missing+=("$bin")
+        fi
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        for m in "${missing[@]}"; do
+            echo "  ✗ Missing: $m"
+        done
+        return 1
+    fi
+    return 0
+}
+
 wait_for_binaries() {
     echo "Waiting for cross-compile workflow to complete:"
 
@@ -1138,11 +1172,19 @@ wait_for_binaries() {
         return 0
     fi
 
-    # Check if binaries are already available
-    local asset_count
-    asset_count=$(gh release view "v$VERSION" --repo freenet/freenet-core --json assets --jq '.assets | length' 2>/dev/null || echo "0")
-    if [[ "$asset_count" -ge 8 ]]; then
-        echo "  ✓ Binaries already available ($asset_count assets)"
+    # Required platform binaries that must be present in the release
+    local REQUIRED_BINARIES=(
+        "freenet-x86_64-unknown-linux-musl.tar.gz"
+        "freenet-aarch64-unknown-linux-musl.tar.gz"
+        "freenet-aarch64-apple-darwin.tar.gz"
+        "freenet-x86_64-apple-darwin.tar.gz"
+        "freenet-x86_64-pc-windows-msvc.zip"
+    )
+
+    # Check if all required binaries are already available
+    if verify_required_binaries "${REQUIRED_BINARIES[@]}"; then
+        echo "  ✓ All required platform binaries already available"
+        publish_draft_release
         return 0
     fi
 
@@ -1187,11 +1229,17 @@ wait_for_binaries() {
             if [[ "$conclusion" == "success" ]]; then
                 echo "  ✓ Cross-compile workflow completed successfully"
 
-                # Verify assets are uploaded
+                # Verify all required platform binaries are uploaded
                 sleep 5  # Brief delay for asset upload
-                asset_count=$(gh release view "v$VERSION" --repo freenet/freenet-core --json assets --jq '.assets | length' 2>/dev/null || echo "0")
-                echo "  ✓ Release has $asset_count assets attached"
-                return 0
+                if verify_required_binaries "${REQUIRED_BINARIES[@]}"; then
+                    echo "  ✓ All required platform binaries attached"
+                    publish_draft_release
+                    return 0
+                else
+                    echo "  ✗ Cross-compile succeeded but some required binaries are missing"
+                    echo "     Check: https://github.com/freenet/freenet-core/actions/runs/$run_id"
+                    return 1
+                fi
             else
                 echo "  ✗ Cross-compile workflow failed (conclusion: $conclusion)"
                 echo "     Binaries will NOT be available for auto-update."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1153,7 +1153,7 @@ verify_required_binaries() {
     fi
     local missing=()
     for bin in "${required[@]}"; do
-        if ! echo "$assets" | grep -qF "$bin"; then
+        if ! echo "$assets" | grep -xqF "$bin"; then
             missing+=("$bin")
         fi
     done
@@ -1174,13 +1174,19 @@ wait_for_binaries() {
         return 0
     fi
 
-    # Required platform binaries that must be present in the release
+    # Required platform binaries that must be present in the release.
+    # Both freenet and fdev must be present for all platforms.
     local REQUIRED_BINARIES=(
         "freenet-x86_64-unknown-linux-musl.tar.gz"
         "freenet-aarch64-unknown-linux-musl.tar.gz"
         "freenet-aarch64-apple-darwin.tar.gz"
         "freenet-x86_64-apple-darwin.tar.gz"
         "freenet-x86_64-pc-windows-msvc.zip"
+        "fdev-x86_64-unknown-linux-musl.tar.gz"
+        "fdev-aarch64-unknown-linux-musl.tar.gz"
+        "fdev-aarch64-apple-darwin.tar.gz"
+        "fdev-x86_64-apple-darwin.tar.gz"
+        "fdev-x86_64-pc-windows-msvc.zip"
     )
 
     # Check if all required binaries are already available


### PR DESCRIPTION
## Problem

v0.2.38 shipped without the x86_64-apple-darwin (Intel Mac) binary due to three layered failures:

1. `continue-on-error: true` on the x86_64 macOS build job silently swallowed the failure
2. `release.sh` only checked `asset_count >= 8` instead of verifying specific platform binaries
3. The release skill didn't enumerate expected binaries for verification

## Approach

**cross-compile.yml:**
- Remove `continue-on-error: true` from `build-x86_64-macos` (now that #3823 fixed the underlying wasmtime issue)
- Remove `continue-on-error: true` from x86_64 macOS artifact download steps
- Remove conditional logic for "may not exist" x86_64 macOS artifacts

**scripts/release.sh:**
- Replace count-based check with `verify_required_binaries()` that validates each required platform binary by name
- Create GitHub release as a draft, only publishing after all binaries are confirmed attached
- Add `publish_draft_release()` helper for idempotent draft->published transition

**Release skill (separate repo):**
- Updated Step 6 to enumerate all 12 expected release assets explicitly

## Testing

- Shell script changes are process/workflow changes, not testable in unit tests
- CI workflow changes will be validated on next release tag push
- The `verify_required_binaries` function can be tested with `--dry-run` mode

Closes #3825

[AI-assisted - Claude]