### PR TITLE
fix(server): route target=_blank cross-origin links through open_url bridge

### DIFF
--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1128,10 +1128,15 @@ const NAVIGATION_INTERCEPTOR_JS: &str = r#"
     // Skip links explicitly marked to bypass interception
     if (target.dataset && target.dataset.freenetNoIntercept) return;
     // Classify by origin. Cross-origin always goes through the open_url
-    // bridge — regardless of the `target` attribute — because a sandboxed
+    // bridge, regardless of the `target` attribute, because a sandboxed
     // popup would have a null origin and break CORS on the destination
     // (freenet/river#208).
-    var isCrossOrigin = false;
+    //
+    // Fail-safe default: if the origin comparison throws (pathological URLs
+    // that slipped past the protocol check above) we assume cross-origin,
+    // because the failure mode we are guarding against is a null-origin
+    // sandboxed popup, not an accidental in-contract navigation.
+    var isCrossOrigin = true;
     try {
       isCrossOrigin = target.origin !== location.origin;
     } catch(err) {}

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -1095,10 +1095,23 @@ const WEBSOCKET_SHIM_JS: &str = r#"
 /// JavaScript navigation interceptor injected into sandboxed iframe HTML pages.
 ///
 /// Intercepts clicks on `<a>` elements and sends a postMessage to the shell
