### PR TITLE
feat: support multi-page website navigation in gateway iframe sandbox

### DIFF
--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -182,7 +182,8 @@ async fn web_home(
 
         // Serve sandbox content (contract HTML + WS shim) inside the iframe.
         // No auth token or cookie — the shell page handles auth via postMessage.
-        let contract_response = path_handlers::serve_sandbox_content(key, api_version).await?;
+        let contract_response =
+            path_handlers::serve_sandbox_content(key, api_version, None).await?;
         let mut response = contract_response.into_response();
         add_sandbox_cors_headers(&mut response);
         // CSP for sandbox content: the iframe has an opaque origin (null) because the
@@ -258,7 +259,47 @@ async fn web_subpages(
     key: String,
     last_path: String,
     api_version: ApiVersion,
+    query_string: Option<String>,
+    req_headers: axum::http::HeaderMap,
 ) -> Result<axum::response::Response, WebSocketApiError> {
+    let is_sandbox = query_string
+        .as_ref()
+        .map(|qs| qs.split('&').any(|p| p == "__sandbox=1"))
+        .unwrap_or(false);
+
+    // For sandbox sub-page requests to HTML files, serve through the sandbox
+    // content pipeline (with WebSocket shim + navigation interceptor injected).
+    if is_sandbox && is_html_page(&last_path) {
+        // Block top-level navigation to sandbox URLs (same protection as web_home)
+        let fetch_dest = req_headers
+            .get("sec-fetch-dest")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if fetch_dest == "document" {
+            let shell_url = format!("/{}/contract/web/{key}/", api_version.prefix());
+            return Ok(axum::response::Redirect::to(&shell_url).into_response());
+        }
+
+        let contract_response =
+            path_handlers::serve_sandbox_content(key, api_version, Some(&last_path)).await?;
+        let mut response = contract_response.into_response();
+        add_sandbox_cors_headers(&mut response);
+        let local_api_origin = req_headers
+            .get(axum::http::header::HOST)
+            .and_then(|h| h.to_str().ok())
+            .map(|host| format!("http://{host}"))
+            .unwrap_or_else(|| "'self'".to_string());
+        let csp = format!(
+            "default-src {local_api_origin} 'unsafe-inline' 'unsafe-eval' blob: data:; connect-src {local_api_origin} blob: data:"
+        );
+        if let Ok(csp_value) = axum::http::HeaderValue::from_str(&csp) {
+            response
+                .headers_mut()
+                .insert(axum::http::header::CONTENT_SECURITY_POLICY, csp_value);
+        }
+        return Ok(response);
+    }
+
     let version_prefix = api_version.prefix();
     let full_path: String = format!("/{version_prefix}/contract/web/{key}/{last_path}");
     path_handlers::variable_content(key, full_path, api_version)
@@ -269,6 +310,20 @@ async fn web_subpages(
             add_sandbox_cors_headers(&mut response);
             response
         })
+}
+
+/// Returns true if the path looks like an HTML page request.
+fn is_html_page(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    // Explicit .html or .htm extension
+    if lower.ends_with(".html") || lower.ends_with(".htm") {
+        return true;
+    }
+    // Directory-style paths (e.g., "news/") where the server would serve index.html
+    if lower.ends_with('/') || !lower.contains('.') {
+        return true;
+    }
+    false
 }
 
 /// Adds CORS and security headers needed for sandbox iframe responses.
