### PR TITLE
feat(server): render permission prompts as in-page overlays

### DIFF
--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -1,9 +1,15 @@
 //! HTTP endpoints for delegate permission prompts.
 //!
 //! When a delegate emits `RequestUserInput`, the `DashboardPrompter` stores the
-//! pending prompt and the gateway shell page's JS detects it via polling. The user
-//! clicks a browser notification to open the permission page, responds, and the
-//! result flows back to the delegate.
+//! pending prompt and the gateway shell page's JS detects it via polling the
+//! `/permission/pending` endpoint. The shell page renders the prompt as an
+//! in-page overlay (see issue #3836) on every open Freenet tab. When the user
+//! clicks a button in any tab the response is POSTed to
+//! `/permission/{nonce}/respond` and the result flows back to the delegate;
+//! other tabs see the nonce disappear on their next poll and hide the overlay.
+//!
+//! The standalone `/permission/{nonce}` HTML page is retained as a fallback
+//! (e.g. if JS is disabled in the shell, or for debugging / manual testing).
 
 use axum::extract::Path;
 use axum::http::HeaderMap;
@@ -22,15 +28,28 @@ pub(super) fn routes() -> Router {
         .route("/permission/{nonce}/respond", post(permission_respond))
 }
 
-/// Return a list of pending prompt nonces (for the shell page to show notifications).
-/// Only returns nonces and message previews, not full prompt data.
+/// Maximum message length returned to the shell-page overlay. Caps the
+/// amount of delegate-controlled text the shell renders per poll so a
+/// malicious delegate cannot balloon the polling response.
+const OVERLAY_MESSAGE_MAX: usize = 2048;
+
+/// Return the list of pending prompts for the shell page to render as
+/// in-page overlays (see issue #3836). Each entry includes the message,
+/// button labels, and delegate/contract context. The shell page is trusted
+/// and same-origin with the gateway, so it renders this data outside the
+/// sandboxed iframe where the contract can't reach it.
 async fn pending_prompts(Extension(pending): Extension<PendingPrompts>) -> impl IntoResponse {
     let prompts: Vec<serde_json::Value> = pending
         .iter()
         .map(|entry| {
+            let prompt = entry.value();
+            let message: String = prompt.message.chars().take(OVERLAY_MESSAGE_MAX).collect();
             serde_json::json!({
                 "nonce": entry.key(),
-                "preview": entry.value().message.chars().take(100).collect::<String>(),
+                "message": message,
+                "labels": prompt.labels,
+                "delegate_key": prompt.delegate_key,
+                "contract_id": prompt.contract_id,
             })
         })
         .collect();
@@ -387,5 +406,84 @@ mod tests {
     #[test]
     fn test_html_escape_ampersand() {
         assert_eq!(html_escape("a & b"), "a &amp; b");
+    }
+
+    // Regression test for issue #3836: the /permission/pending JSON must
+    // carry enough data for the shell-page overlay to render the prompt
+    // (message, labels, delegate key, contract id), not just a preview.
+    // Before the overlay existed the endpoint returned only `{nonce, preview}`
+    // because the shell fired a browser Notification and the user was expected
+    // to navigate to `/permission/{nonce}` for the full page.
+    #[tokio::test]
+    async fn test_pending_prompts_includes_overlay_fields() {
+        use crate::contract::user_input::PendingPrompt;
+        use axum::body::to_bytes;
+        use axum::response::IntoResponse;
+        use dashmap::DashMap;
+        use std::sync::Arc;
+
+        let pending: PendingPrompts = Arc::new(DashMap::new());
+        let (tx, _rx) = tokio::sync::oneshot::channel::<usize>();
+        pending.insert(
+            "nonce123".to_string(),
+            PendingPrompt {
+                message: "Approve this?".to_string(),
+                labels: vec![
+                    "Allow Once".to_string(),
+                    "Always Allow".to_string(),
+                    "Deny".to_string(),
+                ],
+                delegate_key: "dkey".to_string(),
+                contract_id: "cid".to_string(),
+                response_tx: tx,
+            },
+        );
+
+        let resp = pending_prompts(Extension(pending)).await.into_response();
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let arr = value.as_array().expect("array");
+        assert_eq!(arr.len(), 1);
+        let entry = &arr[0];
+        assert_eq!(entry["nonce"], "nonce123");
+        assert_eq!(entry["message"], "Approve this?");
+        assert_eq!(
+            entry["labels"],
+            serde_json::json!(["Allow Once", "Always Allow", "Deny"])
+        );
+        assert_eq!(entry["delegate_key"], "dkey");
+        assert_eq!(entry["contract_id"], "cid");
+    }
+
+    // Oversized delegate messages must be clipped so a malicious delegate
+    // can't balloon the polling response the shell fetches every few seconds.
+    #[tokio::test]
+    async fn test_pending_prompts_message_capped() {
+        use crate::contract::user_input::PendingPrompt;
+        use axum::body::to_bytes;
+        use axum::response::IntoResponse;
+        use dashmap::DashMap;
+        use std::sync::Arc;
+
+        let pending: PendingPrompts = Arc::new(DashMap::new());
+        let (tx, _rx) = tokio::sync::oneshot::channel::<usize>();
+        let huge = "a".repeat(OVERLAY_MESSAGE_MAX * 4);
+        pending.insert(
+            "n".to_string(),
+            PendingPrompt {
+                message: huge,
+                labels: vec!["OK".to_string()],
+                delegate_key: "d".to_string(),
+                contract_id: "c".to_string(),
+                response_tx: tx,
+            },
+        );
+
+        let resp = pending_prompts(Extension(pending)).await.into_response();
+        let body = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let msg = value[0]["message"].as_str().unwrap();
+        assert_eq!(msg.chars().count(), OVERLAY_MESSAGE_MAX);
     }
 }

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -32,28 +32,90 @@ pub(super) fn routes() -> Router {
 /// amount of delegate-controlled text the shell renders per poll so a
 /// malicious delegate cannot balloon the polling response.
 const OVERLAY_MESSAGE_MAX: usize = 2048;
+/// Maximum number of button labels rendered on the overlay. A delegate
+/// cannot force the shell to create an unbounded button grid.
+const OVERLAY_LABELS_MAX: usize = 8;
+/// Maximum length of each individual button label.
+const OVERLAY_LABEL_CHARS_MAX: usize = 64;
+/// Maximum length of `delegate_key` / `contract_id` rendered on the overlay.
+/// These are normally short keys; the cap bounds the amplification surface if
+/// the producer populates them from untrusted data in the future.
+const OVERLAY_KEY_CHARS_MAX: usize = 256;
+
+/// Strip characters that can visually spoof or hide delegate identity in the
+/// overlay: ASCII control characters (except `\t`, `\n`, `\r`) and Unicode
+/// bidirectional / formatting overrides. A right-to-left override in a
+/// delegate_key could otherwise visually reverse the key displayed in the
+/// context panel, undermining user trust.
+fn sanitize_display(s: &str, max_chars: usize) -> String {
+    let mut out = String::with_capacity(s.len().min(max_chars * 4));
+    for ch in s.chars().take(max_chars) {
+        let keep = match ch {
+            '\t' | '\n' | '\r' => true,
+            // C0 / C1 controls
+            c if (c as u32) < 0x20 || ((c as u32) >= 0x7f && (c as u32) <= 0x9f) => false,
+            // Bidi overrides and invisible formatters
+            '\u{202A}'..='\u{202E}' => false,
+            '\u{2066}'..='\u{2069}' => false,
+            '\u{200B}'..='\u{200F}' => false,
+            '\u{FEFF}' => false,
+            _ => true,
+        };
+        if keep {
+            out.push(ch);
+        }
+    }
+    out
+}
 
 /// Return the list of pending prompts for the shell page to render as
-/// in-page overlays (see issue #3836). Each entry includes the message,
-/// button labels, and delegate/contract context. The shell page is trusted
-/// and same-origin with the gateway, so it renders this data outside the
-/// sandboxed iframe where the contract can't reach it.
-async fn pending_prompts(Extension(pending): Extension<PendingPrompts>) -> impl IntoResponse {
+/// in-page overlays (see issue #3836). Each entry includes the sanitized
+/// message, button labels, and delegate/contract context.
+///
+/// The endpoint is protected by the same Origin check as
+/// `/permission/{nonce}/respond`: since this response now carries the full
+/// delegate-controlled message (rather than just a 100-char preview), a
+/// cross-origin page or rebinding attacker could otherwise scrape live
+/// prompts before the user sees them. Only trusted localhost origins pass.
+async fn pending_prompts(
+    headers: HeaderMap,
+    Extension(pending): Extension<PendingPrompts>,
+) -> impl IntoResponse {
+    if let Some(origin) = headers.get("origin") {
+        let origin = origin.to_str().unwrap_or("");
+        if !is_trusted_origin(origin) {
+            return (
+                axum::http::StatusCode::FORBIDDEN,
+                Json(serde_json::json!({"error": "forbidden"})),
+            );
+        }
+    }
+    // Requests with no Origin header (e.g. same-origin top-level fetch from
+    // some browsers) are allowed: the gateway only listens on loopback, the
+    // response is same-origin by policy, and the polled payload is not a
+    // capability — answering still requires POSTing to `/respond` with an
+    // Origin check that does reject the no-header case.
     let prompts: Vec<serde_json::Value> = pending
         .iter()
         .map(|entry| {
             let prompt = entry.value();
-            let message: String = prompt.message.chars().take(OVERLAY_MESSAGE_MAX).collect();
+            let message = sanitize_display(&prompt.message, OVERLAY_MESSAGE_MAX);
+            let labels: Vec<String> = prompt
+                .labels
+                .iter()
+                .take(OVERLAY_LABELS_MAX)
+                .map(|l| sanitize_display(l, OVERLAY_LABEL_CHARS_MAX))
+                .collect();
             serde_json::json!({
                 "nonce": entry.key(),
                 "message": message,
-                "labels": prompt.labels,
-                "delegate_key": prompt.delegate_key,
-                "contract_id": prompt.contract_id,
+                "labels": labels,
+                "delegate_key": sanitize_display(&prompt.delegate_key, OVERLAY_KEY_CHARS_MAX),
+                "contract_id": sanitize_display(&prompt.contract_id, OVERLAY_KEY_CHARS_MAX),
             })
         })
         .collect();
-    Json(prompts)
+    (axum::http::StatusCode::OK, Json(serde_json::json!(prompts)))
 }
 
 /// Serve the HTML permission prompt page.
@@ -408,41 +470,73 @@ mod tests {
         assert_eq!(html_escape("a & b"), "a &amp; b");
     }
 
-    // Regression test for issue #3836: the /permission/pending JSON must
-    // carry enough data for the shell-page overlay to render the prompt
-    // (message, labels, delegate key, contract id), not just a preview.
-    // Before the overlay existed the endpoint returned only `{nonce, preview}`
-    // because the shell fired a browser Notification and the user was expected
-    // to navigate to `/permission/{nonce}` for the full page.
-    #[tokio::test]
-    async fn test_pending_prompts_includes_overlay_fields() {
-        use crate::contract::user_input::PendingPrompt;
-        use axum::body::to_bytes;
-        use axum::response::IntoResponse;
+    fn empty_pending() -> PendingPrompts {
         use dashmap::DashMap;
         use std::sync::Arc;
+        Arc::new(DashMap::new())
+    }
 
-        let pending: PendingPrompts = Arc::new(DashMap::new());
-        let (tx, _rx) = tokio::sync::oneshot::channel::<usize>();
+    fn insert_prompt(
+        pending: &PendingPrompts,
+        nonce: &str,
+        message: &str,
+        labels: Vec<&str>,
+        delegate_key: &str,
+        contract_id: &str,
+    ) -> tokio::sync::oneshot::Receiver<usize> {
+        use crate::contract::user_input::PendingPrompt;
+        let (tx, rx) = tokio::sync::oneshot::channel::<usize>();
         pending.insert(
-            "nonce123".to_string(),
+            nonce.to_string(),
             PendingPrompt {
-                message: "Approve this?".to_string(),
-                labels: vec![
-                    "Allow Once".to_string(),
-                    "Always Allow".to_string(),
-                    "Deny".to_string(),
-                ],
-                delegate_key: "dkey".to_string(),
-                contract_id: "cid".to_string(),
+                message: message.to_string(),
+                labels: labels.into_iter().map(String::from).collect(),
+                delegate_key: delegate_key.to_string(),
+                contract_id: contract_id.to_string(),
                 response_tx: tx,
             },
         );
+        rx
+    }
 
-        let resp = pending_prompts(Extension(pending)).await.into_response();
-        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    fn trusted_header() -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("origin", "http://localhost:7509".parse().unwrap());
+        h
+    }
+
+    async fn call_pending(
+        headers: HeaderMap,
+        pending: PendingPrompts,
+    ) -> (axum::http::StatusCode, serde_json::Value) {
+        use axum::body::to_bytes;
+        use axum::response::IntoResponse;
+        let resp = pending_prompts(headers, Extension(pending))
+            .await
+            .into_response();
+        let status = resp.status();
+        let body = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        (status, value)
+    }
 
+    // Regression test for issue #3836: the /permission/pending JSON must
+    // carry enough data for the shell-page overlay to render the prompt
+    // (message, labels, delegate key, contract id), not just a preview.
+    #[tokio::test]
+    async fn test_pending_prompts_includes_overlay_fields() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(
+            &pending,
+            "nonce123",
+            "Approve this?",
+            vec!["Allow Once", "Always Allow", "Deny"],
+            "dkey",
+            "cid",
+        );
+
+        let (status, value) = call_pending(trusted_header(), pending).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
         let arr = value.as_array().expect("array");
         assert_eq!(arr.len(), 1);
         let entry = &arr[0];
@@ -460,30 +554,180 @@ mod tests {
     // can't balloon the polling response the shell fetches every few seconds.
     #[tokio::test]
     async fn test_pending_prompts_message_capped() {
-        use crate::contract::user_input::PendingPrompt;
-        use axum::body::to_bytes;
-        use axum::response::IntoResponse;
-        use dashmap::DashMap;
-        use std::sync::Arc;
-
-        let pending: PendingPrompts = Arc::new(DashMap::new());
-        let (tx, _rx) = tokio::sync::oneshot::channel::<usize>();
+        let pending = empty_pending();
         let huge = "a".repeat(OVERLAY_MESSAGE_MAX * 4);
-        pending.insert(
-            "n".to_string(),
-            PendingPrompt {
-                message: huge,
-                labels: vec!["OK".to_string()],
-                delegate_key: "d".to_string(),
-                contract_id: "c".to_string(),
-                response_tx: tx,
-            },
-        );
+        let _rx = insert_prompt(&pending, "n", &huge, vec!["OK"], "d", "c");
 
-        let resp = pending_prompts(Extension(pending)).await.into_response();
-        let body = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
-        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let msg = value[0]["message"].as_str().unwrap();
-        assert_eq!(msg.chars().count(), OVERLAY_MESSAGE_MAX);
+        let (_, value) = call_pending(trusted_header(), pending).await;
+        assert_eq!(
+            value[0]["message"].as_str().unwrap().chars().count(),
+            OVERLAY_MESSAGE_MAX
+        );
+    }
+
+    // Multi-byte characters (emoji, CJK) must be counted by `char`, not
+    // byte, so truncation never splits a grapheme and panics.
+    #[tokio::test]
+    async fn test_pending_prompts_message_cap_is_char_based() {
+        let pending = empty_pending();
+        // Each fire emoji is 4 UTF-8 bytes; OVERLAY_MESSAGE_MAX * 4 bytes
+        // would be the naive byte budget. Char-based truncation keeps them
+        // all intact.
+        let emoji = "\u{1F525}".repeat(OVERLAY_MESSAGE_MAX);
+        let _rx = insert_prompt(&pending, "n", &emoji, vec!["OK"], "d", "c");
+        let (_, value) = call_pending(trusted_header(), pending).await;
+        let got = value[0]["message"].as_str().unwrap();
+        assert_eq!(got.chars().count(), OVERLAY_MESSAGE_MAX);
+        assert!(got.chars().all(|c| c == '\u{1F525}'));
+    }
+
+    // A delegate supplying thousands of labels must not be able to make the
+    // shell draw a button grid of arbitrary size. The response must cap
+    // both the count and the per-label length.
+    #[tokio::test]
+    async fn test_pending_prompts_labels_capped_and_truncated() {
+        let pending = empty_pending();
+        let long_label: String = "L".repeat(OVERLAY_LABEL_CHARS_MAX * 4);
+        let labels: Vec<String> = (0..OVERLAY_LABELS_MAX * 4)
+            .map(|_| long_label.clone())
+            .collect();
+        {
+            use crate::contract::user_input::PendingPrompt;
+            let (tx, _rx) = tokio::sync::oneshot::channel::<usize>();
+            pending.insert(
+                "n".to_string(),
+                PendingPrompt {
+                    message: "m".to_string(),
+                    labels,
+                    delegate_key: "d".to_string(),
+                    contract_id: "c".to_string(),
+                    response_tx: tx,
+                },
+            );
+        }
+        let (_, value) = call_pending(trusted_header(), pending).await;
+        let out_labels = value[0]["labels"].as_array().unwrap();
+        assert_eq!(out_labels.len(), OVERLAY_LABELS_MAX);
+        for l in out_labels {
+            assert_eq!(l.as_str().unwrap().chars().count(), OVERLAY_LABEL_CHARS_MAX);
+        }
+    }
+
+    // Empty-labels case: the JSON must still round-trip as `[]`, and the
+    // shell JS has a local `['OK']` fallback that kicks in client-side.
+    #[tokio::test]
+    async fn test_pending_prompts_empty_labels_round_trip() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(&pending, "n", "m", vec![], "d", "c");
+        let (_, value) = call_pending(trusted_header(), pending).await;
+        assert_eq!(value[0]["labels"], serde_json::json!([]));
+    }
+
+    // Unicode right-to-left override in delegate_key / contract_id must
+    // be stripped so a hostile delegate can't visually reverse the key
+    // displayed in the overlay's context panel and spoof identity.
+    #[tokio::test]
+    async fn test_pending_prompts_strips_bidi_and_controls() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(
+            &pending,
+            "n",
+            // LRO + text + RLO in the middle of the message
+            "Hello\u{202E}evil\u{202A}!",
+            vec!["\u{202E}Allow\u{202C}"],
+            "\u{FEFF}key\u{200B}123",
+            "c\u{0007}id",
+        );
+        let (_, value) = call_pending(trusted_header(), pending).await;
+        assert_eq!(value[0]["message"], "Helloevil!");
+        assert_eq!(value[0]["labels"], serde_json::json!(["Allow"]));
+        assert_eq!(value[0]["delegate_key"], "key123");
+        assert_eq!(value[0]["contract_id"], "cid");
+    }
+
+    // /permission/pending now returns full delegate-controlled text, so
+    // the endpoint must reject cross-origin requests (same Origin check
+    // as /respond). This guards against DNS rebinding / browser-extension
+    // scraping of live prompts.
+    #[tokio::test]
+    async fn test_pending_prompts_rejects_untrusted_origin() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(&pending, "n", "m", vec!["OK"], "d", "c");
+        let mut headers = HeaderMap::new();
+        headers.insert("origin", "http://evil.com".parse().unwrap());
+        let (status, _) = call_pending(headers, pending).await;
+        assert_eq!(status, axum::http::StatusCode::FORBIDDEN);
+    }
+
+    // Missing Origin is allowed (some fetch flavors omit it); this matches
+    // the documented threat model: the poll payload is not a capability,
+    // and the /respond endpoint still rejects the no-Origin case.
+    #[tokio::test]
+    async fn test_pending_prompts_allows_missing_origin() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(&pending, "n", "m", vec!["OK"], "d", "c");
+        let (status, _) = call_pending(HeaderMap::new(), pending).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+    }
+
+    // End-to-end flow: two prompts pending, user answers one, other remains,
+    // second response to the same nonce returns 404. This is the cross-tab
+    // dismissal contract the shell JS relies on ("another tab already
+    // answered" → hide the overlay).
+    #[tokio::test]
+    async fn test_respond_consumes_nonce_and_second_response_404s() {
+        let pending = empty_pending();
+        let rx_a = insert_prompt(&pending, "a", "mA", vec!["Yes", "No"], "d", "c");
+        let _rx_b = insert_prompt(&pending, "b", "mB", vec!["Yes", "No"], "d", "c");
+
+        let (_, value) = call_pending(trusted_header(), pending.clone()).await;
+        let nonces: Vec<&str> = value
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["nonce"].as_str().unwrap())
+            .collect();
+        assert_eq!(nonces.len(), 2);
+        assert!(nonces.contains(&"a") && nonces.contains(&"b"));
+
+        // Answer A.
+        let (status, _) = {
+            let resp = permission_respond(
+                Path("a".to_string()),
+                trusted_header(),
+                Extension(pending.clone()),
+                Json(PermissionResponse { index: 0 }),
+            )
+            .await
+            .into_response();
+            let status = resp.status();
+            use axum::body::to_bytes;
+            let _ = to_bytes(resp.into_body(), 1024).await.unwrap();
+            (status, ())
+        };
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(rx_a.await.unwrap(), 0);
+
+        // Only B remains.
+        let (_, value) = call_pending(trusted_header(), pending.clone()).await;
+        let remaining: Vec<&str> = value
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["nonce"].as_str().unwrap())
+            .collect();
+        assert_eq!(remaining, vec!["b"]);
+
+        // Responding to A again 404s — the shell JS treats this as "another
+        // tab already answered" and hides its overlay card.
+        let resp = permission_respond(
+            Path("a".to_string()),
+            trusted_header(),
+            Extension(pending),
+            Json(PermissionResponse { index: 0 }),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
     }
 }

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -671,37 +671,187 @@ function freenetBridge(authToken) {
   window.addEventListener('popstate', forwardHash);
   window.addEventListener('hashchange', forwardHash);
 
-  // Permission prompt polling: check for pending delegate permission requests
-  // and show browser notifications. The user clicks the notification to open
-  // the permission page in a new tab.
-  var knownPrompts = {};
+  // Permission prompt overlay: render a modal in the shell page's DOM
+  // (outside the sandboxed iframe) whenever a delegate permission prompt
+  // is pending. The shell is trusted and same-origin with the gateway, so
+  // the sandboxed contract cannot reach into this DOM. See issue #3836.
+  //
+  // Every open Freenet tab renders the overlay for every pending prompt.
+  // When the user responds in one tab, the gateway removes the nonce from
+  // the pending registry; other tabs see it disappear on their next poll
+  // and hide their overlays automatically.
+  var overlayRoot = null;
+  var overlayCards = {}; // nonce -> card element
+  var OVERLAY_CSS =
+    '#__freenet_perm_overlay{position:fixed;inset:0;z-index:2147483647;' +
+    'background:rgba(8,10,14,0.62);backdrop-filter:blur(4px);' +
+    '-webkit-backdrop-filter:blur(4px);display:none;align-items:center;' +
+    'justify-content:center;padding:20px;overflow:auto;' +
+    'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;}' +
+    '#__freenet_perm_overlay .fn-card{--bg:#0f1419;--fg:#e6e8eb;--card:#1a2028;' +
+    '--accent:#3b82f6;--border:#2d3748;--warn:#f59e0b;--muted:#9ca3af;' +
+    'background:var(--card);color:var(--fg);border:1px solid var(--border);' +
+    'border-radius:14px;padding:28px;max-width:520px;width:100%;margin:12px 0;' +
+    'box-shadow:0 12px 40px rgba(0,0,0,0.5);box-sizing:border-box;}' +
+    '@media (prefers-color-scheme: light){#__freenet_perm_overlay .fn-card{' +
+    '--bg:#f5f5f5;--fg:#1a1a1a;--card:#ffffff;--accent:#2563eb;' +
+    '--border:#d1d5db;--warn:#d97706;--muted:#6b7280;' +
+    'box-shadow:0 12px 40px rgba(0,0,0,0.18);}}' +
+    '#__freenet_perm_overlay .fn-header{display:flex;align-items:center;gap:12px;' +
+    'margin-bottom:18px;}' +
+    '#__freenet_perm_overlay .fn-icon{font-size:28px;line-height:1;}' +
+    '#__freenet_perm_overlay .fn-title{font-size:18px;font-weight:600;margin:0;' +
+    'color:var(--fg);}' +
+    '#__freenet_perm_overlay .fn-ctx{background:var(--bg);border:1px solid var(--border);' +
+    'border-radius:8px;padding:12px 14px;margin-bottom:16px;font-size:12px;' +
+    'color:var(--muted);}' +
+    '#__freenet_perm_overlay .fn-ctx dt{font-weight:600;color:var(--fg);' +
+    'font-family:inherit;margin-top:6px;}' +
+    '#__freenet_perm_overlay .fn-ctx dt:first-child{margin-top:0;}' +
+    '#__freenet_perm_overlay .fn-ctx dd{margin:2px 0 0 0;font-family:ui-monospace,' +
+    'SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;word-break:break-all;}' +
+    '#__freenet_perm_overlay .fn-msg-label{font-size:11px;color:var(--muted);' +
+    'text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px;}' +
+    '#__freenet_perm_overlay .fn-msg{font-size:15px;line-height:1.5;margin:0 0 22px 0;' +
+    'padding:14px 16px;background:var(--bg);border-left:3px solid var(--warn);' +
+    'border-radius:4px;white-space:pre-wrap;word-wrap:break-word;color:var(--fg);}' +
+    '#__freenet_perm_overlay .fn-btns{display:flex;gap:10px;flex-wrap:wrap;}' +
+    '#__freenet_perm_overlay .fn-btn{padding:10px 20px;border-radius:8px;' +
+    'font-size:14px;cursor:pointer;flex:1;min-width:100px;font-weight:500;' +
+    'border:1px solid var(--border);background:var(--card);color:var(--fg);' +
+    'transition:transform 0.12s, opacity 0.12s, filter 0.12s;font-family:inherit;}' +
+    '#__freenet_perm_overlay .fn-btn.primary{background:var(--accent);' +
+    'color:#fff;border-color:var(--accent);}' +
+    '#__freenet_perm_overlay .fn-btn:hover:not(:disabled){transform:translateY(-1px);' +
+    'filter:brightness(1.08);}' +
+    '#__freenet_perm_overlay .fn-btn:disabled{opacity:0.55;cursor:not-allowed;}';
+  function ensureOverlayRoot() {
+    if (overlayRoot) return overlayRoot;
+    var style = document.createElement('style');
+    style.textContent = OVERLAY_CSS;
+    document.head.appendChild(style);
+    overlayRoot = document.createElement('div');
+    overlayRoot.id = '__freenet_perm_overlay';
+    document.body.appendChild(overlayRoot);
+    return overlayRoot;
+  }
+  function setText(el, text) {
+    // textContent avoids any HTML interpretation of delegate-controlled
+    // strings. Delegate-provided fields are never parsed as markup.
+    el.textContent = text == null ? '' : String(text);
+  }
+  function createCard(p) {
+    var card = document.createElement('div');
+    card.className = 'fn-card';
+    card.setAttribute('data-nonce', p.nonce);
+
+    var header = document.createElement('div');
+    header.className = 'fn-header';
+    var icon = document.createElement('span');
+    icon.className = 'fn-icon';
+    icon.textContent = '\u{1F512}';
+    var title = document.createElement('h1');
+    title.className = 'fn-title';
+    title.textContent = 'Permission Request';
+    header.appendChild(icon);
+    header.appendChild(title);
+    card.appendChild(header);
+
+    var ctx = document.createElement('dl');
+    ctx.className = 'fn-ctx';
+    var dkLabel = document.createElement('dt');
+    dkLabel.textContent = 'Delegate';
+    var dkVal = document.createElement('dd');
+    setText(dkVal, p.delegate_key || 'Unknown');
+    var ciLabel = document.createElement('dt');
+    ciLabel.textContent = 'Requesting contract';
+    var ciVal = document.createElement('dd');
+    setText(ciVal, p.contract_id || 'Unknown');
+    ctx.appendChild(dkLabel);
+    ctx.appendChild(dkVal);
+    ctx.appendChild(ciLabel);
+    ctx.appendChild(ciVal);
+    card.appendChild(ctx);
+
+    var msgLabel = document.createElement('div');
+    msgLabel.className = 'fn-msg-label';
+    msgLabel.textContent = 'Delegate says';
+    card.appendChild(msgLabel);
+    var msg = document.createElement('p');
+    msg.className = 'fn-msg';
+    setText(msg, p.message || 'A delegate is requesting permission.');
+    card.appendChild(msg);
+
+    var buttons = document.createElement('div');
+    buttons.className = 'fn-btns';
+    var labels = Array.isArray(p.labels) && p.labels.length > 0 ? p.labels : ['OK'];
+    labels.forEach(function(label, idx) {
+      var b = document.createElement('button');
+      b.className = 'fn-btn' + (idx === 0 ? ' primary' : '');
+      setText(b, label);
+      b.addEventListener('click', function() {
+        respondToPrompt(p.nonce, idx, card);
+      });
+      buttons.appendChild(b);
+    });
+    card.appendChild(buttons);
+    return card;
+  }
+  function showCard(nonce, card) {
+    var root = ensureOverlayRoot();
+    root.appendChild(card);
+    root.style.display = 'flex';
+    overlayCards[nonce] = card;
+  }
+  function hideCard(nonce) {
+    var card = overlayCards[nonce];
+    if (!card) return;
+    if (card.parentNode) card.parentNode.removeChild(card);
+    delete overlayCards[nonce];
+    if (overlayRoot && Object.keys(overlayCards).length === 0) {
+      overlayRoot.style.display = 'none';
+    }
+  }
+  function respondToPrompt(nonce, index, card) {
+    var btns = card.querySelectorAll('button');
+    btns.forEach(function(b) { b.disabled = true; b.style.opacity = '0.5'; });
+    fetch('/permission/' + encodeURIComponent(nonce) + '/respond', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ index: index })
+    }).then(function(r) {
+      // 404 means another tab already answered (or it auto-denied) — hide
+      // the overlay here as well so the user isn't staring at a dead button.
+      if (r.ok || r.status === 404) {
+        hideCard(nonce);
+      } else {
+        btns.forEach(function(b) { b.disabled = false; b.style.opacity = '1'; });
+      }
+    }).catch(function() {
+      btns.forEach(function(b) { b.disabled = false; b.style.opacity = '1'; });
+    });
+  }
   function checkPermissions() {
     fetch('/permission/pending').then(function(r) { return r.json(); }).then(function(prompts) {
+      if (!Array.isArray(prompts)) return;
+      var seen = {};
       prompts.forEach(function(p) {
-        if (knownPrompts[p.nonce]) return;
-        knownPrompts[p.nonce] = true;
-        if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
-          var n = new Notification('Freenet: Permission needed', {
-            body: p.preview || 'A delegate is requesting permission.',
-            tag: 'freenet-perm-' + p.nonce
-          });
-          n.onclick = function() { window.open('/permission/' + p.nonce, '_blank'); };
-        } else {
-          // Fallback: open directly if notifications not available
-          window.open('/permission/' + p.nonce, '_blank');
-        }
+        if (!p || typeof p.nonce !== 'string') return;
+        seen[p.nonce] = true;
+        if (overlayCards[p.nonce]) return;
+        var card = createCard(p);
+        showCard(p.nonce, card);
       });
-      // Clean up nonces no longer pending
-      Object.keys(knownPrompts).forEach(function(k) {
-        if (!prompts.some(function(p) { return p.nonce === k; })) delete knownPrompts[k];
+      // Any card whose nonce is no longer pending was answered elsewhere
+      // (another tab, the 60s auto-deny, or delegate cancelled). Remove it
+      // so the user isn't clicking a dead button.
+      Object.keys(overlayCards).forEach(function(nonce) {
+        if (!seen[nonce]) hideCard(nonce);
       });
     }).catch(function() {});
   }
-  // Request notification permission on first load
-  if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
-    Notification.requestPermission();
-  }
   setInterval(checkPermissions, 3000);
