### PR TITLE
build(release): make River announcement reliable

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1382,19 +1382,34 @@ if current_key != key_bytes:
     # `riverctl` binary. The installed binary embeds room_contract.wasm at install time,
     # which becomes stale when the contract WASM changes. The repo version uses a build
     # script that copies the current WASM from ui/public/contracts/ at build time.
+    #
+    # RIVER_SKIP_CONTRACT_CHECK=1 disables riverctl's build-time staleness check that
+    # compares `ui/public/contracts/room_contract.wasm` against
+    # `target/wasm32-unknown-unknown/release/room_contract.wasm`. That check catches
+    # out-of-date WASM before *publishing* riverctl to crates.io, but here we are only
+    # *running* riverctl locally to send a chat message. A developer with a freshly
+    # rebuilt room-contract in their workspace will otherwise hit a panic unrelated to
+    # sending the message.
+    #
+    # stderr is captured into a log instead of discarded so future failures are
+    # diagnosable from the release log.
     local RIVER_DIR="$HOME/code/freenet/river/main"
+    local RIVER_LOG="/tmp/release-$VERSION-river.log"
     if [[ -d "$RIVER_DIR" ]]; then
-        if (cd "$RIVER_DIR" && timeout 60 cargo run -p riverctl -- message send "$ROOM_OWNER_VK" "$announcement" 2>/dev/null); then
+        if (cd "$RIVER_DIR" && RIVER_SKIP_CONTRACT_CHECK=1 timeout 180 cargo run -p riverctl -- message send "$ROOM_OWNER_VK" "$announcement" >"$RIVER_LOG" 2>&1); then
             echo "✓"
             mark_completed "RIVER_ANNOUNCED"
         else
+            local rc=$?
             echo "✗"
-            echo "  ⚠️  Failed to send River announcement (non-critical)"
-            echo "     Manual: cd $RIVER_DIR && cargo run -p riverctl -- message send $ROOM_OWNER_VK \"$announcement\""
+            echo "  ⚠️  Failed to send River announcement (non-critical, rc=$rc)"
+            echo "     Last log lines from $RIVER_LOG:"
+            tail -15 "$RIVER_LOG" 2>/dev/null | sed 's/^/       /'
+            echo "     Manual: cd $RIVER_DIR && RIVER_SKIP_CONTRACT_CHECK=1 cargo run -p riverctl -- message send $ROOM_OWNER_VK \"$announcement\""
         fi
     else
         echo "⚠️  River repo not found at $RIVER_DIR"
-        echo "     Manual: cd <river-repo> && cargo run -p riverctl -- message send $ROOM_OWNER_VK \"$announcement\""
+        echo "     Manual: cd <river-repo> && RIVER_SKIP_CONTRACT_CHECK=1 cargo run -p riverctl -- message send $ROOM_OWNER_VK \"$announcement\""
     fi
 }
 


### PR DESCRIPTION
## Problem

During the v0.2.42 release the River announcement step failed silently. The release script invokes \`cargo run -p riverctl\` from the river repo to post a chat message; riverctl's \`build.rs\` panics when its bundled \`room_contract.wasm\` differs from a freshly built \`target/wasm32.../release/room_contract.wasm\`. The staleness check is meaningful before *publishing* riverctl to crates.io, but the release script is only *running* riverctl locally to post a message.

Two things made this hard to diagnose:

1. The script invocation swallowed stderr with \`2>/dev/null\`, so the real error (\"room_contract.wasm is out of date. Run \`cargo make sync-cli-wasm\`\") never reached the release log. The operator saw only \`✗\` and a manual retry hint.
2. Even \`cargo make sync-cli-wasm\` does not reliably fix the drift in all workspace states: it copies \`ui/public/contracts/room_contract.wasm\` → \`cli/contracts/room_contract.wasm\`, but \`ui/public/\` itself can be stale relative to \`target/wasm32.../release/\`, so the build.rs check still panics on the subsequent \`cargo run\`. Manual recovery during v0.2.42 required \`RIVER_SKIP_CONTRACT_CHECK=1\` on the invocation.

## Solution

Set \`RIVER_SKIP_CONTRACT_CHECK=1\` in the riverctl invocation. riverctl's \`build.rs\` explicitly supports this env var as an escape hatch for \"I just want to run riverctl, I am not about to publish it.\" That is exactly the release script's use case.

Also:

- Stop swallowing stderr. Redirect to \`/tmp/release-\$VERSION-river.log\` and \`tail -15\` the log on failure so the operator sees the real error without having to reproduce by hand.
- Bump the \`cargo run\` timeout from 60s to 180s. Cold riverctl builds on a fresh checkout can exceed 60s (especially the first time after a workspace-wide clean), which would otherwise look like a \"timeout\" when the real error is a slow build.

## Testing

- Bash syntax check: \`bash -n scripts/release.sh\` ✓
- Manually reproduced the v0.2.42 failure with \`cargo run -p riverctl -- message send ...\` (panic at \`cli/build.rs:89\` with \"room_contract.wasm is out of date\").
- Confirmed that \`RIVER_SKIP_CONTRACT_CHECK=1 cargo run -p riverctl -- message send ...\` succeeds and posts the message to the Freenet Official room without any WASM fix-up.

## Fixes

Surfaced during the v0.2.42 release. No issue filed; this is the fix.

[AI-assisted - Claude]