### PR TITLE
feat: add --node-url flag to fdev for remote gateway publishing

### DIFF
--- a/crates/fdev/README-FULL.md
+++ b/crates/fdev/README-FULL.md
@@ -55,6 +55,27 @@ Usually you'll build `fdev` as part of the Freenet project:
 
 ---
 
+## Connection Options
+
+By default, `fdev` connects to a local Freenet node at `ws://127.0.0.1:7509`. You can customize this with:
+
+- **`--address`** and **`--port`**: Override the host/port for the WebSocket connection.
+- **`--node-url`**: Provide a full WebSocket URL, bypassing address/port construction. This is required when connecting through a gateway proxy that uses an auth secret in the URL path.
+
+```bash
+# Connect via gateway proxy (e.g. from CI/CD)
+fdev --node-url "ws://nova.locut.us:7520/SECRET/v1/contract/command?encodingProtocol=native" \
+    website publish ./public/ --key my-site
+
+# Or via environment variable
+export FREENET_NODE_URL="ws://nova.locut.us:7520/SECRET/v1/contract/command?encodingProtocol=native"
+fdev website publish ./public/ --key my-site
+```
+
+When `--node-url` is provided, `--address` and `--port` cannot be specified.
+
+---
+
 ## Local Node Example
 
 If you want to try out a contract in local mode, you typically run a separate “local node” process that listens for contract commands. There is a `local-node` executable (or an equivalent) in the Freenet repository. You can do something like:
@@ -271,7 +292,7 @@ fdev wasm-runtime \
     --deserialization-format binary \
     --terminal-output
 ```
-- The tool will connect to a local Freenet node by default (see `--mode`, `--address`, `--port` if needed).
+- The tool will connect to a local Freenet node by default (see `--mode`, `--address`, `--port` if needed). Use `--node-url` to connect to a remote gateway via proxy.
 - Commands you type—like `put`, `get`, `update`, or `exit`—are forwarded to the local node.
 - Additional command data is read from the file specified by `--input-file`.
 
@@ -676,7 +697,7 @@ fdev wasm-runtime \
     --deserialization-format json \
     --terminal-output
 ```
-- The tool will connect to a local Freenet node by default (see `--mode`, `--address`, `--port` if needed).
+- The tool will connect to a local Freenet node by default (see `--mode`, `--address`, `--port` if needed). Use `--node-url` to connect to a remote gateway via proxy.
 - Commands you type—like `put`, `get`, `update`, or `exit`—are forwarded to the local node.
 - Additional command data is read from the file specified by `--input-file`.
 

