### PR TITLE
fix: route initial subscribe Request to home node via OpCtx target

### DIFF
--- a/crates/core/src/contract/storages/sqlite.rs
+++ b/crates/core/src/contract/storages/sqlite.rs
@@ -72,11 +72,13 @@ async fn create_hosting_metadata_table(pool: &SqlitePool) -> Result<(), SqlDbErr
     // Migrate existing databases: add local_client_access column if missing.
     // CREATE TABLE IF NOT EXISTS won't alter an existing table's schema.
     // Ignore the error if the column already exists.
-    let _ = sqlx::query(
-        "ALTER TABLE hosting_metadata ADD COLUMN local_client_access INTEGER NOT NULL DEFAULT 0",
-    )
-    .execute(pool)
-    .await;
+    drop(
+        sqlx::query(
+            "ALTER TABLE hosting_metadata ADD COLUMN local_client_access INTEGER NOT NULL DEFAULT 0",
+        )
+        .execute(pool)
+        .await,
+    );
 
     Ok(())
 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -56,7 +56,9 @@ use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 
 use crate::operations::handle_op_request;
-pub(crate) use network_bridge::{ConnectionError, EventLoopNotificationsSender, NetworkBridge};
+pub(crate) use network_bridge::{
+    ConnectionError, EventLoopNotificationsSender, NetworkBridge, OpExecutionPayload,
+};
 #[cfg(test)]
 pub(crate) use network_bridge::{EventLoopNotificationsReceiver, event_loop_notification_channel};
 // Re-export types for dev_tool and testing

--- a/crates/core/src/node/network_bridge.rs
+++ b/crates/core/src/node/network_bridge.rs
@@ -181,15 +181,31 @@ pub(crate) fn event_loop_notification_channel()
     )
 }
 
