### PR TITLE
build: replace local release build+test with cargo check

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -619,40 +619,28 @@ update_versions() {
         exit 1
     fi
 
-    # Verify that the project compiles with the new versions
-    echo -n "  Verifying compilation... "
-    if cargo build --release --quiet 2>/dev/null; then
+    # Quick sanity check that the version-bumped workspace still type-checks.
+    # This is intentionally `cargo check`, not `cargo build --release` or
+    # `cargo test --release`: the PR opened below runs the full build and test
+    # suite on GitHub CI, and that is the gate auto-merge waits on. The local
+    # step only needs to catch trivially broken states (bad Cargo.toml edit,
+    # version mismatch, `cargo update` pulling in an incompatible transitive)
+    # before we round-trip through CI — codegen and the test suite are pure
+    # duplication here and can cost 5–15+ minutes of local wall time per
+    # release depending on cache state.
+    echo -n "  Running cargo check on workspace... "
+    if cargo check --workspace --quiet 2>/dev/null; then
         echo "✓"
     else
         echo "✗"
         echo ""
-        echo "  ⚠️  ERROR: Project failed to compile with new versions!"
-        echo "     Running cargo build to see errors:"
+        echo "  ⚠️  ERROR: Workspace failed to type-check with new versions!"
+        echo "     Running cargo check to see errors:"
         echo ""
-        cargo build --release
+        cargo check --workspace
         echo ""
-        echo "  Please fix compilation errors before releasing."
+        echo "  Please fix errors before releasing."
         exit 1
-    fi
-
-    # Run tests to ensure nothing is broken
-    if [[ "$SKIP_TESTS" == "false" ]]; then
-        echo -n "  Running tests... "
-        if cargo test --release --quiet 2>/dev/null; then
-            echo "✓"
-        else
-            echo "✗"
-            echo ""
-            echo "  ⚠️  ERROR: Tests failed with new versions!"
-            echo "     Running cargo test to see failures:"
-            echo ""
-            cargo test --release
-            echo ""
-            echo "  Please fix test failures before releasing."
-            exit 1
-        fi
-    else
-        echo "  ⚠️  Skipping tests (--skip-tests specified)"
     fi
 }
 


### PR DESCRIPTION
## Problem

\`scripts/release.sh\` currently runs \`cargo build --release --quiet\` followed by \`cargo test --release --quiet\` on the local machine before opening the release PR. Both are duplicated by GitHub CI on the PR itself, which is what auto-merge actually gates on, so the local run has no correctness value — it's a second copy of the work CI is about to do anyway.

On a release, \`cargo update --workspace\` runs just before this step to regenerate \`Cargo.lock\`. Because the workspace's own crate versions have just been bumped, that effectively cold-invalidates the release target dir, so the \"verify\" step rebuilds the entire workspace in release mode from scratch every time. Observed cost: **5–15+ minutes of local wall time per release**, depending on cache state and concurrent load. On this repo's release runner (nova), when another worktree is doing cargo work at the same time the two contend for cores and the target-dir lock, which inflates wall time further and starves interactive sessions.

## Approach

Replace the local \`cargo build --release --quiet\` with \`cargo check --workspace --quiet\`. This still catches the cases the step exists to catch — bad \`Cargo.toml\` edit, version mismatch between \`crates/core\` and \`crates/fdev\`, an incompatible transitive dependency pulled in by \`cargo update\` — because those are all type-check or metadata errors, not codegen errors. What it skips is the expensive codegen pass and linking, which CI re-does anyway.

Drop the \`cargo test --release\` block entirely. CI runs the test suite on every PR and auto-merge is already gated on that run; repeating it locally buys nothing except wall-clock. The informational block earlier in the script (around line 556) already says *\"Pre-release tests will be run by GitHub CI during the release PR\"*, so the intent was already recognized — this PR just brings the rest of the script in line with that intent.

The \`--skip-tests\` CLI flag stays as a no-op so existing invocations don't break; its only effect now is to suppress the \"tests will run in CI\" reminder. I considered removing it, but (a) that's a breaking change to the CLI surface and (b) a future contributor might re-add a local test step and want to gate it on this flag.

### Alternatives considered

- **Keep \`cargo build --release\` but drop only the test run.** Saves the slower half but still does the full codegen + link pass that CI is about to re-do. \`cargo check\` captures 95% of the bug-catching value for <10% of the cost.
- **Run \`cargo check\` only on \`-p freenet -p fdev\` (the two crates whose versions are actually bumped).** Tempting but not safe: \`cargo update --workspace\` can pull new transitive dependencies for anything in the workspace, and a workspace-wide \`cargo check\` is the only way to catch \"release PR breaks apps/freenet-ping\" before round-tripping through CI. It's also cheap enough that narrowing the scope isn't worth the loss of coverage.
- **Remove the local step entirely.** Would work, but losing the smoke test means a one-character typo in a \`Cargo.toml\` version field waits 10+ minutes to fail in CI instead of ~30 seconds locally. The \`cargo check\` version is the happy middle.

## Testing

- Shell syntax validated: \`bash -n scripts/release.sh\` passes.
- Behavioral change is a straight substitution in a developer-tool script: same control flow, same exit code on success/failure, same error-display-on-failure pattern (quiet mode first, verbose mode on fail). The code paths that matter for correctness — \`update_versions\`, \`create_release_pr\`, post-merge steps — are untouched.
- No unit tests exist for \`release.sh\` and this PR doesn't add them; a test harness for this script would be larger than this change. Happy to file a follow-up if reviewers want one.

The next release that goes through this script is the validation. If \`cargo check\` catches a real compilation problem it will show it with the same error-display pattern the old code used, and CI will still catch anything \`cargo check\` missed.

## Fixes

N/A — no tracking issue. Noticed while investigating unrelated CPU contention on nova (release build running concurrently with another agent's cargo test loop was saturating 16 cores and causing interactive SSH/mosh lag).

[AI-assisted - Claude]