--- a/crates/fdev/src/commands/v1.rs
+++ b/crates/fdev/src/commands/v1.rs
@@ -1,27 +1,28 @@
 use super::*;
 
 pub(super) async fn start_api_client(cfg: BaseConfig) -> anyhow::Result<WebApi> {
-    let mode = cfg.mode;
-    let address = cfg.address;
-    let target = match mode {
-        OperationMode::Local => {
-            if !address.is_loopback() {
-                return Err(anyhow::anyhow!(
-                    "invalid ip: {address}, expecting a loopback ip address in local mode"
-                ));
+    let url = if let Some(node_url) = &cfg.node_url {
+        node_url.clone()
+    } else {
+        let mode = cfg.mode;
+        let address = cfg.address;
+        let target = match mode {
+            OperationMode::Local => {
+                if !address.is_loopback() {
+                    return Err(anyhow::anyhow!(
+                        "invalid ip: {address}, expecting a loopback ip address in local mode"
+                    ));
+                }
+                SocketAddr::new(address, cfg.port)
             }
-            SocketAddr::new(address, cfg.port)
-        }
-        OperationMode::Network => SocketAddr::new(address, cfg.port),
+            OperationMode::Network => SocketAddr::new(address, cfg.port),
+        };
+        format!("ws://{target}/v1/contract/command?encodingProtocol=native")
     };
 
-    let (stream, _) = tokio_tungstenite::connect_async(&format!(
-        "ws://{target}/v1/contract/command?encodingProtocol=native"
-    ))
-    .await
-    .map_err(|e| {
+    let (stream, _) = tokio_tungstenite::connect_async(&url).await.map_err(|e| {
         tracing::error!(err=%e);
-        anyhow::anyhow!(format!("fail to connect to the host({target}): {e}"))
+        anyhow::anyhow!("fail to connect to the host({url}): {e}")
     })?;
 
     Ok(WebApi::start(stream))

--- a/crates/fdev/src/commands/v1.rs
+++ b/crates/fdev/src/commands/v1.rs
@@ -1,8 +1,14 @@
 use super::*;
 
-pub(super) async fn start_api_client(cfg: BaseConfig) -> anyhow::Result<WebApi> {
-    let url = if let Some(node_url) = &cfg.node_url {
-        node_url.clone()
+/// Resolve the WebSocket URL from the config, either from `node_url` or constructed from address/port/mode.
+pub(super) fn resolve_ws_url(cfg: &BaseConfig) -> anyhow::Result<String> {
+    if let Some(node_url) = &cfg.node_url {
+        if !node_url.starts_with("ws://") && !node_url.starts_with("wss://") {
+            return Err(anyhow::anyhow!(
+                "invalid --node-url: must start with ws:// or wss://"
+            ));
+        }
+        Ok(node_url.clone())
     } else {
         let mode = cfg.mode;
         let address = cfg.address;
@@ -17,12 +23,34 @@ pub(super) async fn start_api_client(cfg: BaseConfig) -> anyhow::Result<WebApi> 
             }
             OperationMode::Network => SocketAddr::new(address, cfg.port),
         };
-        format!("ws://{target}/v1/contract/command?encodingProtocol=native")
-    };
+        Ok(format!(
+            "ws://{target}/v1/contract/command?encodingProtocol=native"
+        ))
+    }
+}
+
+/// Sanitize a URL for logging by replacing path segments between host and `/v1/` with `***`.
+fn sanitize_url_for_log(url: &str) -> String {
+    if let Some(idx) = url.find("/v1/") {
+        let scheme_end = url.find("://").map(|i| i + 3).unwrap_or(0);
+        let host_end = url[scheme_end..].find('/').map(|i| i + scheme_end);
+        if let Some(host_end) = host_end {
+            if host_end < idx {
+                return format!("{}/***/v1/{}", &url[..host_end], &url[idx + 4..]);
+            }
+        }
+    }
+    // No /v1/ path found or no secret segment; return as-is
+    url.to_string()
+}
+
+pub(super) async fn start_api_client(cfg: BaseConfig) -> anyhow::Result<WebApi> {
+    let url = resolve_ws_url(&cfg)?;
 
     let (stream, _) = tokio_tungstenite::connect_async(&url).await.map_err(|e| {
+        let safe_url = sanitize_url_for_log(&url);
         tracing::error!(err=%e);
-        anyhow::anyhow!("fail to connect to the host({url}): {e}")
+        anyhow::anyhow!("failed to connect to the host({safe_url}): {e}")
     })?;
 
     Ok(WebApi::start(stream))
@@ -34,4 +62,85 @@ pub(super) async fn execute_command(
 ) -> anyhow::Result<()> {
     api_client.send(request).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn base_config_with_node_url(node_url: Option<String>) -> BaseConfig {
+        BaseConfig {
+            paths: Default::default(),
+            mode: OperationMode::Local,
+            port: 7509,
+            address: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            node_url,
+        }
+    }
+
+    #[test]
+    fn test_resolve_ws_url_with_node_url() {
+        let url = "ws://remote:7520/secret/v1/contract/command?encodingProtocol=native";
+        let cfg = base_config_with_node_url(Some(url.to_string()));
+        assert_eq!(resolve_ws_url(&cfg).unwrap(), url);
+    }
+
+    #[test]
+    fn test_resolve_ws_url_without_node_url() {
+        let cfg = base_config_with_node_url(None);
+        assert_eq!(
+            resolve_ws_url(&cfg).unwrap(),
+            "ws://127.0.0.1:7509/v1/contract/command?encodingProtocol=native"
+        );
+    }
+
+    #[test]
+    fn test_resolve_ws_url_rejects_non_ws_scheme() {
+        let cfg = base_config_with_node_url(Some("http://example.com".to_string()));
+        let err = resolve_ws_url(&cfg).unwrap_err();
+        assert!(err.to_string().contains("must start with ws://"));
+    }
+
+    #[test]
+    fn test_resolve_ws_url_local_mode_rejects_non_loopback() {
+        let mut cfg = base_config_with_node_url(None);
+        cfg.address = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let err = resolve_ws_url(&cfg).unwrap_err();
+        assert!(err.to_string().contains("loopback"));
+    }
+
+    #[test]
+    fn test_resolve_ws_url_network_mode() {
+        let mut cfg = base_config_with_node_url(None);
+        cfg.mode = OperationMode::Network;
+        cfg.address = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        cfg.port = 8080;
+        assert_eq!(
+            resolve_ws_url(&cfg).unwrap(),
+            "ws://10.0.0.1:8080/v1/contract/command?encodingProtocol=native"
+        );
+    }
+
+    #[test]
+    fn test_resolve_ws_url_accepts_wss() {
+        let url = "wss://secure.example.com/v1/contract/command?encodingProtocol=native";
+        let cfg = base_config_with_node_url(Some(url.to_string()));
+        assert_eq!(resolve_ws_url(&cfg).unwrap(), url);
+    }
+
+    #[test]
+    fn test_sanitize_url_hides_secret_path() {
+        let url = "ws://host:7520/my-secret/v1/contract/command?encodingProtocol=native";
+        assert_eq!(
+            sanitize_url_for_log(url),
+            "ws://host:7520/***/v1/contract/command?encodingProtocol=native"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_url_no_secret() {
+        let url = "ws://127.0.0.1:7509/v1/contract/command?encodingProtocol=native";
+        assert_eq!(sanitize_url_for_log(url), url);
+    }
 }

--- a/crates/fdev/src/commands/v1.rs
+++ b/crates/fdev/src/commands/v1.rs
@@ -49,8 +49,11 @@ pub(super) async fn start_api_client(cfg: BaseConfig) -> anyhow::Result<WebApi> 
 
     let (stream, _) = tokio_tungstenite::connect_async(&url).await.map_err(|e| {
         let safe_url = sanitize_url_for_log(&url);
-        tracing::error!(err=%e);
-        anyhow::anyhow!("failed to connect to the host({safe_url}): {e}")
+        // Log only the sanitized URL and error kind -- the raw tungstenite error
+        // may contain the full URL (including auth secrets) in its Display output.
+        let err_msg = sanitize_url_for_log(&e.to_string());
+        tracing::error!(url=%safe_url, err=%err_msg);
+        anyhow::anyhow!("failed to connect to the host({safe_url}): {err_msg}")
     })?;
 
     Ok(WebApi::start(stream))
@@ -142,5 +145,76 @@ mod tests {
     fn test_sanitize_url_no_secret() {
         let url = "ws://127.0.0.1:7509/v1/contract/command?encodingProtocol=native";
         assert_eq!(sanitize_url_for_log(url), url);
+    }
+
+    #[test]
+    fn test_sanitize_url_hides_multi_segment_secret() {
+        let url = "ws://host:7520/token/extra/nested/v1/contract/command";
+        assert_eq!(
+            sanitize_url_for_log(url),
+            "ws://host:7520/***/v1/contract/command"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_url_in_error_message() {
+        // Secrets embedded in error messages (e.g. from tungstenite) are also sanitized
+        let err = "Connection failed: ws://host:7520/my-secret/v1/contract/command";
+        assert_eq!(
+            sanitize_url_for_log(err),
+            "Connection failed: ws://host:7520/***/v1/contract/command"
+        );
+    }
+
+    #[test]
+    fn test_clap_node_url_with_defaults() {
+        use crate::config::Config;
+        use clap::Parser;
+        // --node-url alone should work; defaulted --address/--port don't trigger conflicts
+        assert!(
+            Config::try_parse_from([
+                "fdev",
+                "--node-url",
+                "ws://host/v1/contract/command?encodingProtocol=native",
+                "query",
+            ])
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_clap_node_url_conflicts_with_explicit_port() {
+        use crate::config::Config;
+        use clap::Parser;
+        // --node-url + explicit --port should fail
+        assert!(
+            Config::try_parse_from([
+                "fdev",
+                "--node-url",
+                "ws://host/v1/contract/command?encodingProtocol=native",
+                "--port",
+                "8080",
+                "query",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_clap_node_url_conflicts_with_explicit_address() {
+        use crate::config::Config;
+        use clap::Parser;
+        // --node-url + explicit --address should fail
+        assert!(
+            Config::try_parse_from([
+                "fdev",
+                "--node-url",
+                "ws://host/v1/contract/command?encodingProtocol=native",
+                "--address",
+                "10.0.0.1",
+                "query",
+            ])
+            .is_err()
+        );
     }
 }

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -34,6 +34,10 @@ pub struct BaseConfig {
     /// The default value is `127.0.0.1`.
     #[arg(short, long, default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub(crate) address: IpAddr,
+    /// Full WebSocket URL to connect to (e.g. ws://host:port/secret/v1/contract/command?encodingProtocol=native).
+    /// When provided, --address, --port, and --mode are ignored.
+    #[arg(long, env = "FREENET_NODE_URL")]
+    pub(crate) node_url: Option<String>,
 }
 
 #[derive(clap::Subcommand, Clone)]

--- a/crates/fdev/src/config.rs
+++ b/crates/fdev/src/config.rs
@@ -35,8 +35,8 @@ pub struct BaseConfig {
     #[arg(short, long, default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
     pub(crate) address: IpAddr,
     /// Full WebSocket URL to connect to (e.g. ws://host:port/secret/v1/contract/command?encodingProtocol=native).
-    /// When provided, --address, --port, and --mode are ignored.
-    #[arg(long, env = "FREENET_NODE_URL")]
+    /// When provided, --address and --port must not be specified.
+    #[arg(long, env = "FREENET_NODE_URL", conflicts_with_all = ["address", "port"])]
     pub(crate) node_url: Option<String>,
 }
 


### PR DESCRIPTION
## Problem

`fdev` constructs its WebSocket URL from `--address` and `--port` flags, which doesn't work with the gateway proxy (`freenet-gateway-proxy`) that requires an auth secret in the URL path. This makes it impossible to use `fdev` commands from CI/CD pipelines that publish through a remote gateway via the proxy.

## Solution

Add a `--node-url` flag (matching `riverctl`'s interface) that accepts a full WebSocket URL, bypassing the address/port construction. Also available via `FREENET_NODE_URL` environment variable. The URL is validated to require `ws://` or `wss://` prefix, and secrets in the URL path are sanitized from error/log output.

```bash
fdev --node-url "ws://nova.locut.us:7520/SECRET/v1/contract/command?encodingProtocol=native" \
    website publish ./public/ --key my-site
```

Key design decisions:
- `conflicts_with` on `--address`/`--port` so clap rejects conflicting flags
- URL scheme validation (`ws://`/`wss://` required) for clear error messages
- URL sanitization in error/log messages to avoid leaking auth secrets
- Extracted `resolve_ws_url()` as a pure testable function

## Testing

- 8 unit tests covering all code paths:
  - `node_url` provided vs constructed from address/port
  - `ws://` and `wss://` schemes accepted
  - Non-WebSocket schemes rejected with clear error
  - Local mode loopback validation preserved
  - Network mode with custom address/port
  - URL sanitization hides secret path segments
  - URL sanitization preserves URLs without secrets
- `cargo clippy -p fdev --all-targets -- -D warnings` clean
- `cargo fmt` clean

## Fixes

Closes #3831

[AI-assisted - Claude]