### PR TITLE
feat: check GitHub for updates on node startup

### DIFF
--- a/crates/core/src/bin/commands/auto_update.rs
+++ b/crates/core/src/bin/commands/auto_update.rs
@@ -285,6 +285,88 @@ pub fn has_reached_max_backoff() -> bool {
     get_current_backoff() >= MAX_BACKOFF
 }
 
+/// One-shot GitHub check performed at node startup, independent of peer signals.
+///
+/// Addresses the "offline-for-days transient peer" gap: a node that has been
+/// offline long enough to fall out of the compatible-version window cannot rely
+/// on a peer handshake to tell it to update, because handshakes with an
+/// incompatible peer may never complete successfully. The normal peer-signal
+/// driven update loop therefore never triggers.
+///
+/// This function asks GitHub directly whether a newer release exists. It is
+/// intentionally decoupled from the backoff / failure-count state used by the
+/// peer-signal loop: startup is a distinct one-shot event and should not
+/// interact with running-state backoff.
+///
+/// Fail-open: any error (GitHub unreachable, parse failure, etc.) returns
+/// `None` so the caller falls through to the normal update loop.
+///
+/// Returns `Some(latest_version_string)` only when GitHub confirms a strictly
+/// newer release than `current_version`. Never returns a downgrade.
+pub async fn startup_update_check(current_version: &str) -> Option<String> {
+    startup_update_check_with_fetcher(current_version, get_latest_version).await
+}
+
+/// Testable core of [`startup_update_check`]. The `fetcher` argument returns
+/// the latest version string as reported by the release source; tests inject a
+/// fake fetcher to avoid hitting GitHub.
+pub(crate) async fn startup_update_check_with_fetcher<F, Fut>(
+    current_version: &str,
+    fetcher: F,
+) -> Option<String>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<String>>,
+{
+    let latest = match fetcher().await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                "Startup update check: failed to fetch latest version: {}. \
+                 Continuing with current binary.",
+                e
+            );
+            return None;
+        }
+    };
+    compare_versions_for_startup(current_version, &latest)
+}
+
+/// Pure version comparison for the startup check.
+///
+/// Returns `Some(latest)` iff `latest` parses as semver strictly greater than
+/// `current`. Returns `None` on any parse failure (fail-open) or when the
+/// current binary is already at or ahead of the reported release.
+pub(crate) fn compare_versions_for_startup(current: &str, latest: &str) -> Option<String> {
+    let current_ver = match Version::parse(current) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "Startup update check: failed to parse current version '{}': {}",
+                current,
+                e
+            );
+            return None;
+        }
+    };
+    let latest_ver = match Version::parse(latest) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "Startup update check: failed to parse latest version '{}': {}",
+                latest,
+                e
+            );
+            return None;
+        }
+    };
+    if latest_ver > current_ver {
+        Some(latest.to_string())
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,6 +424,90 @@ mod tests {
         let msg = format!("{}", err);
         assert!(msg.contains("0.1.74"));
         assert!(msg.contains("auto-update"));
+    }
+
+    #[test]
+    fn test_compare_versions_newer_available() {
+        assert_eq!(
+            compare_versions_for_startup("0.1.74", "0.1.75"),
+            Some("0.1.75".to_string())
+        );
+        assert_eq!(
+            compare_versions_for_startup("0.1.74", "0.2.0"),
+            Some("0.2.0".to_string())
+        );
+        assert_eq!(
+            compare_versions_for_startup("0.1.74", "1.0.0"),
+            Some("1.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_compare_versions_already_current() {
+        assert_eq!(compare_versions_for_startup("0.1.75", "0.1.75"), None);
+    }
+
+    #[test]
+    fn test_compare_versions_never_downgrades() {
+        // GitHub reports an older version (e.g. tag rollback) — never downgrade.
+        assert_eq!(compare_versions_for_startup("0.2.0", "0.1.99"), None);
+        assert_eq!(compare_versions_for_startup("1.0.0", "0.9.99"), None);
+    }
+
+    #[test]
+    fn test_compare_versions_unparseable_fails_open() {
+        assert_eq!(
+            compare_versions_for_startup("not-a-version", "0.1.75"),
+            None
+        );
+        assert_eq!(compare_versions_for_startup("0.1.74", "also-garbage"), None);
+        assert_eq!(compare_versions_for_startup("", "0.1.75"), None);
+    }
+
+    #[test]
+    fn test_compare_versions_prerelease_semver_semantics() {
+        // semver: 0.1.75-alpha < 0.1.75, 0.1.75 > 0.1.75-alpha
+        assert_eq!(
+            compare_versions_for_startup("0.1.75-alpha", "0.1.75"),
+            Some("0.1.75".to_string())
+        );
+        assert_eq!(compare_versions_for_startup("0.1.75", "0.1.75-alpha"), None);
+    }
+
+    #[tokio::test]
+    async fn test_startup_check_fetcher_error_returns_none() {
+        // Fetcher failure must not propagate — startup check is fail-open so
+        // the node always boots even when GitHub is unreachable.
+        let result = startup_update_check_with_fetcher("0.1.74", || async {
+            anyhow::bail!("simulated network failure")
+        })
+        .await;
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_startup_check_finds_newer_version() {
+        let result =
+            startup_update_check_with_fetcher("0.1.74", || async { Ok("0.1.75".to_string()) })
+                .await;
+        assert_eq!(result, Some("0.1.75".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_startup_check_no_update_when_current() {
+        let result =
+            startup_update_check_with_fetcher("0.1.75", || async { Ok("0.1.75".to_string()) })
+                .await;
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_startup_check_refuses_downgrade() {
+        // A node running a newer (possibly pre-release) build must never be
+        // downgraded by the startup check, even if GitHub reports an older tag.
+        let result =
+            startup_update_check_with_fetcher("0.2.0", || async { Ok("0.1.99".to_string()) }).await;
+        assert_eq!(result, None);
     }
 
     #[test]

--- a/crates/core/src/bin/freenet.rs
+++ b/crates/core/src/bin/freenet.rs
@@ -128,7 +128,7 @@ async fn run_network_node_with_signals(
     use commands::auto_update::{
         UpdateCheckResult, UpdateNeededError, check_if_update_available, clear_version_mismatch,
         get_open_connection_count, has_reached_max_backoff, has_version_mismatch, reset_backoff,
-        version_mismatch_generation,
+        startup_update_check, version_mismatch_generation,
     };
     use freenet::transport::{clear_urgent_update, get_highest_seen_version, is_urgent_update};
     use tokio::signal;
@@ -218,6 +218,47 @@ async fn run_network_node_with_signals(
             std::future::pending::<()>().await;
             return;
         }
+
+        // --- Startup update check (#3864) ---
+        //
+        // Ask GitHub directly, once at boot, whether a newer release exists.
+        // This closes the "offline-for-days transient peer" gap where a node
+        // that has fallen out of the compatible-version window has no way to
+        // discover the new release via peer handshake (handshakes with an
+        // incompatible peer may never complete), so the peer-signal-driven
+        // update loop below never fires.
+        //
+        // Cross-platform: on Linux (systemd ExecStopPost), macOS (wrapper
+        // script), and Windows (wrapper loop), a successful update is
+        // propagated through `update_tx` → graceful shutdown → exit 42 →
+        // the service manager runs `freenet update --quiet` and restarts
+        // the freshly installed binary.
+        //
+        // Small jitter (0-60s) avoids a thundering-herd GitHub API hit when
+        // many nodes restart together (e.g. post-outage). Jitter lives in
+        // the caller so the helper stays pure and unit-testable.
+        //
+        // Fail-open: any GitHub / parse error returns None and the node
+        // continues booting normally into the peer-signal loop below.
+        let startup_jitter_secs = freenet::config::GlobalRng::random_u64() % 60;
+        if startup_jitter_secs > 0 {
+            tokio::time::sleep(std::time::Duration::from_secs(startup_jitter_secs)).await;
+        }
+        tracing::info!(
+            current = build_info::VERSION,
+            jitter_secs = startup_jitter_secs,
+            "Startup update check against GitHub"
+        );
+        if let Some(new_version) = startup_update_check(build_info::VERSION).await {
+            tracing::info!(
+                new_version = %new_version,
+                "Startup check: newer version on GitHub, triggering auto-update"
+            );
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = update_tx.send(new_version);
+            return;
+        }
+        tracing::debug!("Startup update check: no newer version found");
 
         /// Parse our version string into a (major, minor, patch) tuple for comparison.
         fn parse_our_version() -> Option<(u8, u8, u16)> {


### PR DESCRIPTION
## Problem

Transient peers (especially on Windows) that resume after being offline long enough to fall out of the compatible-version window have no way to auto-update, because **every** existing update trigger requires a successful peer handshake first:

1. **Urgent update** — needs the remote's `min_compatible` from a handshake
2. **Decentralized discovery** — needs `highest_seen_version` from a handshake
3. **Legacy mismatch fallback** — needs `has_version_mismatch` from a handshake

If the handshake itself fails (incompatible peer, unreachable gateway), the node sits on the old binary forever. Users have reported that Windows transient nodes resumed after multi-day downtime need `freenet update` to be run manually to unstick them — which defeats the purpose of having auto-update.

## Approach

Add a one-shot GitHub check at node startup, independent of peer signals. On finding a newer release it pushes the new version string through the existing `update_tx` channel, which triggers graceful shutdown and exit code 42.

Exit-42 restart is **already** wired on every supported platform, so no platform-specific plumbing is needed for this fix:

| Platform | Exit-42 handler |
|----------|-----------------|
| Linux    | systemd `ExecStopPost` runs `freenet update --quiet` |
| macOS    | `freenet-service-wrapper.sh` handles exit 42 |
| Windows  | `run-wrapper` loop (`service.rs`) handles exit 42 |

Design notes:

- **Decoupled from the peer-signal backoff state.** Startup is a distinct one-shot event — it should not touch or be throttled by the running-state backoff / failure-count used by the peer-signal loop. The helper calls GitHub directly and bypasses the backoff marker file.
- **Fail-open.** Any GitHub fetch or parse error returns `None` so the node always boots and falls through to the normal peer-signal-driven loop below.
- **Dirty-build guard still applies.** The existing dev/dirty-build check at the top of `update_check_task` prevents auto-update from clobbering locally-modified builds.
- **Downgrade-safe.** Only triggers when `latest > current`. Never downgrades, even if GitHub reports an older tag.
- **Thundering-herd jitter.** A 0–60s random delay before the check avoids a simultaneous GitHub API hit when many nodes restart together (e.g. post-outage). GitHub's unauthenticated limit is 60 req/hr/IP, which is comfortable with jitter.

I am a bit reluctant to rely on a centralised check for a decentralised project, but the reality is that our release distribution is already centralised on GitHub — so declining to poll it on startup is cutting off our nose despite our face.

## Testing

New unit tests in `auto_update.rs`, exercising the pure comparison helper and the fetcher-injected startup-check wrapper (no network access):

- `test_compare_versions_newer_available` — three cases (patch, minor, major bumps)
- `test_compare_versions_already_current`
- `test_compare_versions_never_downgrades` — explicit downgrade-refusal
- `test_compare_versions_unparseable_fails_open` — garbage in either position
- `test_compare_versions_prerelease_semver_semantics` — `0.1.75-alpha < 0.1.75`
- `test_startup_check_finds_newer_version`
- `test_startup_check_no_update_when_current`
- `test_startup_check_refuses_downgrade`
- `test_startup_check_fetcher_error_returns_none` — GitHub-unreachable path

Local validation:

- `cargo fmt`
- `cargo clippy -p freenet --bin freenet -- -D warnings` — clean
- `cargo test -p freenet --bin freenet auto_update` — 14 pass

## Why didn't CI catch this?

There is no CI test that simulates a node booting with a stale version and no reachable peers — the existing tests all exercise the peer-signal-driven path. The gap here isn't a logic error in tested code; it's a missing trigger. The added unit tests cover the new path and the core comparison / downgrade / parse-error logic. A fuller integration test would require mocking the GitHub API in a CI environment, which is worth considering in follow-up but is out of scope for this fix.

## Fixes

User-reported: transient Windows peers don't self-update after multi-day downtime, require manual `freenet update`.

[AI-assisted - Claude]