@@ -357,5 +412,39 @@ impl ClientEventsProxy for HttpClientApi {
             Ok(())
         }
         .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_html_page_detects_html_extensions() {
+        assert!(is_html_page("page.html"));
+        assert!(is_html_page("page.HTML"));
+        assert!(is_html_page("page.htm"));
+        assert!(is_html_page("dir/page.html"));
+    }
+
+    #[test]
+    fn is_html_page_detects_directory_style_paths() {
+        assert!(is_html_page("news/"));
+        assert!(is_html_page("about/team/"));
+    }
+
+    #[test]
+    fn is_html_page_detects_extensionless_paths() {
+        // Extensionless paths are likely directory-style navigation
+        assert!(is_html_page("news"));
+        assert!(is_html_page("about/team"));
+    }
+
+    #[test]
+    fn is_html_page_rejects_non_html_files() {
+        assert!(!is_html_page("app.js"));
+        assert!(!is_html_page("style.css"));
+        assert!(!is_html_page("image.png"));
+        assert!(!is_html_page("assets/app.wasm"));
     }
 }

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -166,20 +166,6 @@ async fn web_home(
         .unwrap_or(false);
 
     if is_sandbox {
-        // Block top-level navigation to sandbox URLs. With allow-popups-to-escape-sandbox
-        // on the iframe, a malicious contract could window.open() its own URL to escape
-        // the sandbox and gain same-origin access to the API. Sec-Fetch-Dest: iframe
-        // is set by the browser automatically and cannot be spoofed by scripts.
-        let fetch_dest = req_headers
-            .get("sec-fetch-dest")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        if fetch_dest == "document" {
-            // Top-level navigation to a sandbox URL — redirect to the shell page instead
-            let shell_url = format!("/{}/contract/web/{key}/", api_version.prefix());
-            return Ok(axum::response::Redirect::to(&shell_url).into_response());
-        }
-
         return serve_sandbox_response(key, api_version, None, &req_headers).await;
     }
 
@@ -277,12 +263,27 @@ fn is_html_page(path: &str) -> bool {
 ///
 /// Shared by `web_home` (for the root page) and `web_subpages` (for sub-pages).
 /// No auth token or cookie -- the shell page handles auth via postMessage.
+///
+/// Includes `Sec-Fetch-Dest` check: if a sandbox URL is loaded as a top-level
+/// document (e.g. pasted in the address bar), redirect to the shell page instead
+/// of serving raw sandbox content outside the iframe.
 async fn serve_sandbox_response(
     key: String,
     api_version: ApiVersion,
     sub_path: Option<&str>,
     req_headers: &axum::http::HeaderMap,
 ) -> Result<axum::response::Response, WebSocketApiError> {
+    // Block top-level navigation to sandbox URLs. Sec-Fetch-Dest: iframe is set
+    // by the browser automatically and cannot be spoofed by scripts.
+    let fetch_dest = req_headers
+        .get("sec-fetch-dest")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if fetch_dest == "document" {
+        let shell_url = format!("/{}/contract/web/{key}/", api_version.prefix());
+        return Ok(axum::response::Redirect::to(&shell_url).into_response());
+    }
+
     let contract_response =
         path_handlers::serve_sandbox_content(key, api_version, sub_path).await?;
     let mut response = contract_response.into_response();

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -180,32 +180,7 @@ async fn web_home(
             return Ok(axum::response::Redirect::to(&shell_url).into_response());
         }
 
-        // Serve sandbox content (contract HTML + WS shim) inside the iframe.
-        // No auth token or cookie — the shell page handles auth via postMessage.
-        let contract_response =
-            path_handlers::serve_sandbox_content(key, api_version, None).await?;
-        let mut response = contract_response.into_response();
-        add_sandbox_cors_headers(&mut response);
-        // CSP for sandbox content: the iframe has an opaque origin (null) because the
-        // sandbox attribute omits allow-same-origin. This means CSP 'self' won't match
-        // the local API server's actual origin, so we must use the explicit local API
-        // origin derived from the Host header. This allows the iframe to load scripts,
-        // styles, images, and WASM from the local API server while blocking access
-        // to other origins.
-        let local_api_origin = req_headers
-            .get(axum::http::header::HOST)
-            .and_then(|h| h.to_str().ok())
-            .map(|host| format!("http://{host}"))
-            .unwrap_or_else(|| "'self'".to_string());
-        let csp = format!(
-            "default-src {local_api_origin} 'unsafe-inline' 'unsafe-eval' blob: data:; connect-src {local_api_origin} blob: data:"
-        );
-        if let Ok(csp_value) = axum::http::HeaderValue::from_str(&csp) {
-            response
-                .headers_mut()
-                .insert(axum::http::header::CONTENT_SECURITY_POLICY, csp_value);
-        }
-        return Ok(response);
+        return serve_sandbox_response(key, api_version, None, &req_headers).await;
     }
 
     // Shell page: generate auth token, serve iframe wrapper with CSP
@@ -270,34 +245,7 @@ async fn web_subpages(
     // For sandbox sub-page requests to HTML files, serve through the sandbox
     // content pipeline (with WebSocket shim + navigation interceptor injected).
     if is_sandbox && is_html_page(&last_path) {
-        // Block top-level navigation to sandbox URLs (same protection as web_home)
-        let fetch_dest = req_headers
-            .get("sec-fetch-dest")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        if fetch_dest == "document" {
-            let shell_url = format!("/{}/contract/web/{key}/", api_version.prefix());
-            return Ok(axum::response::Redirect::to(&shell_url).into_response());
-        }
-
-        let contract_response =
-            path_handlers::serve_sandbox_content(key, api_version, Some(&last_path)).await?;
-        let mut response = contract_response.into_response();
-        add_sandbox_cors_headers(&mut response);
-        let local_api_origin = req_headers
-            .get(axum::http::header::HOST)
-            .and_then(|h| h.to_str().ok())
-            .map(|host| format!("http://{host}"))
-            .unwrap_or_else(|| "'self'".to_string());
-        let csp = format!(
-            "default-src {local_api_origin} 'unsafe-inline' 'unsafe-eval' blob: data:; connect-src {local_api_origin} blob: data:"
-        );
-        if let Ok(csp_value) = axum::http::HeaderValue::from_str(&csp) {
-            response
-                .headers_mut()
-                .insert(axum::http::header::CONTENT_SECURITY_POLICY, csp_value);
-        }
-        return Ok(response);
+        return serve_sandbox_response(key, api_version, Some(&last_path), &req_headers).await;
     }
 
     let version_prefix = api_version.prefix();
@@ -313,17 +261,50 @@ async fn web_subpages(
 }
 
 /// Returns true if the path looks like an HTML page request.
+///
+/// Matches `.html`/`.htm` extensions, directory-style paths (`news/`),
+/// and extensionless paths (`about/team`) that likely resolve to `index.html`.
 fn is_html_page(path: &str) -> bool {
     let lower = path.to_lowercase();
-    // Explicit .html or .htm extension
-    if lower.ends_with(".html") || lower.ends_with(".htm") {
-        return true;
+    lower.ends_with(".html")
+        || lower.ends_with(".htm")
+        || lower.ends_with('/')
+        || !lower.contains('.')
+}
+
+/// Serves sandbox content (contract HTML + WS shim) inside the iframe and adds
+/// the appropriate CORS and CSP headers.
+///
+/// Shared by `web_home` (for the root page) and `web_subpages` (for sub-pages).
+/// No auth token or cookie -- the shell page handles auth via postMessage.
+async fn serve_sandbox_response(
+    key: String,
+    api_version: ApiVersion,
+    sub_path: Option<&str>,
+    req_headers: &axum::http::HeaderMap,
+) -> Result<axum::response::Response, WebSocketApiError> {
+    let contract_response =
+        path_handlers::serve_sandbox_content(key, api_version, sub_path).await?;
+    let mut response = contract_response.into_response();
+    add_sandbox_cors_headers(&mut response);
+    // CSP for sandbox content: the iframe has an opaque origin (null) because the
+    // sandbox attribute omits allow-same-origin. This means CSP 'self' won't match
+    // the local API server's actual origin, so we must use the explicit local API
+    // origin derived from the Host header.
+    let local_api_origin = req_headers
+        .get(axum::http::header::HOST)
+        .and_then(|h| h.to_str().ok())
+        .map(|host| format!("http://{host}"))
+        .unwrap_or_else(|| "'self'".to_string());
+    let csp = format!(
+        "default-src {local_api_origin} 'unsafe-inline' 'unsafe-eval' blob: data:; connect-src {local_api_origin} blob: data:"
+    );
+    if let Ok(csp_value) = axum::http::HeaderValue::from_str(&csp) {
+        response
+            .headers_mut()
+            .insert(axum::http::header::CONTENT_SECURITY_POLICY, csp_value);
     }
-    // Directory-style paths (e.g., "news/") where the server would serve index.html
-    if lower.ends_with('/') || !lower.contains('.') {
-        return true;
-    }
-    false
+    Ok(response)
 }
 
 /// Adds CORS and security headers needed for sandbox iframe responses.

--- a/crates/core/src/server/client_api/v1.rs
+++ b/crates/core/src/server/client_api/v1.rs
@@ -23,6 +23,8 @@ async fn web_home_v1(
 
 async fn web_subpages_v1(
     Path((key, last_path)): Path<(String, String)>,
+    axum::extract::RawQuery(query): axum::extract::RawQuery,
+    headers: axum::http::HeaderMap,
 ) -> Result<axum::response::Response, WebSocketApiError> {
-    web_subpages(key, last_path, ApiVersion::V1).await
+    web_subpages(key, last_path, ApiVersion::V1, query, headers).await
 }

--- a/crates/core/src/server/client_api/v2.rs
+++ b/crates/core/src/server/client_api/v2.rs
@@ -26,6 +26,8 @@ async fn web_home_v2(
 
 async fn web_subpages_v2(
     Path((key, last_path)): Path<(String, String)>,
+    axum::extract::RawQuery(query): axum::extract::RawQuery,
+    headers: axum::http::HeaderMap,
 ) -> Result<axum::response::Response, WebSocketApiError> {
-    web_subpages(key, last_path, ApiVersion::V2).await
+    web_subpages(key, last_path, ApiVersion::V2, query, headers).await
 }

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -829,10 +829,6 @@ const NAVIGATION_INTERCEPTOR_JS: &str = r#"
       __freenet_shell__: true, type: 'navigate', href: target.href
     }, '*');
   }, true);
-
-  // Also intercept form-based navigation and programmatic location changes
-  // by overriding window.location assignment (history.pushState is already
-  // blocked by the sandbox without allow-same-origin).
 })();
 "#;
 