+  checkPermissions();
 }
 "#;
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -724,7 +724,13 @@ function freenetBridge(authToken) {
     'color:#fff;border-color:var(--accent);}' +
     '#__freenet_perm_overlay .fn-btn:hover:not(:disabled){transform:translateY(-1px);' +
     'filter:brightness(1.08);}' +
-    '#__freenet_perm_overlay .fn-btn:disabled{opacity:0.55;cursor:not-allowed;}';
+    '#__freenet_perm_overlay .fn-btn:disabled{opacity:0.55;cursor:not-allowed;}' +
+    '#__freenet_perm_overlay .fn-timer{margin-top:14px;font-size:12px;' +
+    'color:var(--muted);text-align:center;}';
+  // Auto-deny duration in seconds, mirroring the standalone /permission/{nonce}
+  // fallback page. Tracked client-side only; the server enforces the real
+  // timeout and will clear the nonce regardless.
+  var OVERLAY_AUTO_DENY_SECONDS = 60;
   function ensureOverlayRoot() {
     if (overlayRoot) return overlayRoot;
     var style = document.createElement('style');
@@ -732,7 +738,26 @@ function freenetBridge(authToken) {
     document.head.appendChild(style);
     overlayRoot = document.createElement('div');
     overlayRoot.id = '__freenet_perm_overlay';
+    overlayRoot.setAttribute('role', 'dialog');
+    overlayRoot.setAttribute('aria-modal', 'true');
+    overlayRoot.setAttribute('aria-label', 'Delegate permission request');
     document.body.appendChild(overlayRoot);
+    // Escape-to-dismiss: routes to the last button in the most-recently-added
+    // card, which (by the standard delegate convention Allow Once / Always
+    // Allow / Deny) is the Deny button. If the delegate supplied a single
+    // label this is a no-op — Escape just does nothing.
+    document.addEventListener('keydown', function(e) {
+      if (e.key !== 'Escape') return;
+      if (!overlayRoot || overlayRoot.style.display === 'none') return;
+      var nonces = Object.keys(overlayCards);
+      if (nonces.length === 0) return;
+      var nonce = nonces[nonces.length - 1];
+      var card = overlayCards[nonce];
+      var btns = card.querySelectorAll('button');
+      if (btns.length < 2) return; // no non-primary option, ignore
+      btns[btns.length - 1].click();
+      e.preventDefault();
+    });
     return overlayRoot;
   }
   function setText(el, text) {
@@ -795,6 +820,25 @@ function freenetBridge(authToken) {
       buttons.appendChild(b);
     });
     card.appendChild(buttons);
+
+    // Countdown mirroring the standalone permission page. The real timeout
+    // lives server-side; this is a hint for the user that the prompt won't
+    // wait forever. On expiry the next poll drops the card via the
+    // reconciliation path, so we don't need a local hide here.
+    var timer = document.createElement('div');
+    timer.className = 'fn-timer';
+    var remaining = OVERLAY_AUTO_DENY_SECONDS;
+    timer.textContent = 'Auto-deny in ' + remaining + 's';
+    card._fnTimerId = setInterval(function() {
+      remaining -= 1;
+      if (remaining <= 0) {
+        clearInterval(card._fnTimerId);
+        timer.textContent = 'Auto-denied';
+        return;
+      }
+      timer.textContent = 'Auto-deny in ' + remaining + 's';
+    }, 1000);
+    card.appendChild(timer);
     return card;
   }
   function showCard(nonce, card) {
@@ -802,10 +846,20 @@ function freenetBridge(authToken) {
     root.appendChild(card);
     root.style.display = 'flex';
     overlayCards[nonce] = card;
+    // Move keyboard focus to the primary button so Enter/Space answer the
+    // prompt without requiring a mouse click.
+    var primary = card.querySelector('.fn-btn.primary');
+    if (primary && typeof primary.focus === 'function') {
+      try { primary.focus(); } catch (e) {}
+    }
   }
   function hideCard(nonce) {
     var card = overlayCards[nonce];
     if (!card) return;
+    if (card._fnTimerId) {
+      clearInterval(card._fnTimerId);
+      card._fnTimerId = null;
+    }
     if (card.parentNode) card.parentNode.removeChild(card);
     delete overlayCards[nonce];
     if (overlayRoot && Object.keys(overlayCards).length === 0) {
@@ -832,6 +886,14 @@ function freenetBridge(authToken) {
     });
   }
   function checkPermissions() {
+    // Skip polling when the tab is hidden: saves bandwidth and gateway
+    // load when the user has many Freenet tabs open in the background.
+    // The tab picks up the prompt again on its next visibility event.
+    if (typeof document !== 'undefined' &&
+        document.visibilityState === 'hidden' &&
+        Object.keys(overlayCards).length === 0) {
+      return;
+    }
     fetch('/permission/pending').then(function(r) { return r.json(); }).then(function(prompts) {
       if (!Array.isArray(prompts)) return;
       var seen = {};
@@ -852,6 +914,14 @@ function freenetBridge(authToken) {
   }
   setInterval(checkPermissions, 3000);
   checkPermissions();
+  // Re-check as soon as the tab becomes visible again so a user returning
+  // to a background tab sees any prompt that accumulated while they were
+  // away without waiting for the next poll tick.
+  if (typeof document !== 'undefined' && document.addEventListener) {
+    document.addEventListener('visibilitychange', function() {
+      if (document.visibilityState === 'visible') checkPermissions();
+    });
+  }
 }
 "#;
 
@@ -1243,6 +1313,82 @@ mod tests {
         assert!(
             html.contains("open_url"),
             "shell bridge must handle open_url messages for external links"
+        );
+    }
+
+    /// Regression test for issue #3836: permission prompts must render as an
+    /// in-page overlay in the shell DOM, NOT via browser Notifications (which
+    /// users block, miss, or dismiss accidentally).
+    #[tokio::test]
+    async fn shell_page_permission_overlay_present_and_safe() {
+        let token = AuthToken::generate();
+        let html =
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, None).unwrap()).await;
+
+        // Overlay root and accessibility attributes
+        assert!(
+            html.contains("__freenet_perm_overlay"),
+            "permission overlay root element missing from shell JS"
+        );
+        assert!(
+            html.contains("'role', 'dialog'") || html.contains("\"role\", \"dialog\""),
+            "overlay must declare role=dialog for a11y"
+        );
+        assert!(html.contains("aria-modal"), "overlay must set aria-modal");
+        // Polls the new pending endpoint and POSTs back with the response.
+        assert!(
+            html.contains("/permission/pending"),
+            "shell JS must poll /permission/pending"
+        );
+        assert!(
+            html.contains("/respond"),
+            "shell JS must POST to /permission/{{nonce}}/respond"
+        );
+        // The 404 branch is the cross-tab dismissal contract: "another tab
+        // answered, hide my card".
+        assert!(
+            html.contains("r.status === 404"),
+            "shell JS must treat 404 on respond as 'already answered' and hide the card"
+        );
+        // All delegate-controlled strings must go through textContent, never
+        // innerHTML — guards against a future refactor re-opening XSS into
+        // the trusted shell origin.
+        assert!(
+            html.contains("function setText(el, text)"),
+            "setText helper (textContent-only) missing"
+        );
+        // innerHTML must not appear anywhere in the overlay code path. It
+        // can appear elsewhere in the shell JS if needed, but this test
+        // enforces that the overlay diff doesn't introduce it.
+        let overlay_start = html.find("__freenet_perm_overlay").unwrap();
+        let overlay_end = html[overlay_start..]
+            .find("setInterval(checkPermissions")
+            .unwrap();
+        let overlay_slice = &html[overlay_start..overlay_start + overlay_end];
+        assert!(
+            !overlay_slice.contains("innerHTML"),
+            "overlay code path must not use innerHTML (XSS surface)"
+        );
+
+        // The old Notification flow must be gone: no requestPermission(),
+        // no new Notification(...), no window.open('/permission/').
+        assert!(
+            !html.contains("Notification.requestPermission"),
+            "browser Notification permission request must be removed (#3836)"
+        );
+        assert!(
+            !html.contains("new Notification("),
+            "browser Notification construction must be removed (#3836)"
+        );
+        assert!(
+            !html.contains("window.open('/permission/")
+                && !html.contains("window.open(\"/permission/"),
+            "shell must no longer open /permission/{{nonce}} as a popup (#3836)"
+        );
+        // Visibility gating keeps background tabs from polling forever.
+        assert!(
+            html.contains("visibilityState"),
+            "overlay polling should be gated on document.visibilityState"
         );
     }
 


### PR DESCRIPTION
## Problem

The permission prompt system added in #3818 relies on browser Notifications to surface delegate permission requests:

1. Many users deny notification permissions by default, so the prompt never shows
2. One accidental swipe/click dismisses a notification permanently with no recovery
3. DND, focused monitor, or mobile can cause the notification to be missed entirely
4. Even when it works the user must click through to \`/permission/{nonce}\` in a separate tab

Permission prompts gate delegate operations — a missed prompt stalls the delegate indefinitely. Depending on a mechanism users can silently block is too fragile.

## Solution

Render the prompt as an **in-page overlay** in the shell page's own DOM, on top of the sandboxed iframe. The shell page (trusted, same-origin with the gateway) already polls \`/permission/pending\` every 3s; now, instead of firing \`new Notification(...)\`, it injects a modal card with the delegate's message, context, and buttons. Clicking a button POSTs to the existing \`/permission/{nonce}/respond\` endpoint.

Every open Freenet tab runs the shell page with the same polling, so the overlay appears on every visible page. When the user responds in one tab the gateway removes the nonce from the pending registry; the other tabs see it disappear on their next poll and hide their overlays automatically. No cross-tab messaging needed — the gateway is the state of truth.

### Key points

- **Security boundary unchanged**: overlay is in the shell DOM; the sandboxed iframe cannot access it, same as before.
- **XSS-safe**: all delegate-provided strings go through \`textContent\`, never \`innerHTML\`.
- **Server change**: \`/permission/pending\` now returns the full message (capped at 2048 chars), button labels, delegate key, and contract id. Previously it returned only \`{nonce, preview}\`, which was enough for a notification headline but not for an overlay.
- **Fallback retained**: the standalone \`/permission/{nonce}\` HTML page is kept for JS-disabled clients and debugging.
- **Dark/light mode**: single injected \`<style>\` with CSS variables and \`prefers-color-scheme\`, not inline styles.

### Visual verification

Rendered via a standalone HTML mockup using the exact same CSS/markup and screenshotted under both color schemes with Playwright — both look clean (blurred backdrop, prominent primary button, wrapped key/hash fields, warning-bordered delegate message).

## Testing

- New unit tests in \`permission_prompts.rs\`:
  - \`test_pending_prompts_includes_overlay_fields\` — asserts the endpoint returns \`nonce\`, \`message\`, \`labels\`, \`delegate_key\`, \`contract_id\` (regression against anyone trimming it back to \`{nonce, preview}\`)
  - \`test_pending_prompts_message_capped\` — asserts oversized delegate messages are clipped to 2048 chars so a malicious delegate can't balloon the poll response
- All 14 \`permission_prompts\` tests pass (12 pre-existing + 2 new)
- \`cargo fmt\` + \`cargo clippy -p freenet --lib -- -D warnings\` clean

## Fixes

Closes #3836

[AI-assisted - Claude]