### PR TITLE
feat(server): integrate browser history with gateway iframe navigation

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -550,7 +550,21 @@ function freenetBridge(authToken) {
         if (h.length > 0 && h.charAt(0) === '#') {
           // Preserve the existing state object (which may carry our
           // __freenet_nav__ marker) so popstate can still restore the iframe.
-          history.replaceState(history.state, '', h);
+          // If the current entry is tagged, also update its iframePath to
+          // include the new fragment — otherwise back/forward would restore
+          // the iframe without the user's current fragment position.
+          var curState = history.state;
+          if (curState && curState.__freenet_nav__ === true &&
+              typeof curState.iframePath === 'string') {
+            var basePath = curState.iframePath.split('#')[0];
+            history.replaceState(
+              { __freenet_nav__: true, iframePath: basePath + h },
+              '',
+              h
+            );
+          } else {
+            history.replaceState(history.state, '', h);
+          }
         }
       } else if (msg.type === 'clipboard' && typeof msg.text === 'string') {
         // Sandboxed iframes can't use navigator.clipboard due to permissions
@@ -570,6 +584,9 @@ function freenetBridge(authToken) {
         // navigation requests to the shell which updates iframe.src.
         // Security: only allows paths under the current contract's web prefix
         // to prevent cross-contract navigation or path traversal.
+        // Cap href length to prevent a malicious contract from bloating
+        // history.state or the address bar with arbitrarily large URLs.
+        if (msg.href.length > 4096) return;
         try {
           var resolved = new URL(msg.href, iframe.src);
           // Only allow same-origin navigation (no cross-site)
@@ -582,9 +599,13 @@ function freenetBridge(authToken) {
           // when src changes, orphaning any connection callbacks.
           connections.forEach(function(ws) { try { ws.close(); } catch(e) {} });
           connections.clear();
+          // Cap the hash component to match the 8192-byte cap used by the
+          // hash-forwarding path; the iframe path is stored in history.state
+          // so unbounded hashes would bloat the per-tab history record.
+          var cappedHash = resolved.hash ? resolved.hash.slice(0, 8192) : '';
           // Build new sandbox URL preserving __sandbox=1
           resolved.searchParams.set('__sandbox', '1');
-          var newIframePath = resolved.pathname + resolved.search;
+          var newIframePath = resolved.pathname + resolved.search + cappedHash;
           iframe.src = newIframePath;
           // Push a history entry so the browser back/forward buttons navigate
           // between visited subpages, and update the address bar to the
@@ -595,7 +616,7 @@ function freenetBridge(authToken) {
             history.pushState(
               { __freenet_nav__: true, iframePath: newIframePath },
               '',
-              cleanPath + resolved.hash
+              cleanPath + cappedHash
             );
           } catch(e) {}
         } catch(e) {}
@@ -703,9 +724,15 @@ function freenetBridge(authToken) {
       // A stale state object from a different contract must not be able to
       // redirect the iframe elsewhere.
       if (contractPrefix && state.iframePath.indexOf(contractPrefix) === 0) {
-        connections.forEach(function(ws) { try { ws.close(); } catch(e) {} });
-        connections.clear();
-        iframe.src = state.iframePath;
+        // No-op if the iframe is already on the target path (e.g. popstate
+        // fired from a bfcache restore where iframe state was retained).
+        // This avoids a spurious reload that would tear down live WebSocket
+        // connections unnecessarily.
+        if (iframe.src.indexOf(state.iframePath) === -1) {
+          connections.forEach(function(ws) { try { ws.close(); } catch(e) {} });
+          connections.clear();
+          iframe.src = state.iframePath;
+        }
         return;
       }
     }
@@ -1962,7 +1989,7 @@ mod tests {
         // The pushState URL must be the clean path (without __sandbox=1) so the
         // address bar shows the user-visible subpage URL, not the sandbox flag.
         assert!(
-            SHELL_BRIDGE_JS.contains("cleanPath + resolved.hash"),
+            SHELL_BRIDGE_JS.contains("cleanPath + cappedHash"),
             "pushState URL must be the clean (non-sandbox) path"
         );
     }
@@ -2004,6 +2031,46 @@ mod tests {
         assert!(
             SHELL_BRIDGE_JS.contains("history.replaceState(history.state"),
             "hash replaceState must preserve the existing state object"
+        );
+    }
+
+    #[test]
+    fn bridge_js_navigate_caps_href_length() {
+        // Prevent a malicious contract from bloating history.state / URL by
+        // spamming arbitrarily large navigate hrefs.
+        assert!(
+            SHELL_BRIDGE_JS.contains("msg.href.length > 4096"),
+            "navigate handler must cap msg.href length"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("resolved.hash.slice(0, 8192)"),
+            "navigate handler must cap the hash component stored in history.state"
+        );
+    }
+
+    #[test]
+    fn bridge_js_hash_update_syncs_nav_state() {
+        // When the iframe sends a hash update while sitting on a pushState
+        // entry, the stored iframePath must be refreshed to include the new
+        // fragment — otherwise back/forward loses the user's fragment.
+        assert!(
+            SHELL_BRIDGE_JS.contains("curState.__freenet_nav__ === true"),
+            "hash handler must detect tagged nav state"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("basePath + h"),
+            "hash handler must rewrite iframePath with the new fragment"
+        );
+    }
+
+    #[test]
+    fn bridge_js_popstate_skips_reload_when_iframe_on_target() {
+        // bfcache restore can fire popstate while the iframe is already on
+        // the target path. Re-assigning iframe.src would tear down live
+        // WebSockets for no reason.
+        assert!(
+            SHELL_BRIDGE_JS.contains("iframe.src.indexOf(state.iframePath) === -1"),
+            "popstate handler must skip reload when iframe is already on the target"
         );
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -498,11 +498,26 @@ function freenetBridge(authToken) {
   // linking. Using data-src (not src) in the HTML means the iframe
   // doesn't start loading until we set .src here, so there is exactly
   // one load -- with the hash already in the URL.
-  var iframeSrc = iframe.getAttribute('data-src');
+  var iframeDataSrc = iframe.getAttribute('data-src');
+  // Cache the contract web prefix once; used by nav/popstate path validation.
+  var contractPrefixMatch = iframeDataSrc.match(/^(\/v[12]\/contract\/web\/[^/]+\/)/);
+  var contractPrefix = contractPrefixMatch ? contractPrefixMatch[1] : null;
+  var iframeSrc = iframeDataSrc;
   if (location.hash) {
     iframeSrc += location.hash.slice(0, 8192);
   }
   iframe.src = iframeSrc;
+  // Seed history state so that back-navigating to the initial entry still
+  // has an identifiable __freenet_nav__ record. Using replaceState avoids
+  // adding a new entry — we just tag the existing one.
+  if (contractPrefix) {
+    try {
+      history.replaceState(
+        { __freenet_nav__: true, iframePath: iframeSrc },
+        ''
+      );
+    } catch(e) {}
+  }
 
   function sendToIframe(msg) {
     iframe.contentWindow.postMessage(msg, '*');
@@ -533,7 +548,9 @@ function freenetBridge(authToken) {
         // replaceState does NOT fire popstate or hashchange, preventing loops.
         var h = msg.hash.slice(0, 8192);
         if (h.length > 0 && h.charAt(0) === '#') {
-          history.replaceState(null, '', h);
+          // Preserve the existing state object (which may carry our
+          // __freenet_nav__ marker) so popstate can still restore the iframe.
+          history.replaceState(history.state, '', h);
         }
       } else if (msg.type === 'clipboard' && typeof msg.text === 'string') {
         // Sandboxed iframes can't use navigator.clipboard due to permissions
@@ -558,13 +575,8 @@ function freenetBridge(authToken) {
           // Only allow same-origin navigation (no cross-site)
           if (resolved.origin !== location.origin) return;
           var cleanPath = resolved.pathname;
-          // Extract the contract web prefix from the iframe's data-src
-          var dataSrc = iframe.getAttribute('data-src');
-          var baseParts = dataSrc.match(/^(\/v[12]\/contract\/web\/[^/]+\/)/);
-          if (!baseParts) return;
-          var contractPrefix = baseParts[1];
           // Ensure navigation stays within the same contract
-          if (cleanPath.indexOf(contractPrefix) !== 0) return;
+          if (!contractPrefix || cleanPath.indexOf(contractPrefix) !== 0) return;
           // Close any open WebSocket connections from the previous page to
           // prevent resource leaks. The old iframe document will be destroyed
           // when src changes, orphaning any connection callbacks.
@@ -572,7 +584,20 @@ function freenetBridge(authToken) {
           connections.clear();
           // Build new sandbox URL preserving __sandbox=1
           resolved.searchParams.set('__sandbox', '1');
-          iframe.src = resolved.pathname + resolved.search;
+          var newIframePath = resolved.pathname + resolved.search;
+          iframe.src = newIframePath;
+          // Push a history entry so the browser back/forward buttons navigate
+          // between visited subpages, and update the address bar to the
+          // non-sandbox URL. The sandbox flag is intentionally omitted from the
+          // outer URL; the shell always re-adds it when loading the iframe.
+          // See issue #3839.
+          try {
+            history.pushState(
+              { __freenet_nav__: true, iframePath: newIframePath },
+              '',
+              cleanPath + resolved.hash
+            );
+          } catch(e) {}
         } catch(e) {}
       } else if (msg.type === 'open_url' && typeof msg.url === 'string') {
         // Open external URLs in a new tab. Popups from the sandboxed iframe
@@ -668,7 +693,24 @@ function freenetBridge(authToken) {
       sendToIframe({ __freenet_shell__: true, type: 'hash', hash: location.hash.slice(0, 8192) });
     }
   }
-  window.addEventListener('popstate', forwardHash);
+  // popstate fires when the user presses back/forward. If the popped entry
+  // carries our __freenet_nav__ marker, restore the iframe to the matching
+  // subpage. Otherwise, fall back to forwarding the hash. See issue #3839.
+  window.addEventListener('popstate', function(ev) {
+    var state = ev.state;
+    if (state && state.__freenet_nav__ === true && typeof state.iframePath === 'string') {
+      // Security: path must still live under this contract's web prefix.
+      // A stale state object from a different contract must not be able to
+      // redirect the iframe elsewhere.
+      if (contractPrefix && state.iframePath.indexOf(contractPrefix) === 0) {
+        connections.forEach(function(ws) { try { ws.close(); } catch(e) {} });
+        connections.clear();
+        iframe.src = state.iframePath;
+        return;
+      }
+    }
+    forwardHash();
+  });
   window.addEventListener('hashchange', forwardHash);
 
   // Permission prompt overlay: render a modal in the shell page's DOM
@@ -1617,11 +1659,7 @@ mod tests {
         );
         assert!(
             SHELL_BRIDGE_JS.contains("history.replaceState"),
-            "bridge JS must use replaceState (not pushState) to avoid polluting browser history"
-        );
-        assert!(
-            !SHELL_BRIDGE_JS.contains("history.pushState"),
-            "bridge JS must not use pushState — hash changes should replace, not push"
+            "bridge JS must use replaceState for hash updates to avoid polluting browser history"
         );
         // Initial hash: built into iframe src from data-src for deep linking
         assert!(
@@ -1903,6 +1941,70 @@ mod tests {
 
         let result = sandbox_content_body(dir.path(), key, ApiVersion::V1, "escape.html").await;
         assert!(result.is_err(), "symlink escape should be rejected");
+    }
+
+    #[test]
+    fn bridge_js_navigate_pushes_history_state() {
+        // Regression test for #3839: in-contract navigation must push a browser
+        // history entry so back/forward works and the address bar updates.
+        assert!(
+            SHELL_BRIDGE_JS.contains("history.pushState"),
+            "navigate handler must push a history entry"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("__freenet_nav__: true"),
+            "history state must be tagged with __freenet_nav__ so popstate can recognise it"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("iframePath: newIframePath"),
+            "history state must carry the iframe sandbox URL for popstate restore"
+        );
+        // The pushState URL must be the clean path (without __sandbox=1) so the
+        // address bar shows the user-visible subpage URL, not the sandbox flag.
+        assert!(
+            SHELL_BRIDGE_JS.contains("cleanPath + resolved.hash"),
+            "pushState URL must be the clean (non-sandbox) path"
+        );
+    }
+
+    #[test]
+    fn bridge_js_popstate_restores_iframe_from_state() {
+        // Regression test for #3839: browser back/forward must restore the
+        // iframe to the previously-visited subpage by reading history state.
+        assert!(
+            SHELL_BRIDGE_JS.contains("addEventListener('popstate'"),
+            "bridge JS must listen for popstate events"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("state.__freenet_nav__ === true"),
+            "popstate handler must check for the __freenet_nav__ marker"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("state.iframePath.indexOf(contractPrefix) === 0"),
+            "popstate handler must validate the restored iframe path stays under the contract prefix"
+        );
+        assert!(
+            SHELL_BRIDGE_JS.contains("iframe.src = state.iframePath"),
+            "popstate handler must restore iframe.src from state"
+        );
+    }
+
+    #[test]
+    fn bridge_js_seeds_initial_history_state() {
+        // Regression test for #3839: the initial history entry must carry the
+        // __freenet_nav__ marker so that navigating back to the first page
+        // still restores the iframe via popstate.
+        assert!(
+            SHELL_BRIDGE_JS.contains("history.replaceState"),
+            "bridge JS must seed history state on load"
+        );
+        // The replaceState call for hash forwarding must preserve existing
+        // state (history.state) rather than passing null, or it would wipe the
+        // __freenet_nav__ marker and break back-navigation.
+        assert!(
+            SHELL_BRIDGE_JS.contains("history.replaceState(history.state"),
+            "hash replaceState must preserve the existing state object"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When the gateway's postMessage bridge navigates between pages within a
web container (via the navigate handler from #3834), it updates
`iframe.src` but does not push entries to the browser's history stack.
As a result:

1. **Back button doesn't work** — clicking back either does nothing or
   navigates away from the contract entirely.
2. **URL doesn't update** — the browser address bar always shows the
   initial contract URL regardless of which subpage the user is on.
3. **No way to recover from dead-end pages** — if a user navigates to a
   page that doesn't exist, they're stuck with no way to go back.

## Solution

Extend the shell bridge's `navigate` handler to call `history.pushState`
with a tagged state object (`__freenet_nav__`) carrying the iframe's
sandbox URL. Add a `popstate` listener that restores `iframe.src` from
this state on back/forward, falling back to the existing hash-forwarding
behaviour for non-nav entries. The initial history entry is seeded with
`replaceState` so back-navigating to it still triggers iframe restore.

The existing `hash` message handler now preserves the state object
instead of wiping it with `null`, so a hash update does not break the
nav marker on the current entry.

The pushState URL uses the clean (non-sandbox) path, so the address bar
shows the user-visible URL; the shell always re-adds `__sandbox=1` when
loading the iframe.

**Security:** both pushState and popstate paths validate that the
target iframe path lives under the current contract's web prefix, so a
stale state object cannot redirect the iframe cross-contract. The
existing same-origin and prefix checks on the navigate handler are
preserved.

## Testing

Three new regression tests in `path_handlers.rs`:

- `bridge_js_navigate_pushes_history_state` — asserts the navigate
  handler calls `pushState` with the `__freenet_nav__` marker and
  `iframePath`, and that the URL argument is the clean path.
- `bridge_js_popstate_restores_iframe_from_state` — asserts the popstate
  listener checks the marker, validates the contract prefix, and
  restores `iframe.src`.
- `bridge_js_seeds_initial_history_state` — asserts the initial entry
  is seeded via `replaceState` and that the hash replaceState preserves
  existing state (`history.replaceState(history.state, ...)`).

Updated `bridge_js_contains_origin_check` — removed the now-stale
assertion forbidding `history.pushState`, which is intentional for
navigation.

**Out of scope:** deep-link reload (refreshing the browser on a pushed
URL like `/v1/contract/web/KEY/news/`). The server still routes
non-sandbox sub-paths through `variable_content`, so a reload will 404.
Fixing that requires plumbing `sub_path` through the shell page render
path and is a larger change than the issue's implementation sketch.

Fixes #3839

[AI-assisted - Claude]