### PR TITLE
build(release): restore FDEV_VERSION from state on resume

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -259,7 +259,12 @@ fi
 # State file for tracking progress (backup for manual inspection)
 STATE_FILE="/tmp/release-${VERSION}.state"
 
-# Get current fdev version and increment patch version
+# Provisional fdev version: bump the current Cargo.toml patch by one. On a
+# fresh run this is the target version. On a resume `load_state_file` will
+# overwrite FDEV_VERSION with the value persisted when the release PR was
+# created, so we never double-bump when the local Cargo.toml already reflects
+# the just-released version. See the v0.2.42 incident for the bug this guards
+# against: the summary printed 0.3.206, crates.io shipped 0.3.205.
 CURRENT_FDEV_VERSION=$(grep "^version" "$PROJECT_ROOT/crates/fdev/Cargo.toml" 2>/dev/null | cut -d'"' -f2)
 if [[ -n "$CURRENT_FDEV_VERSION" ]]; then
     FDEV_MAJOR=$(echo "$CURRENT_FDEV_VERSION" | cut -d. -f1)
@@ -302,6 +307,17 @@ load_state_file() {
             if [[ "$key" =~ ^COMPLETED_ ]]; then
                 local step="${key#COMPLETED_}"
                 COMPLETED_STEPS["$step"]=1
+            elif [[ "$key" == "FDEV_VERSION" && -n "$value" ]]; then
+                # Restore FDEV_VERSION from state so resumes after the release
+                # PR has already merged don't bump the already-published version
+                # a second time. Without this override, the top-level compute at
+                # script startup reads the just-released Cargo.toml value and
+                # adds 1, leaving the final summary printing a version that is
+                # one ahead of what actually shipped (v0.2.42 incident).
+                if [[ "$FDEV_VERSION" != "$value" ]]; then
+                    echo "  Restoring FDEV_VERSION from state: $value (was $FDEV_VERSION)"
+                    FDEV_VERSION="$value"
+                fi
             fi
         done < "$STATE_FILE"
     fi
@@ -1401,13 +1417,16 @@ if current_key != key_bytes:
 # Main execution
 echo "Freenet Release Script"
 echo "======================"
-echo "Target version: freenet $VERSION, fdev $FDEV_VERSION"
 echo "Project root: $PROJECT_ROOT"
 echo "State file: $STATE_FILE"
 echo
 
-# Auto-detect what's already completed
+# Auto-detect what's already completed. load_state_file runs inside
+# auto_detect_state and may restore FDEV_VERSION from a persisted value — so
+# the "Target version" line must be printed *after* that, not before.
 auto_detect_state
+echo
+echo "Target version: freenet $VERSION, fdev $FDEV_VERSION"
 echo
 
 check_prerequisites

--- a/scripts/release_state_restore_test.sh
+++ b/scripts/release_state_restore_test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Regression test for the FDEV_VERSION double-bump bug surfaced by the
+# v0.2.42 release (see build(release): restore FDEV_VERSION from state on
+# resume).
+#
+# The release script computes FDEV_VERSION at startup by reading the current
+# crates/fdev/Cargo.toml patch version and adding one. On a resume *after*
+# the release PR has merged and the operator has pulled main, the local
+# Cargo.toml already contains the just-released version, so the +1 produces
+# a value one patch ahead of what actually shipped. The fix is that
+# load_state_file restores FDEV_VERSION from the persisted state file,
+# overriding the tentative top-level compute.
+#
+# This test exercises the restore logic in isolation: it seeds a state file
+# with the correct FDEV_VERSION, clobbers the in-memory variable to the
+# buggy double-bumped value, invokes the restore logic, and asserts the
+# in-memory value is corrected back to the persisted one.
+#
+# Run manually with: bash scripts/release_state_restore_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE_SH="$SCRIPT_DIR/release.sh"
+
+if [[ ! -f "$RELEASE_SH" ]]; then
+    echo "FAIL: $RELEASE_SH not found" >&2
+    exit 1
+fi
+
+# Extract the load_state_file function from release.sh and source it into
+# this test script with the state file path we control. Keeping the test
+# self-contained means release.sh can stay a single file and does not need
+# to be refactored for testability.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+STATE_FILE="$TMP/release.state"
+declare -A COMPLETED_STEPS
+
+# Pull the function body verbatim from release.sh so the test is guaranteed
+# to exercise the real implementation, not a copy that can drift.
+eval "$(awk '/^load_state_file\(\) \{/,/^}/' "$RELEASE_SH")"
+
+test_restores_persisted_value() {
+    local name="$1" persisted="$2" tentative="$3" expected="$4"
+    cat > "$STATE_FILE" <<EOF
+# Release state for v0.2.42
+VERSION=0.2.42
+FDEV_VERSION=$persisted
+COMPLETED_PR_CREATED=1
+COMPLETED_PR_MERGED=1
+EOF
+    FDEV_VERSION="$tentative"
+    COMPLETED_STEPS=()
+    load_state_file > /dev/null
+    if [[ "$FDEV_VERSION" != "$expected" ]]; then
+        echo "FAIL [$name]: expected FDEV_VERSION=$expected, got $FDEV_VERSION" >&2
+        exit 1
+    fi
+    if [[ "${COMPLETED_STEPS[PR_CREATED]:-}" != "1" ]]; then
+        echo "FAIL [$name]: PR_CREATED not restored from state" >&2
+        exit 1
+    fi
+    if [[ "${COMPLETED_STEPS[PR_MERGED]:-}" != "1" ]]; then
+        echo "FAIL [$name]: PR_MERGED not restored from state" >&2
+        exit 1
+    fi
+    echo "PASS [$name]"
+}
+
+test_no_persisted_keeps_tentative() {
+    rm -f "$STATE_FILE"
+    FDEV_VERSION="0.3.205"
+    COMPLETED_STEPS=()
+    load_state_file > /dev/null
+    if [[ "$FDEV_VERSION" != "0.3.205" ]]; then
+        echo "FAIL [no state]: tentative should survive; got $FDEV_VERSION" >&2
+        exit 1
+    fi
+    echo "PASS [no state]"
+}
+
+# v0.2.42 regression: state has the correct 0.3.205, but the in-memory
+# variable has been double-bumped to 0.3.206 by the top-level compute
+# reading the post-merge Cargo.toml. Restore must win.
+test_restores_persisted_value "v0.2.42 regression" "0.3.205" "0.3.206" "0.3.205"
+
+# No-op case: persisted value matches tentative value, nothing to do.
+test_restores_persisted_value "matching values" "0.3.205" "0.3.205" "0.3.205"
+
+# Fresh run: no state file exists, tentative value must be used as-is.
+test_no_persisted_keeps_tentative
+
+echo "All tests passed."


### PR DESCRIPTION
## Problem

During the v0.2.42 release the final Summary line printed \`fdev 0.3.206\` while crates.io and the release tarball actually shipped \`0.3.205\`. Two follow-up debugging sessions traced the discrepancy to the script's tentative top-level \`FDEV_VERSION\` compute: it reads the current \`crates/fdev/Cargo.toml\` version and adds one every invocation.

On a resume *after* the release PR has merged and the operator has pulled main, the local \`Cargo.toml\` already contains the just-released fdev version, so the \`+1\` produces a value one patch ahead of what actually shipped. Every subsequent \`save_state\` call then overwrites the correct persisted \`FDEV_VERSION\` with the wrong in-memory value, leaving a state file that is internally consistent with the wrong answer.

## Solution

Make the state file authoritative for \`FDEV_VERSION\`. \`load_state_file\` now restores \`FDEV_VERSION\` from the persisted value when present, overriding the top-level tentative compute. The tentative compute remains the source of truth for fresh runs where no state exists yet; the first \`save_state\` after \`update_versions\` persists it; every subsequent resume reads it back verbatim.

Also reorder the \`Target version\` header line to print after \`auto_detect_state\` so it reflects the corrected value on resumes, not the pre-restore tentative value.

## Testing

Inline bash test that seeds a state file with \`FDEV_VERSION=0.3.205\`, clobbers the in-memory variable to the buggy \`0.3.206\`, invokes the new \`load_state_file\` logic, and asserts both \`FDEV_VERSION == 0.3.205\` and \`COMPLETED_STEPS[PR_CREATED] == 1\` are restored.

\`bash -n scripts/release.sh\` clean.

Correctness reasoning for the three cases:

- **Fresh run** (no state file): tentative compute wins, first \`save_state\` persists the correct value. No change in behavior.
- **Clean resume** (state file has correct FDEV_VERSION, local Cargo.toml still pre-merge): restore wins, matches the already-correct tentative value. No change in observable behavior.
- **Resume after PR merge + pull** (state file has correct FDEV_VERSION, local Cargo.toml now reflects the just-released version): tentative compute double-bumps, restore corrects it. This is the v0.2.42 case.

The v0.2.42 state file itself ended up corrupted because \`save_state\` wrote the wrong value *after* the double-bump. This is purely historical — v0.2.42 is complete, the corrupted state file was deleted as part of this change, and the fix prevents the same failure mode for 0.2.43+.

## Fixes

Surfaced during the v0.2.42 release; no issue filed.

[AI-assisted - Claude]