-/// page, which updates the iframe's `src` to navigate within the contract.
-/// This enables multi-page website navigation without weakening the sandbox
-/// (no `allow-top-navigation` needed). Only intercepts same-origin relative
-/// links; external links are left to the existing `open_url` bridge.
+/// page, which either opens the URL in a new window (cross-origin) or updates
+/// the iframe's `src` (same-origin). This enables multi-page website
+/// navigation without weakening the sandbox (no `allow-top-navigation` nor
+/// `allow-popups-to-escape-sandbox` needed).
+///
+/// Cross-origin links MUST be handled regardless of their `target` attribute,
+/// because without `allow-popups-to-escape-sandbox` a `target="_blank"` click
+/// would open a sandboxed popup with a null origin and the destination site
+/// would see CORS failures. This was freenet/river#208: River webapps added
+/// `target="_blank"` to every external link, the old interceptor skipped any
+/// anchor with an explicit target, and the resulting sandboxed popups broke
+/// logged-in pages like GitHub. The `open_url` bridge hands the URL to the
+/// shell page, which opens it with a proper origin via `window.open`.
+///
+/// Same-origin links with an explicit non-`_self` target are left to the
+/// browser so webapps that legitimately want multi-tab navigation within
+/// their own contract still work.
 const NAVIGATION_INTERCEPTOR_JS: &str = r#"
 (function() {
   'use strict';
@@ -1107,8 +1120,6 @@ const NAVIGATION_INTERCEPTOR_JS: &str = r#"
     // Walk up to find the nearest <a> element (handles clicks on child elements)
     while (target && target.tagName !== 'A') target = target.parentElement;
     if (!target || !target.href) return;
-    // Skip links with explicit targets (e.g. target="_blank")
-    if (target.target && target.target !== '_self') return;
     // Skip javascript: and mailto: links
     var protocol = target.protocol;
     if (protocol && protocol !== 'http:' && protocol !== 'https:') return;
@@ -1116,16 +1127,24 @@ const NAVIGATION_INTERCEPTOR_JS: &str = r#"
     if (target.hasAttribute('download')) return;
     // Skip links explicitly marked to bypass interception
     if (target.dataset && target.dataset.freenetNoIntercept) return;
-    // For cross-origin links, use the open_url bridge instead
+    // Classify by origin. Cross-origin always goes through the open_url
+    // bridge — regardless of the `target` attribute — because a sandboxed
+    // popup would have a null origin and break CORS on the destination
+    // (freenet/river#208).
+    var isCrossOrigin = false;
     try {
-      if (target.origin !== location.origin) {
-        e.preventDefault();
-        window.parent.postMessage({
-          __freenet_shell__: true, type: 'open_url', url: target.href
-        }, '*');
-        return;
-      }
+      isCrossOrigin = target.origin !== location.origin;
     } catch(err) {}
+    if (isCrossOrigin) {
+      e.preventDefault();
+      window.parent.postMessage({
+        __freenet_shell__: true, type: 'open_url', url: target.href
+      }, '*');
+      return;
+    }
+    // Same-origin link. Respect explicit non-_self targets so webapps
+    // that open multiple tabs within their own contract still work.
+    if (target.target && target.target !== '_self') return;
     // Same-origin in-contract link: request navigation via shell
     e.preventDefault();
     window.parent.postMessage({
@@ -1854,15 +1873,61 @@ mod tests {
             NAVIGATION_INTERCEPTOR_JS.contains("type: 'open_url'"),
             "interceptor must route cross-origin links through open_url"
         );
-        // Skip links with target="_blank" etc.
+        // Same-origin links: must respect explicit non-_self target so
+        // webapps that open multiple tabs within their own contract still
+        // work.
         assert!(
             NAVIGATION_INTERCEPTOR_JS.contains("target.target"),
-            "interceptor must respect target attribute on links"
+            "interceptor must respect target attribute on same-origin links"
         );
         // Must walk up DOM to handle clicks on child elements of <a>
         assert!(
             NAVIGATION_INTERCEPTOR_JS.contains("target.parentElement"),
             "interceptor must walk up DOM to find <a> ancestor"
+        );
+    }
+
+    /// Regression test for freenet/river#208.
+    ///
+    /// River (and any other webapp) transforms links to include
+    /// `target="_blank"`. The original interceptor short-circuited on any
+    /// anchor with an explicit target, so cross-origin clicks fell through
+    /// to the browser. Without `allow-popups-to-escape-sandbox`, that
+    /// produced a sandboxed popup with a null origin, which broke CORS on
+    /// every external site (GitHub issues page reported by @lukors).
+    ///
+    /// Pin the contract: the cross-origin branch MUST be reached before
+    /// the target-attribute check, i.e. the origin classification dominates.
+    #[test]
+    fn navigation_interceptor_handles_cross_origin_target_blank() {
+        let js = NAVIGATION_INTERCEPTOR_JS;
+
+        // Anchor the cross-origin check and the target-attribute check and
+        // confirm the cross-origin check comes FIRST in the source order.
+        let cross_origin_idx = js
+            .find("target.origin !== location.origin")
+            .expect("cross-origin check present");
+        let target_attr_idx = js
+            .find("target.target && target.target !== '_self'")
+            .expect("target-attribute check present");
+        assert!(
+            cross_origin_idx < target_attr_idx,
+            "cross-origin classification must run before the target-attribute \
+             skip, otherwise target=\"_blank\" cross-origin links bypass the \
+             open_url bridge (freenet/river#208). cross_origin_idx={cross_origin_idx}, \
+             target_attr_idx={target_attr_idx}"
+        );
+
+        // The cross-origin branch must call preventDefault and send open_url,
+        // not navigate.
+        let cross_origin_block = &js[cross_origin_idx..target_attr_idx];
+        assert!(
+            cross_origin_block.contains("preventDefault"),
+            "cross-origin branch must preventDefault before opening popup"
+        );
+        assert!(
+            cross_origin_block.contains("type: 'open_url'"),
+            "cross-origin branch must send open_url, not navigate"
         );
     }
 


### PR DESCRIPTION
## Problem

@lukors reported in freenet/river#208 that following a link from a Freenet webapp to the regular web produced a flood of `Cross-Origin request blocked` errors and broke pages like GitHub's issues list:

> If I follow a link in River to a website on the regular web, I get a bunch of Cross-Origin errors in the console, and the website I land on does not work properly. For instance if I follow a link to a GitHub issue, and then click the "issues" link at the top of the page, the issues don't load.

Root cause: the sandboxed-iframe navigation interceptor in `crates/core/src/server/path_handlers.rs` skipped any anchor with an explicit non-`_self` target **before** checking whether the link was cross-origin:

```js
if (target.target && target.target !== '_self') return;   // ← short-circuit
...
if (target.origin !== location.origin) { ... open_url ... }
```

River (and any other Freenet webapp) rewrites external links to include `target="_blank"`, so every cross-origin click fell through the interceptor into the browser's default handling. Since #1499 removed `allow-popups-to-escape-sandbox` from the iframe sandbox, that default is a sandboxed popup with a null origin — which breaks CORS on the destination site.

## Approach

Reorder the classification so the origin check dominates:

1. Walk up to the anchor, sanity-check protocol/download/data-no-intercept.
2. **Compute origin.** If cross-origin → always `preventDefault` + `open_url` postMessage, regardless of the `target` attribute.
3. Only then: if same-origin and has an explicit non-`_self` target, let the browser handle it (multi-tab within a contract still works).
4. Otherwise same-origin in-contract navigation via `navigate` postMessage.

The shell page already opens `open_url` destinations via `window.open(url, '_blank', 'noopener')`, which gives the popup a proper (non-null) origin and makes CORS work normally.

This also means River doesn't need to stop emitting `target="_blank"`; the fix is pure server-side and every existing webapp benefits immediately.

## Testing

New unit test `navigation_interceptor_handles_cross_origin_target_blank` in `crates/core/src/server/path_handlers.rs`. It:
- locates the cross-origin check (`target.origin !== location.origin`) and the target-attribute skip (`target.target && target.target !== '_self'`) in the JS source,
- asserts the cross-origin check appears **first** in source order — pinning the contract and failing loudly if a future refactor reintroduces the bug,
- asserts the cross-origin branch contains `preventDefault` and `type: 'open_url'`.

```
cargo test -p freenet --lib server::path_handlers::tests::navigation
# 2 passed (existing + new regression test)
```

`cargo clippy -p freenet --lib -- -D warnings` clean.

### Why didn't CI catch this?

The existing `navigation_interceptor_js_intercepts_clicks` test only substring-checks for presence of various tokens; it didn't pin source ordering, so swapping the branches (the exact shape of this bug) would still pass. The new test closes that gap by asserting the cross-origin check precedes the target-attribute skip.

## Fixes

Closes freenet/river#208.

[AI-assisted - Claude]