+/// Payload shared between [`EventLoopNotificationsSender::op_execution_sender`]
+/// and the event loop's `handle_op_execution` receiver.
+///
+/// `target_addr` carries the peer the driver wants the Request to reach on
+/// the wire. When `Some`, `handle_op_execution` emits
+/// [`ConnEvent::OutboundMessageWithTarget`] so the message is dispatched
+/// directly to that peer's connection. When `None`, the message loops back
+/// as a local [`ConnEvent::InboundMessage`] (the original Phase 2b behavior,
+/// used by non-routed call sites and tests).
+///
+/// The target-aware path was added for issue #3838: when a client-initiated
+/// SUBSCRIBE has the contract cached locally, the loop-back `InboundMessage`
+/// was short-circuiting in `process_message` instead of propagating upstream
+/// to register as a downstream subscriber on the home node.
+pub(crate) type OpExecutionPayload = (Sender<NetMessage>, NetMessage, Option<SocketAddr>);
+
 pub(crate) struct EventLoopNotificationsReceiver {
     pub(crate) notifications_receiver: Receiver<Either<NetMessage, NodeEvent>>,
-    pub(crate) op_execution_receiver: Receiver<(Sender<NetMessage>, NetMessage)>,
+    pub(crate) op_execution_receiver: Receiver<OpExecutionPayload>,
 }
 
 #[derive(Clone)]
 pub(crate) struct EventLoopNotificationsSender {
     pub(crate) notifications_sender: Sender<Either<NetMessage, NodeEvent>>,
-    pub(crate) op_execution_sender: Sender<(Sender<NetMessage>, NetMessage)>,
+    pub(crate) op_execution_sender: Sender<OpExecutionPayload>,
 }
 
 impl EventLoopNotificationsSender {

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -3860,17 +3860,31 @@ impl P2pConnManager {
 
     fn handle_op_execution(
         &self,
-        msg: Option<(Sender<NetMessage>, NetMessage)>,
+        msg: Option<super::OpExecutionPayload>,
         state: &mut EventListenerState,
     ) -> EventResult {
         match msg {
-            Some((callback, msg)) => {
+            Some((callback, msg, target_addr)) => {
                 state.pending_op_results.insert(*msg.id(), callback);
                 crate::config::GlobalTestMetrics::record_pending_op_insert();
                 crate::config::GlobalTestMetrics::record_pending_op_size(
                     state.pending_op_results.len() as u64,
                 );
-                EventResult::Event(ConnEvent::InboundMessage(msg.into()).into())
+                // When the driver supplied an explicit target, dispatch the
+                // message to that peer over the network instead of looping it
+                // back as a local InboundMessage. The reply still flows back
+                // through the `pending_op_results` callback we just inserted.
+                //
+                // This is the load-bearing branch for issue #3838:
+                // client-initiated SUBSCRIBE with the contract cached locally
+                // would otherwise short-circuit in `process_message` and never
+                // register as a downstream subscriber on the home node.
+                match target_addr {
+                    Some(target_addr) => EventResult::Event(
+                        ConnEvent::OutboundMessageWithTarget { target_addr, msg }.into(),
+                    ),
+                    None => EventResult::Event(ConnEvent::InboundMessage(msg.into()).into()),
+                }
             }
             None => {
                 EventResult::Event(ConnEvent::ClosedChannel(ChannelCloseReason::OpExecution).into())

--- a/crates/core/src/node/network_bridge/priority_select.rs
+++ b/crates/core/src/node/network_bridge/priority_select.rs
@@ -10,6 +10,7 @@ use tokio::sync::mpsc::Receiver;
 use crate::client_events::ClientId;
 use crate::contract::WaitingTransaction;
 
+use super::OpExecutionPayload;
 use super::p2p_protoc::ConnEvent;
 use crate::contract::{
     ContractHandlerChannel, ExecutorToEventLoopChannel, NetworkEventListenerHalve,
@@ -24,7 +25,7 @@ pub(crate) use super::p2p_protoc::P2pBridgeEvent;
 #[derive(Debug)]
 pub(super) enum SelectResult {
     Notification(Option<Either<NetMessage, NodeEvent>>),
-    OpExecution(Option<(tokio::sync::mpsc::Sender<NetMessage>, NetMessage)>),
+    OpExecution(Option<OpExecutionPayload>),
     PeerConnection(Option<ConnEvent>),
     ConnBridge(Option<P2pBridgeEvent>),
     Handshake(Option<crate::node::network_bridge::handshake::Event>),
@@ -60,8 +61,7 @@ where
 {
     // Streams created from owned receivers
     notification: tokio_stream::wrappers::ReceiverStream<Either<NetMessage, NodeEvent>>,
-    op_execution:
-        tokio_stream::wrappers::ReceiverStream<(tokio::sync::mpsc::Sender<NetMessage>, NetMessage)>,
+    op_execution: tokio_stream::wrappers::ReceiverStream<OpExecutionPayload>,
     conn_bridge: tokio_stream::wrappers::ReceiverStream<P2pBridgeEvent>,
     node_controller: tokio_stream::wrappers::ReceiverStream<NodeEvent>,
     conn_events: tokio_stream::wrappers::ReceiverStream<ConnEvent>,
@@ -101,7 +101,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         notification_rx: Receiver<Either<NetMessage, NodeEvent>>,
-        op_execution_rx: Receiver<(tokio::sync::mpsc::Sender<NetMessage>, NetMessage)>,
+        op_execution_rx: Receiver<OpExecutionPayload>,
         conn_bridge_rx: Receiver<P2pBridgeEvent>,
         handshake_handler: H,
         node_controller: Receiver<NodeEvent>,

--- a/crates/core/src/node/network_bridge/priority_select/tests.rs
+++ b/crates/core/src/node/network_bridge/priority_select/tests.rs
@@ -86,7 +86,7 @@ impl Stream for MockExecutorReceiverStream {
 #[test_log::test]
 async fn test_priority_select_future_wakeup() {
     let (notif_tx, notif_rx) = mpsc::channel(10);
-    let (_op_tx, op_rx) = mpsc::channel(10);
+    let (_op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(10);
     let (_conn_event_tx, conn_event_rx) = mpsc::channel(10);
     let (_bridge_tx, bridge_rx) = mpsc::channel(10);
     let (_node_tx, node_rx) = mpsc::channel(10);
@@ -141,7 +141,7 @@ async fn test_priority_select_future_wakeup() {
 #[test_log::test]
 async fn test_priority_select_future_priority_ordering() {
     let (notif_tx, notif_rx) = mpsc::channel(10);
-    let (op_tx, op_rx) = mpsc::channel(10);
+    let (op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(10);
     let (_conn_event_tx, conn_event_rx) = mpsc::channel(10);
     let (bridge_tx, bridge_rx) = mpsc::channel(10);
     let (_, node_rx) = mpsc::channel(10);
@@ -151,7 +151,10 @@ async fn test_priority_select_future_priority_ordering() {
     let dummy_msg = NetMessage::V1(crate::message::NetMessageV1::Aborted(
         crate::message::Transaction::new::<crate::operations::put::PutMsg>(),
     ));
-    op_tx.send((callback_tx, dummy_msg.clone())).await.unwrap();
+    op_tx
+        .send((callback_tx, dummy_msg.clone(), None))
+        .await
+        .unwrap();
     bridge_tx
         .send(P2pBridgeEvent::NodeAction(NodeEvent::Disconnect {
             cause: None,
@@ -356,7 +359,7 @@ async fn test_priority_select_event_loop_simulation() {
 
     // Create channels once (like in wait_for_event)
     let (notif_tx, notif_rx) = mpsc::channel::<Either<NetMessage, NodeEvent>>(10);
-    let (op_tx, op_rx) = mpsc::channel::<(tokio::sync::mpsc::Sender<NetMessage>, NetMessage)>(10);
+    let (op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(10);
     let (_conn_event_tx, conn_event_rx) = mpsc::channel(10);
     let (bridge_tx, bridge_rx) = mpsc::channel::<P2pBridgeEvent>(10);
     let (node_tx, node_rx) = mpsc::channel::<NodeEvent>(10);
@@ -385,7 +388,10 @@ async fn test_priority_select_event_loop_simulation() {
             ));
             let (callback_tx, _) = mpsc::channel(1);
             tracing::info!("Sending op_execution {}", i);
-            op_tx_clone.send((callback_tx, test_msg)).await.unwrap();
+            op_tx_clone
+                .send((callback_tx, test_msg, None))
+                .await
+                .unwrap();
         }
 
         // Send 2 bridge events
@@ -605,7 +611,7 @@ async fn test_with_seed(seed: u64) {
 
     // Create channels once (like in wait_for_event)
     let (notif_tx, notif_rx) = mpsc::channel::<Either<NetMessage, NodeEvent>>(100);
-    let (op_tx, op_rx) = mpsc::channel::<(tokio::sync::mpsc::Sender<NetMessage>, NetMessage)>(100);
+    let (op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(100);
     let (_conn_event_tx, conn_event_rx) = mpsc::channel(100);
     let (bridge_tx, bridge_rx) = mpsc::channel::<P2pBridgeEvent>(100);
     let (node_tx, node_rx) = mpsc::channel::<NodeEvent>(100);
@@ -651,7 +657,7 @@ async fn test_with_seed(seed: u64) {
                 i,
                 delay_us
             );
-            op_tx.send((callback_tx, test_msg)).await.unwrap();
+            op_tx.send((callback_tx, test_msg, None)).await.unwrap();
         }
         tracing::info!("OpExecution task sent all {} messages", OP_COUNT);
         OP_COUNT
@@ -991,7 +997,7 @@ async fn test_priority_select_all_pending_waker_registration() {
 
     // Create all 8 channels
     let (notif_tx, notif_rx) = mpsc::channel::<Either<NetMessage, NodeEvent>>(10);
-    let (op_tx, op_rx) = mpsc::channel::<(tokio::sync::mpsc::Sender<NetMessage>, NetMessage)>(10);
+    let (op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(10);
     let (_conn_event_tx, conn_event_rx) = mpsc::channel(10);
     let (bridge_tx, bridge_rx) = mpsc::channel::<P2pBridgeEvent>(10);
     let (node_tx, node_rx) = mpsc::channel::<NodeEvent>(10);
@@ -1040,7 +1046,10 @@ async fn test_priority_select_all_pending_waker_registration() {
             crate::message::Transaction::new::<crate::operations::put::PutMsg>(),
         ));
         let (callback_tx, _) = mpsc::channel(1);
-        op_tx.send((callback_tx, test_msg.clone())).await.unwrap();
+        op_tx
+            .send((callback_tx, test_msg.clone(), None))
+            .await
+            .unwrap();
 
         tracing::info!("Sending to notification channel (highest priority)");
         notif_tx.send(Either::Left(test_msg)).await.unwrap();
@@ -1764,7 +1773,7 @@ async fn test_waker_registration_after_pending_poll() {
     let (tx, rx) = mpsc::channel::<Either<NetMessage, NodeEvent>>(10);
     let (_conn_event_tx, conn_event_rx) = mpsc::channel(10);
     // Keep senders alive to prevent channel closure
-    let (op_tx, op_rx) = mpsc::channel(10);
+    let (op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(10);
     let (bridge_tx, bridge_rx) = mpsc::channel(10);
     let (node_tx, node_rx) = mpsc::channel(10);
 
@@ -1832,7 +1841,7 @@ async fn test_waker_survives_multiple_pending_polls() {
     let (tx, rx) = mpsc::channel::<Either<NetMessage, NodeEvent>>(10);
     let (_conn_event_tx, conn_event_rx) = mpsc::channel(10);
     // Keep senders alive to prevent channel closure
-    let (op_tx, op_rx) = mpsc::channel(10);
+    let (op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(10);
     let (bridge_tx, bridge_rx) = mpsc::channel(10);
     let (node_tx, node_rx) = mpsc::channel(10);
 
@@ -1898,7 +1907,7 @@ async fn test_waker_survives_multiple_pending_polls() {
 #[test_log::test]
 async fn test_closed_handshake_stream_no_spin() {
     let (notif_tx, notif_rx) = mpsc::channel(10);
-    let (_op_tx, op_rx) = mpsc::channel(10);
+    let (_op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(10);
     let (_conn_event_tx, conn_event_rx) = mpsc::channel(10);
     let (_bridge_tx, bridge_rx) = mpsc::channel(10);
     let (_node_tx, node_rx) = mpsc::channel(10);
@@ -2595,7 +2604,7 @@ async fn test_handshake_p2_before_op_execution_p3() {
     // Handshake (P2) and op_execution (P3) both have one event ready.
     // Handshake should be returned first.
     let (_, notif_rx) = mpsc::channel(1);
-    let (op_tx, op_rx) = mpsc::channel(1);
+    let (op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(1);
     let (_, conn_event_rx) = mpsc::channel(1);
     let (_, bridge_rx) = mpsc::channel(1);
     let (_, node_rx) = mpsc::channel(1);
@@ -2606,7 +2615,7 @@ async fn test_handshake_p2_before_op_execution_p3() {
         crate::message::Transaction::new::<crate::operations::put::PutMsg>(),
     ));
     let (callback_tx, _) = mpsc::channel(1);
-    op_tx.send((callback_tx, dummy_msg)).await.unwrap();
+    op_tx.send((callback_tx, dummy_msg, None)).await.unwrap();
 
     drop(hs_tx);
     drop(op_tx);
@@ -2723,7 +2732,7 @@ async fn run_prefilled_stream(
     }
 
     let (notif_tx, notif_rx) = mpsc::channel(n_notif.max(1));
-    let (op_tx, op_rx) = mpsc::channel(n_op.max(1));
+    let (op_tx, op_rx) = mpsc::channel::<OpExecutionPayload>(n_op.max(1));
     let (_, conn_event_rx) = mpsc::channel(1);
     let (bridge_tx, bridge_rx) = mpsc::channel(n_bridge.max(1));
     let (node_tx, node_rx) = mpsc::channel(n_node.max(1));
@@ -2738,7 +2747,7 @@ async fn run_prefilled_stream(
             crate::message::Transaction::new::<crate::operations::put::PutMsg>(),
         ));
         let (cb, _) = mpsc::channel(1);
-        op_tx.send((cb, msg)).await.unwrap();
+        op_tx.send((cb, msg, None)).await.unwrap();
     }
     for _ in 0..n_bridge {
         bridge_tx

--- a/crates/core/src/operations/op_ctx.rs
+++ b/crates/core/src/operations/op_ctx.rs
@@ -7,9 +7,12 @@
 //! [`crate::operations::subscribe::start_client_subscribe`]) so the
 //! `#[allow(dead_code)]` attributes from Phase 2a have been lifted.
 
+use std::net::SocketAddr;
+
 use tokio::sync::mpsc;
 
 use crate::message::{MessageStats, NetMessage, Transaction};
+use crate::node::OpExecutionPayload;
 use crate::operations::OpError;
 
 /// Per-transaction execution context for the task-per-tx model (#1454).
@@ -30,7 +33,7 @@ use crate::operations::OpError;
 /// [`crate::operations::subscribe::start_client_subscribe`]).
 pub(crate) struct OpCtx {
     tx: Transaction,
-    op_execution_sender: mpsc::Sender<(mpsc::Sender<NetMessage>, NetMessage)>,
+    op_execution_sender: mpsc::Sender<OpExecutionPayload>,
 }
 
 impl OpCtx {
@@ -40,7 +43,7 @@ impl OpCtx {
     /// [`crate::node::OpManager::op_ctx`] and the in-module tests.
     pub(crate) fn new(
         tx: Transaction,
-        op_execution_sender: mpsc::Sender<(mpsc::Sender<NetMessage>, NetMessage)>,
+        op_execution_sender: mpsc::Sender<OpExecutionPayload>,
     ) -> Self {
         Self {
             tx,
@@ -148,7 +151,41 @@ impl OpCtx {
     /// Returns [`OpError::NotificationError`] if the executor channel is
     /// closed (send failure) or the reply receiver is dropped (receiver
     /// hang-up). Both indicate the round-trip could not complete.
+    #[allow(dead_code)] // Kept as stable API surface for later task-per-tx phases (#1454).
     pub async fn send_and_await(&mut self, msg: NetMessage) -> Result<NetMessage, OpError> {
+        self.send_and_await_inner(msg, None).await
+    }
+
+    /// Like [`Self::send_and_await`] but dispatches the message directly to
+    /// `target_addr` over the network instead of looping it back to the local
+    /// event loop as an `InboundMessage`.
+    ///
+    /// This is the load-bearing variant for ops that need their first hop to
+    /// reach a remote peer even when local processing of the same message
+    /// would short-circuit. The motivating case is client-initiated SUBSCRIBE
+    /// when the contract is already cached locally (#3838): looping the
+    /// `Subscribe::Request` back through `process_message` hits the
+    /// "originator has contract locally" branch and synthesizes a success
+    /// reply without the gateway ever seeing the request, so the home node
+    /// never learns we want updates. By emitting
+    /// [`crate::node::network_bridge::p2p_protoc::ConnEvent::OutboundMessageWithTarget`]
+    /// instead, the request reaches the home node and triggers
+    /// `register_downstream_subscriber` there. The reply still flows back via
+    /// the same `pending_op_results` callback registered by
+    /// `handle_op_execution`.
+    pub async fn send_to_and_await(
+        &mut self,
+        target_addr: SocketAddr,
+        msg: NetMessage,
+    ) -> Result<NetMessage, OpError> {
+        self.send_and_await_inner(msg, Some(target_addr)).await
+    }
+
+    async fn send_and_await_inner(
+        &mut self,
+        msg: NetMessage,
+        target_addr: Option<SocketAddr>,
+    ) -> Result<NetMessage, OpError> {
         debug_assert_eq!(
             msg.id(),
             &self.tx,
@@ -158,7 +195,7 @@ impl OpCtx {
         let (response_sender, mut response_receiver) = mpsc::channel::<NetMessage>(1);
 
         self.op_execution_sender
-            .send((response_sender, msg))
+            .send((response_sender, msg, target_addr))
             .await
             .map_err(|_| OpError::NotificationError)?;
 
@@ -233,11 +270,15 @@ mod tests {
         // Executor task: receive the outbound message and fire a synthetic
         // terminal reply keyed by the same tx.
         let executor = tokio::spawn(async move {
-            let (reply_sender, outbound) = op_execution_receiver
+            let (reply_sender, outbound, target_addr) = op_execution_receiver
                 .recv()
                 .await
                 .expect("outbound msg should be delivered");
             assert_eq!(outbound.id(), &tx, "outbound msg tx must match the ctx tx");
+            assert_eq!(
+                target_addr, None,
+                "send_and_await should not specify a target"
+            );
             reply_sender
                 .try_send(dummy_reply_with_tx(tx))
                 .expect("capacity-1 reply channel should accept the first send");
@@ -248,6 +289,70 @@ mod tests {
             .await
             .expect("send_and_await should complete quickly")
             .expect("send_and_await should return Ok");
+
+        assert_eq!(reply.id(), &tx, "reply tx must match ctx tx");
+
+        executor
+            .await
+            .expect("executor task should complete without panicking");
+    }
+
+    /// Regression for #3838. `send_to_and_await` MUST forward the
+    /// caller-provided target address through the op execution channel so
+    /// `handle_op_execution` can dispatch to that peer via
+    /// `OutboundMessageWithTarget` instead of looping the message back as a
+    /// local `InboundMessage`. The local-loop variant short-circuits in
+    /// `process_message` when the contract is cached locally, which is how
+    /// `test_ping_blocked_peers` was failing in the merge queue: the
+    /// gateway never saw the Subscribe Request, so it never registered the
+    /// node as a downstream subscriber, so UPDATE broadcasts never reached
+    /// it.
+    ///
+    /// This test asserts the channel-level invariant. The full integration
+    /// path (Request reaching the gateway, gateway responding, reply
+    /// classification) is covered by `test_ping_blocked_peers`, but that
+    /// test takes ~30 s to run; this one runs in milliseconds and pins the
+    /// contract so a regression that drops the target on the floor would
+    /// fail here first.
+    #[tokio::test]
+    async fn send_to_and_await_forwards_target_address() {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        let (receiver, sender) = event_loop_notification_channel();
+        let EventLoopNotificationsReceiver {
+            mut op_execution_receiver,
+            ..
+        } = receiver;
+
+        let tx = Transaction::new::<ConnectMsg>();
+        let mut ctx = OpCtx::new(tx, sender.op_execution_sender.clone());
+        let expected_target = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 42)), 31337);
+
+        let executor = tokio::spawn(async move {
+            let (reply_sender, outbound, target_addr) = op_execution_receiver
+                .recv()
+                .await
+                .expect("outbound msg should be delivered");
+            assert_eq!(outbound.id(), &tx, "outbound msg tx must match the ctx tx");
+            assert_eq!(
+                target_addr,
+                Some(expected_target),
+                "send_to_and_await must propagate the caller's target address \
+                 through the op execution channel (regression for #3838)"
+            );
+            reply_sender
+                .try_send(dummy_reply_with_tx(tx))
+                .expect("capacity-1 reply channel should accept the first send");
+        });
+
+        let outbound = dummy_reply_with_tx(tx);
+        let reply = timeout(
+            Duration::from_secs(1),
+            ctx.send_to_and_await(expected_target, outbound),
+        )
+        .await
+        .expect("send_to_and_await should complete quickly")
+        .expect("send_to_and_await should return Ok");
 
         assert_eq!(reply.id(), &tx, "reply tx must match ctx tx");
 
@@ -271,7 +376,7 @@ mod tests {
         // without firing anything. The caller must observe the hang-up as
         // `NotificationError`.
         let executor = tokio::spawn(async move {
-            let (reply_sender, _outbound) = op_execution_receiver
+            let (reply_sender, _outbound, _target_addr) = op_execution_receiver
                 .recv()
                 .await
                 .expect("outbound msg should be delivered");
@@ -367,7 +472,7 @@ mod tests {
         let executor = tokio::spawn(async move {
             // First outbound: fire the terminal reply and let the first
             // `send_and_await` resolve normally.
-            let (reply_sender_1, _first) = op_execution_receiver
+            let (reply_sender_1, _first, _target_addr_1) = op_execution_receiver
                 .recv()
                 .await
                 .expect("first outbound delivered");
@@ -383,7 +488,7 @@ mod tests {
             // `completed` set), so the reply channel simply never
             // produces a message or closes. From `send_and_await`'s
             // viewpoint this is indistinguishable from a hang.
-            let (reply_sender_2, _second) = op_execution_receiver
+            let (reply_sender_2, _second, _target_addr_2) = op_execution_receiver
                 .recv()
                 .await
                 .expect("second outbound delivered");

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -314,10 +314,20 @@ async fn drive_client_subscribe_inner(
             is_renewal: false,
         };
 
+        // Dispatch via `send_to_and_await` so the Request reaches `current_target_addr`
+        // on the wire instead of looping back to `process_message` as a local
+        // `InboundMessage`. The local short-circuit would synthesize a success
+        // reply when the contract is cached locally (e.g., after a prior GET),
+        // but the home node would never see the request and never register us
+        // as a downstream subscriber — so subsequent UPDATE broadcasts would
+        // never reach this peer. See issue #3838 and the doc comment on
+        // `OpCtx::send_to_and_await`.
         let mut ctx = op_manager.op_ctx(attempt_tx);
-        let round_trip =
-            tokio::time::timeout(OPERATION_TTL, ctx.send_and_await(NetMessage::from(request)))
-                .await;
+        let round_trip = tokio::time::timeout(
+            OPERATION_TTL,
+            ctx.send_to_and_await(current_target_addr, NetMessage::from(request)),
+        )
+        .await;
 
         // Release the per-attempt `pending_op_results` slot before any
         // retry or return. Without this emission entries would only be
@@ -445,6 +455,21 @@ async fn drive_client_subscribe_inner(
                     outcome = "subscribed",
                     "subscribe (task-per-tx): subscribed"
                 );
+                // Mirror the legacy Response-handler side effects from
+                // `subscribe.rs`'s `SubscribeMsg::Response` arm. The
+                // task-per-tx reply forwarding bypass in `node.rs` skips
+                // `handle_op_request` for terminal Responses, so without
+                // these calls the local interest manager and ring would
+                // never learn about the subscription, breaking
+                // ChangeInterests-driven update propagation. Both calls are
+                // idempotent for repeat subscribes.
+                op_manager.ring.subscribe(key);
+                op_manager.ring.complete_subscription_request(&key, true);
+                let became_interested = op_manager.interest_manager.add_local_client(&key);
+                if became_interested {
+                    crate::operations::broadcast_change_interests(op_manager, vec![key], vec![])
+                        .await;
+                }
                 return Ok(DriverOutcome::Publish(Ok(HostResponse::ContractResponse(
                     ContractResponse::SubscribeResponse {
                         key,


### PR DESCRIPTION
## Problem

`test_ping_blocked_peers` (`freenet-ping-app::run_app_blocked_peers`) is flaky in the merge queue. PR #3837 hit it for an unrelated shell-page change, all 3 nextest retries failed, and the failure pattern matches what #2254 and #3490 tried to address. Locally the test fails in ~280 s (full timeout) on a fresh build.

The failure is asymmetric: gateway and one client node end with all three tags, but the other client node has only its own. In ~2/3 of failures it's Node2 stuck, ~1/3 Node1.

## Root cause

The Phase 2b task-per-tx subscribe driver (`op_ctx_task`, PR #3806, #1454) was dispatching its initial Request through `OpCtx::send_and_await`, which routes via `op_execution_sender` and loops the message back to the local event loop as an `InboundMessage` with `source_addr = None`.

Both client nodes had just done a GET, so the contract was cached locally. When `process_message` ran on the loop-back, it took the `requester_addr.is_none() && has_contract` branch at `subscribe.rs:1417` ("Subscribe completed (originator has contract locally)") and synthesized a `Subscribed` reply via the callback path in `node.rs:1191-1220`. The Request never reached the gateway. The gateway therefore never registered the node as a downstream subscriber, and subsequent UPDATE broadcasts never reached it.

The asymmetry is `auto_subscribe_on_get_response` (`operations.rs:646`) racing the explicit Subscribe: when GET completes, if not already subscribed, it falls back to the legacy `start_subscription_request` / `request_subscribe` path, which uses `notify_op_change` and DOES dispatch over the wire. One client wins that race and registers the legacy way; the other loses and depends on the broken explicit Subscribe.

The comment at `subscribe.rs:480-487` in `prepare_initial_request` explicitly documents the invariant the task-per-tx path was violating:

> Even if we have the contract locally (e.g., from PUT forwarding), we MUST send a Subscribe::Request to the network to register ourselves as a downstream subscriber in the subscription tree. Otherwise, when the contract is updated at the source, we won't receive the update because we're not registered in the upstream peer's subscriber list.

## Approach

Fix at the `OpCtx` send layer, not at `process_message`. The driver already selects `current_target_addr` via `prepare_initial_request`; the `send_and_await` abstraction was throwing it away.

- **`OpCtx::send_to_and_await(target_addr, msg)`** — new variant that carries an explicit target through the op-execution channel. The channel payload is now `(reply_sender, msg, Option<SocketAddr>)`. When the target is `Some`, `handle_op_execution` emits `OutboundMessageWithTarget { target_addr, msg }` and dispatches to that peer's connection. When it's `None`, the existing `InboundMessage` loop-back path is preserved for non-routed call sites and tests.

- **`op_ctx_task` switches to `send_to_and_await`** for the initial Request, passing `current_target_addr`. The reply still flows back through the same `pending_op_results` callback `handle_op_execution` registered.

- **Mirror legacy local side effects on `Subscribed`** in `op_ctx_task`. The task-per-tx reply forwarding bypass at `node.rs:1161` skips `handle_op_request` for terminal Responses, so without this the local interest manager (`ring.subscribe`, `complete_subscription_request`, `interest_manager.add_local_client`) never learned about the subscription. These are the same calls the legacy `SubscribeMsg::Response` arm makes.

- **Preserve the local-originator branch** in `process_message`. It remains correct for true standalone/sole-holder nodes (PRs #2327, #2004 deliberately added it). The fix prevents the network-target path from entering it.

**Wire format is unchanged.** The `SubscribeMsg::Request` bytes on the network are identical; only the internal dispatch path differs.

### Alternatives considered

- **Teach `process_message` to forward instead of short-circuit when a target is available.** Requires plumbing a target through the op state, deeper change, and risks breaking the legitimate standalone case.
- **Use legacy `notify_op_change` from `op_ctx_task`.** Undercuts the task-per-tx model — would mix state ownership back into `OpManager.ops`. Worse architectural fit.

Codex independently arrived at the same conclusion when consulted as a second opinion.

## Testing

- **New unit test**: `send_to_and_await_forwards_target_address` (`crates/core/src/operations/op_ctx.rs`) — pins the channel-level invariant. Asserts that the target address provided by the caller arrives intact at the op execution receiver. A regression that drops the target on the floor (the original bug) would fail this test in milliseconds.

- **Why didn't CI catch this?** `test_ping_blocked_peers` exists and *does* exercise this path, but it depends on a race between the legacy GET-fallback subscribe and the explicit task-per-tx subscribe. CI usually wins one race and flakes only when timing slips. The new unit test pins the contract directly so future regressions surface deterministically before the integration test does.

- **`test_ping_blocked_peers` locally**:
  - Before fix: ~280-293 s, full propagation timeout (Node2 stuck with only its own tag)
  - After fix: ~12-37 s, all tags propagate within first poll round (×4 consecutive runs)

- **Full test suites**:
  - `cargo test -p freenet --lib`: 2221 passed
  - `cargo test -p freenet --lib subscribe`: 113 passed
  - `cargo fmt && cargo clippy --all-targets --all-features`: clean

### Incidental cleanup

- `crates/core/src/contract/storages/sqlite.rs`: replaced `let _ =` on a `sqlx::query(...).execute(...).await` with `drop(...)` to satisfy clippy's `let_underscore_must_use` (newer local clippy than CI; pre-existing on main but only fires on stricter clippy versions).

## Fixes

Closes #3838

[AI-assisted - Claude]