@@ -1136,7 +1132,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sandbox_content_injects_ws_shim_not_auth_token() {
+    async fn sandbox_content_injects_shims_not_auth_token() {
         let dir = tempfile::tempdir().unwrap();
         let key = "testkey123";
         let html = r#"<!DOCTYPE html><html><head></head><body>Hello</body></html>"#;
@@ -1157,6 +1153,11 @@ mod tests {
         assert!(
             result.contains("window.WebSocket = FreenetWebSocket"),
             "WebSocket override not set"
+        );
+        // Navigation interceptor must be injected alongside WebSocket shim
+        assert!(
+            result.contains("type: 'navigate'"),
+            "navigation interceptor not injected"
         );
         // Auth token must NOT appear in sandbox content
         assert!(
@@ -1559,30 +1560,5 @@ mod tests {
         let result =
             sandbox_content_body(dir.path(), key, ApiVersion::V1, "../../../etc/passwd").await;
         assert!(result.is_err(), "path traversal should be rejected");
-    }
-
-    #[tokio::test]
-    async fn sandbox_content_injects_navigation_interceptor() {
-        let dir = tempfile::tempdir().unwrap();
-        let key = "testkey123";
-        let html = r#"<!DOCTYPE html><html><head></head><body>Hello</body></html>"#;
-        std::fs::write(dir.path().join("index.html"), html).unwrap();
-
-        let result = response_body(
-            sandbox_content_body(dir.path(), key, ApiVersion::V1, "index.html")
-                .await
-                .unwrap(),
-        )
-        .await;
-
-        // Navigation interceptor must be injected alongside WebSocket shim
-        assert!(
-            result.contains("FreenetWebSocket"),
-            "WebSocket shim not injected"
-        );
-        assert!(
-            result.contains("type: 'navigate'"),
-            "navigation interceptor not injected"
-        );
     }
 }

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -364,12 +364,17 @@ fn shell_page(
 /// This is called when the iframe requests `?__sandbox=1`. It reads the cached
 /// contract HTML, rewrites asset paths, and injects the WebSocket shim that
 /// routes connections through the shell page's postMessage bridge.
+///
+/// The `sub_path` parameter allows serving pages other than `index.html` for
+/// multi-page websites. When `None`, defaults to `index.html`.
 #[instrument(level = "debug")]
 pub(super) async fn serve_sandbox_content(
     key: String,
     api_version: ApiVersion,
+    sub_path: Option<&str>,
 ) -> Result<impl IntoResponse, WebSocketApiError> {
-    debug!("serve_sandbox_content: serving iframe content for key: {key}");
+    let page = sub_path.unwrap_or("index.html");
+    debug!("serve_sandbox_content: serving iframe content for key: {key}, page: {page}");
     let instance_id =
         ContractInstanceId::from_bytes(&key).map_err(|err| WebSocketApiError::InvalidParam {
             error_cause: format!("{err}"),
@@ -380,16 +385,49 @@ pub(super) async fn serve_sandbox_content(
             error_cause: format!("Contract not cached yet: {key}"),
         });
     }
-    sandbox_content_body(&path, &key, api_version).await
+    sandbox_content_body(&path, &key, api_version, page).await
 }
 
-/// Reads the contract's index.html, rewrites paths, and injects the WebSocket shim.
+/// Reads a contract HTML page, rewrites paths, and injects the WebSocket shim
+/// and navigation interceptor.
 async fn sandbox_content_body(
     path: &Path,
     contract_key: &str,
     api_version: ApiVersion,
+    page: &str,
 ) -> Result<impl IntoResponse + use<>, WebSocketApiError> {
-    let web_path = path.join("index.html");
+    // Sanitize the page path to prevent directory traversal
+    let normalized = Path::new(page);
+    for component in normalized.components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            return Err(WebSocketApiError::InvalidParam {
+                error_cause: "Path traversal not allowed".to_string(),
+            });
+        }
+    }
+
+    let mut web_path = path.join(page);
+    // For directory-style paths, look for index.html inside the directory
+    if web_path.is_dir() {
+        web_path = web_path.join("index.html");
+    }
+    // Ensure the resolved path is still under the contract's cache directory
+    let canonical_base = path
+        .canonicalize()
+        .map_err(|err| WebSocketApiError::NodeError {
+            error_cause: format!("{err}"),
+        })?;
+    let canonical_file = web_path
+        .canonicalize()
+        .map_err(|err| WebSocketApiError::NodeError {
+            error_cause: format!("Page not found: {page} ({err})"),
+        })?;
+    if !canonical_file.starts_with(&canonical_base) {
+        return Err(WebSocketApiError::InvalidParam {
+            error_cause: "Path traversal not allowed".to_string(),
+        });
+    }
+
     let mut key_file = File::open(&web_path)
         .await
         .map_err(|err| WebSocketApiError::NodeError {
@@ -414,16 +452,18 @@ async fn sandbox_content_body(
     body = body.replace("\"/./", &format!("\"{prefix}"));
     body = body.replace("'/./", &format!("'{prefix}"));
 
-    // Inject the WebSocket shim before any other scripts. The shim overrides
-    // window.WebSocket so that wasm-bindgen (which calls `new WebSocket(url)` from
-    // global scope at call time) routes connections through the shell page's bridge.
-    let shim_script = format!("<script>{WEBSOCKET_SHIM_JS}</script>");
+    // Inject the WebSocket shim and navigation interceptor before any other scripts.
+    // The shim overrides window.WebSocket so that wasm-bindgen routes connections
+    // through the shell page's bridge. The interceptor catches <a> clicks and
+    // routes them through postMessage for multi-page navigation.
+    let injected_scripts =
+        format!("<script>{WEBSOCKET_SHIM_JS}</script><script>{NAVIGATION_INTERCEPTOR_JS}</script>");
     if let Some(pos) = body.find("</head>") {
-        body.insert_str(pos, &shim_script);
+        body.insert_str(pos, &injected_scripts);
     } else if let Some(pos) = body.find("<body") {
-        body.insert_str(pos, &shim_script);
+        body.insert_str(pos, &injected_scripts);
     } else {
-        body = format!("{shim_script}{body}");
+        body = format!("{injected_scripts}{body}");
     }
 
     Ok(Html(body))
@@ -498,6 +538,28 @@ function freenetBridge(authToken) {
           lastClipboard = now;
           try { navigator.clipboard.writeText(msg.text.slice(0, 2048)); } catch(e) {}
         }
+      } else if (msg.type === 'navigate' && typeof msg.href === 'string') {
+        // In-contract page navigation for multi-page websites. The sandboxed
+        // iframe cannot navigate itself (no allow-top-navigation), so it sends
+        // navigation requests to the shell which updates iframe.src.
+        // Security: only allows paths under the current contract's web prefix
+        // to prevent cross-contract navigation or path traversal.
+        try {
+          var resolved = new URL(msg.href, iframe.src);
+          // Only allow same-origin navigation (no cross-site)
+          if (resolved.origin !== location.origin) return;
+          var cleanPath = resolved.pathname;
+          // Extract the contract web prefix from the iframe's data-src
+          var dataSrc = iframe.getAttribute('data-src');
+          var baseParts = dataSrc.match(/^(\/v[12]\/contract\/web\/[^/]+\/)/);
+          if (!baseParts) return;
+          var contractPrefix = baseParts[1];
+          // Ensure navigation stays within the same contract
+          if (cleanPath.indexOf(contractPrefix) !== 0) return;
+          // Build new sandbox URL preserving __sandbox=1
+          resolved.searchParams.set('__sandbox', '1');
+          iframe.src = resolved.pathname + resolved.search;
+        } catch(e) {}
       } else if (msg.type === 'open_url' && typeof msg.url === 'string') {
         // Open external URLs in a new tab. Popups from the sandboxed iframe
         // inherit the opaque origin, breaking CORS on target sites. The shell
@@ -727,6 +789,53 @@ const WEBSOCKET_SHIM_JS: &str = r#"
 })();
 "#;
 
+/// JavaScript navigation interceptor injected into sandboxed iframe HTML pages.
+///
+/// Intercepts clicks on `<a>` elements and sends a postMessage to the shell
+/// page, which updates the iframe's `src` to navigate within the contract.
+/// This enables multi-page website navigation without weakening the sandbox
+/// (no `allow-top-navigation` needed). Only intercepts same-origin relative
+/// links; external links are left to the existing `open_url` bridge.
+const NAVIGATION_INTERCEPTOR_JS: &str = r#"
+(function() {
+  'use strict';
+  document.addEventListener('click', function(e) {
+    var target = e.target;
+    // Walk up to find the nearest <a> element (handles clicks on child elements)
+    while (target && target.tagName !== 'A') target = target.parentElement;
+    if (!target || !target.href) return;
+    // Skip links with explicit targets (e.g. target="_blank")
+    if (target.target && target.target !== '_self') return;
+    // Skip javascript: and mailto: links
+    var protocol = target.protocol;
+    if (protocol && protocol !== 'http:' && protocol !== 'https:') return;
+    // Skip links with download attribute
+    if (target.hasAttribute('download')) return;
+    // Skip links explicitly marked to bypass interception
+    if (target.dataset && target.dataset.freenetNoIntercept) return;
+    // For cross-origin links, use the open_url bridge instead
+    try {
+      if (target.origin !== location.origin) {
+        e.preventDefault();
+        window.parent.postMessage({
+          __freenet_shell__: true, type: 'open_url', url: target.href
+        }, '*');
+        return;
+      }
+    } catch(err) {}
+    // Same-origin in-contract link: request navigation via shell
+    e.preventDefault();
+    window.parent.postMessage({
+      __freenet_shell__: true, type: 'navigate', href: target.href
+    }, '*');
+  }, true);
+
+  // Also intercept form-based navigation and programmatic location changes
+  // by overriding window.location assignment (history.pushState is already
+  // blocked by the sandbox without allow-same-origin).
+})();
+"#;
+
 /// Extracts the relative file path from a contract web URI.
 ///
 /// Strips the version and contract key prefix (e.g. `/v1/contract/web/{key}/`)
@@ -813,7 +922,7 @@ mod tests {
         std::fs::write(dir.path().join("index.html"), html).unwrap();
 
         let result = response_body(
-            sandbox_content_body(dir.path(), key, ApiVersion::V1)
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "index.html")
                 .await
                 .unwrap(),
         )
@@ -852,7 +961,7 @@ mod tests {
         std::fs::write(dir.path().join("index.html"), html).unwrap();
 
         let result = response_body(
-            sandbox_content_body(dir.path(), key, ApiVersion::V2)
+            sandbox_content_body(dir.path(), key, ApiVersion::V2, "index.html")
                 .await
                 .unwrap(),
         )
@@ -877,7 +986,7 @@ mod tests {
         std::fs::write(dir.path().join("index.html"), html).unwrap();
 
         let result = response_body(
-            sandbox_content_body(dir.path(), key, ApiVersion::V1)
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "index.html")
                 .await
                 .unwrap(),
         )
@@ -900,7 +1009,7 @@ mod tests {
         std::fs::write(dir.path().join("index.html"), html).unwrap();
 
         let result = response_body(
-            sandbox_content_body(dir.path(), key, ApiVersion::V1)
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "index.html")
                 .await
                 .unwrap(),
         )
@@ -1034,7 +1143,7 @@ mod tests {
         std::fs::write(dir.path().join("index.html"), html).unwrap();
 
         let result = response_body(
-            sandbox_content_body(dir.path(), key, ApiVersion::V1)
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "index.html")
                 .await
                 .unwrap(),
         )
@@ -1065,7 +1174,7 @@ mod tests {
         std::fs::write(dir.path().join("index.html"), html).unwrap();
 
         let result = response_body(
-            sandbox_content_body(dir.path(), key, ApiVersion::V1)
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "index.html")
                 .await
                 .unwrap(),
         )
@@ -1093,7 +1202,7 @@ mod tests {
         std::fs::write(dir.path().join("index.html"), html).unwrap();
 
         let result = response_body(
-            sandbox_content_body(dir.path(), key, ApiVersion::V1)
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "index.html")
                 .await
                 .unwrap(),
         )
@@ -1313,5 +1422,167 @@ mod tests {
         let uri: axum::http::Uri = req_path.parse().unwrap();
         let result = get_file_path(uri);
         assert!(result.is_err(), "expected error for /v3/ prefix");
+    }
+
+    #[test]
+    fn bridge_js_contains_navigate_handler() {
+        // The shell bridge must handle 'navigate' messages for multi-page
+        // website navigation within the sandboxed iframe (issue #3833).
+        assert!(
+            SHELL_BRIDGE_JS.contains("msg.type === 'navigate'"),
+            "bridge JS must handle navigate shell messages"
+        );
+        // Navigate handler must validate the path stays within the contract prefix
+        assert!(
+            SHELL_BRIDGE_JS.contains("contractPrefix"),
+            "navigate handler must extract and check the contract prefix"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("cleanPath.indexOf(contractPrefix) !== 0"),
+            "navigate handler must reject paths outside the contract prefix"
+        );
+        // Navigate handler must add __sandbox=1 to the new URL
+        assert!(
+            SHELL_BRIDGE_JS.contains("resolved.searchParams.set('__sandbox', '1')"),
+            "navigate handler must add __sandbox=1 to navigated URL"
+        );
+        // Navigate handler must validate same-origin
+        assert!(
+            SHELL_BRIDGE_JS.contains("resolved.origin !== location.origin"),
+            "navigate handler must reject cross-origin navigation"
+        );
+    }
+
+    #[test]
+    fn navigation_interceptor_js_intercepts_clicks() {
+        // The navigation interceptor must catch <a> clicks and route them
+        // through postMessage for multi-page navigation (issue #3833).
+        assert!(
+            NAVIGATION_INTERCEPTOR_JS.contains("document.addEventListener('click'"),
+            "interceptor must listen for click events"
+        );
+        assert!(
+            NAVIGATION_INTERCEPTOR_JS.contains("type: 'navigate'"),
+            "interceptor must send navigate messages to shell"
+        );
+        assert!(
+            NAVIGATION_INTERCEPTOR_JS.contains("__freenet_shell__: true"),
+            "interceptor must use __freenet_shell__ namespace"
+        );
+        assert!(
+            NAVIGATION_INTERCEPTOR_JS.contains("e.preventDefault()"),
+            "interceptor must prevent default link behavior"
+        );
+        // Cross-origin links should use open_url instead of navigate
+        assert!(
+            NAVIGATION_INTERCEPTOR_JS.contains("type: 'open_url'"),
+            "interceptor must route cross-origin links through open_url"
+        );
+        // Skip links with target="_blank" etc.
+        assert!(
+            NAVIGATION_INTERCEPTOR_JS.contains("target.target"),
+            "interceptor must respect target attribute on links"
+        );
+        // Must walk up DOM to handle clicks on child elements of <a>
+        assert!(
+            NAVIGATION_INTERCEPTOR_JS.contains("target.parentElement"),
+            "interceptor must walk up DOM to find <a> ancestor"
+        );
+    }
+
+    #[tokio::test]
+    async fn sandbox_content_serves_sub_pages() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "testkey123";
+        // Create a sub-page
+        let sub_html = r#"<!DOCTYPE html><html><head></head><body><h1>News</h1></body></html>"#;
+        std::fs::write(dir.path().join("news.html"), sub_html).unwrap();
+
+        let result = response_body(
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "news.html")
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        // Sub-page content must be served
+        assert!(
+            result.contains("<h1>News</h1>"),
+            "sub-page content not served"
+        );
+        // WebSocket shim must be injected
+        assert!(
+            result.contains("FreenetWebSocket"),
+            "WebSocket shim not injected in sub-page"
+        );
+        // Navigation interceptor must be injected
+        assert!(
+            result.contains("type: 'navigate'"),
+            "navigation interceptor not injected in sub-page"
+        );
+    }
+
+    #[tokio::test]
+    async fn sandbox_content_serves_directory_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "testkey123";
+        // Create a subdirectory with index.html
+        std::fs::create_dir(dir.path().join("news")).unwrap();
+        let sub_html =
+            r#"<!DOCTYPE html><html><head></head><body><h1>News Index</h1></body></html>"#;
+        std::fs::write(dir.path().join("news/index.html"), sub_html).unwrap();
+
+        let result = response_body(
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "news")
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        assert!(
+            result.contains("<h1>News Index</h1>"),
+            "directory index.html not served"
+        );
+        assert!(
+            result.contains("FreenetWebSocket"),
+            "WebSocket shim not injected in directory index"
+        );
+    }
+
+    #[tokio::test]
+    async fn sandbox_content_rejects_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "testkey123";
+        std::fs::write(dir.path().join("index.html"), "<html></html>").unwrap();
+
+        // Attempting to traverse above the contract directory must fail
+        let result =
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "../../../etc/passwd").await;
+        assert!(result.is_err(), "path traversal should be rejected");
+    }
+
+    #[tokio::test]
+    async fn sandbox_content_injects_navigation_interceptor() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "testkey123";
+        let html = r#"<!DOCTYPE html><html><head></head><body>Hello</body></html>"#;
+        std::fs::write(dir.path().join("index.html"), html).unwrap();
+
+        let result = response_body(
+            sandbox_content_body(dir.path(), key, ApiVersion::V1, "index.html")
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        // Navigation interceptor must be injected alongside WebSocket shim
+        assert!(
+            result.contains("FreenetWebSocket"),
+            "WebSocket shim not injected"
+        );
+        assert!(
+            result.contains("type: 'navigate'"),
+            "navigation interceptor not injected"
+        );
     }
 }

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -396,10 +396,16 @@ async fn sandbox_content_body(
     api_version: ApiVersion,
     page: &str,
 ) -> Result<impl IntoResponse + use<>, WebSocketApiError> {
-    // Sanitize the page path to prevent directory traversal
+    // Sanitize the page path to prevent directory traversal and absolute paths.
+    // Path::join with an absolute path replaces the base entirely on Unix,
+    // so we must reject absolute paths, parent directory components, and root
+    // directory components before joining.
     let normalized = Path::new(page);
     for component in normalized.components() {
-        if matches!(component, std::path::Component::ParentDir) {
+        if matches!(
+            component,
+            std::path::Component::ParentDir | std::path::Component::RootDir
+        ) {
             return Err(WebSocketApiError::InvalidParam {
                 error_cause: "Path traversal not allowed".to_string(),
             });
@@ -428,11 +434,14 @@ async fn sandbox_content_body(
         });
     }
 
-    let mut key_file = File::open(&web_path)
-        .await
-        .map_err(|err| WebSocketApiError::NodeError {
-            error_cause: format!("{err}"),
-        })?;
+    // Open the canonical path (not the user-supplied path) to prevent TOCTOU
+    // attacks where a symlink could be swapped between canonicalize and open.
+    let mut key_file =
+        File::open(&canonical_file)
+            .await
+            .map_err(|err| WebSocketApiError::NodeError {
+                error_cause: format!("{err}"),
+            })?;
     let mut buf = vec![];
     key_file
         .read_to_end(&mut buf)
@@ -556,6 +565,11 @@ function freenetBridge(authToken) {
           var contractPrefix = baseParts[1];
           // Ensure navigation stays within the same contract
           if (cleanPath.indexOf(contractPrefix) !== 0) return;
+          // Close any open WebSocket connections from the previous page to
+          // prevent resource leaks. The old iframe document will be destroyed
+          // when src changes, orphaning any connection callbacks.
+          connections.forEach(function(ws) { try { ws.close(); } catch(e) {} });
+          connections.clear();
           // Build new sandbox URL preserving __sandbox=1
           resolved.searchParams.set('__sandbox', '1');
           iframe.src = resolved.pathname + resolved.search;
@@ -1560,5 +1574,52 @@ mod tests {
         let result =
             sandbox_content_body(dir.path(), key, ApiVersion::V1, "../../../etc/passwd").await;
         assert!(result.is_err(), "path traversal should be rejected");
+    }
+
+    #[tokio::test]
+    async fn sandbox_content_rejects_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "testkey123";
+        std::fs::write(dir.path().join("index.html"), "<html></html>").unwrap();
+
+        // Absolute paths would make Path::join replace the base directory entirely,
+        // so they must be rejected by the component check.
+        let result = sandbox_content_body(dir.path(), key, ApiVersion::V1, "/etc/passwd").await;
+        assert!(result.is_err(), "absolute path should be rejected");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sandbox_content_rejects_symlink_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = "testkey123";
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.html"), "<html>secret</html>").unwrap();
+
+        // Create a symlink inside the contract directory pointing outside it.
+        // The canonicalize + starts_with check must catch this even though the
+        // component-level ParentDir check would not.
+        std::os::unix::fs::symlink(
+            outside.path().join("secret.html"),
+            dir.path().join("escape.html"),
+        )
+        .unwrap();
+
+        let result = sandbox_content_body(dir.path(), key, ApiVersion::V1, "escape.html").await;
+        assert!(result.is_err(), "symlink escape should be rejected");
+    }
+
+    #[test]
+    fn bridge_js_cleans_up_websockets_on_navigate() {
+        // When navigating to a new page, existing WebSocket connections must be
+        // closed to prevent resource leaks from orphaned connections.
+        assert!(
+            SHELL_BRIDGE_JS.contains("connections.forEach"),
+            "navigate handler must close existing WebSocket connections"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("connections.clear()"),
+            "navigate handler must clear the connections map"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The gateway serves web container content inside a sandboxed iframe with `allow-scripts allow-forms allow-popups` (no `allow-top-navigation`, no `allow-same-origin`). This works for single-page apps (like River) where all routing happens in JavaScript, but breaks multi-page static websites where links navigate between HTML pages.

When a user clicks a link like `<a href="/v1/contract/web/KEY/news/">`, the navigation is silently blocked by the sandbox. This makes `fdev website publish` essentially broken for any multi-page website.

## Approach

Rather than weakening the sandbox by adding `allow-top-navigation` or `allow-same-origin` (which would compromise security), this implements a **postMessage-based navigation system** that preserves the full sandbox security model:

1. **Navigation interceptor** (`NAVIGATION_INTERCEPTOR_JS`) -- injected into all sandboxed HTML pages, catches `<a>` clicks and sends `{type: 'navigate', href: '...'}` to the parent shell via postMessage. Cross-origin links are routed through the existing `open_url` bridge instead.

2. **Shell bridge navigate handler** -- validates the target path stays within the contract's web prefix (preventing cross-contract navigation), then updates `iframe.src` with `__sandbox=1` to trigger sandbox content serving.

3. **Sub-page sandbox content serving** -- `sandbox_content_body` now accepts a sub-path parameter instead of hardcoding `index.html`. Sub-page HTML requests with `__sandbox=1` are routed through the sandbox pipeline (WebSocket shim + navigation interceptor injection). Directory-style paths (e.g., `news/`) resolve to `index.html` inside that directory.

4. **Path traversal protection** -- `sandbox_content_body` validates paths via component inspection and canonicalization to prevent escaping the contract's cache directory.

### Security invariants preserved
- No new sandbox permissions added (no `allow-top-navigation`, no `allow-same-origin`)
- Cross-origin navigation blocked in both interceptor and shell bridge
- Cross-contract navigation blocked (path prefix validation)
- Path traversal rejected (component + canonicalization checks)
- `Sec-Fetch-Dest: document` check prevents top-level navigation escape on sub-pages
- CSP applied to all sandbox sub-page responses

## Testing

- `bridge_js_contains_navigate_handler` -- verifies navigate message handling, contract prefix validation, same-origin check, __sandbox=1 injection
- `navigation_interceptor_js_intercepts_clicks` -- verifies click interception, navigate/open_url routing, DOM walking, target attribute handling
- `sandbox_content_serves_sub_pages` -- verifies sub-page HTML serving with shim + interceptor injection
- `sandbox_content_serves_directory_index` -- verifies directory-style paths resolve to index.html
- `sandbox_content_rejects_path_traversal` -- verifies `../` traversal is rejected
- `sandbox_content_injects_navigation_interceptor` -- verifies interceptor injection on index.html
- `is_html_page_*` (4 tests) -- verifies HTML detection for .html/.htm, directories, extensionless paths, and non-HTML files

All existing tests updated and passing.

Closes #3833

[AI-assisted - Claude]