### PR TITLE
fix: attest delegate-to-delegate caller via MessageOrigin::Delegate

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -98,3 +98,74 @@ Are there new #[ignore] tests?
 Does test coverage match changed code?
   → NO: Request tests for uncovered paths
 ```
+
+### WHEN a freenet-core PR depends on an unpublished freenet-stdlib change
+
+**Stdlib-first release policy.** The stdlib PR MUST merge to main and
+publish to crates.io BEFORE the freenet-core PR that consumes it opens
+for review.
+
+```
+Tempted to coordinate with [patch.crates-io] git overrides?
+  → DON'T. Multiple repeating sources of pain:
+
+  1. CI cannot resolve `path = "..."` to a sibling worktree on a fresh
+     checkout. Every workspace cargo invocation fails at
+     `cargo metadata` with "failed to load source for dependency".
+
+  2. Cargo's [patch.crates-io] is NOT inherited by nested workspaces.
+     If apps/freenet-ping/ or any other nested workspace path-deps
+     freenet-core, the override must be duplicated there. Forgetting
+     this manifests as "failed to select a version" errors that look
+     like a dep resolver bug but are actually a workspace inheritance
+     gap.
+
+  3. Even when the git override works on CI, the PR cannot merge in
+     that state — every reviewer sees a "MUST be removed before merge"
+     comment and a pre-merge cleanup checklist that exists only because
+     the wrong workflow was chosen upstream.
+
+CORRECT workflow:
+  1. Open the stdlib PR with the new variant / type / API.
+  2. Get reviews + CI green on stdlib alone.
+  3. Merge stdlib → main.
+  4. `cargo publish` the new stdlib version to crates.io.
+  5. THEN open the freenet-core PR with `freenet-stdlib = "X.Y.Z"`
+     pointing at the published version. No git overrides, no path
+     deps, no nested-workspace duplication, no pre-merge cleanup.
+
+The only friction this adds is one extra round-trip on the stdlib
+release; the friction it AVOIDS is a multi-commit cleanup pass and
+broken CI on every fresh checkout of the consumer PR. Pay the
+round-trip — it's cheaper.
+```
+
+### WHEN bumping `freenet-stdlib` to a version that adds enum variants
+
+```
+The wire-boundary enums (MessageOrigin, InboundDelegateMsg,
+OutboundDelegateMsg, UpdateData, ContractError, DelegateError, etc.)
+are all `#[non_exhaustive]` since stdlib 0.6.0. That means:
+
+1. Adding a variant to any of them is wire-format-additive — bincode
+   discriminants for existing variants stay byte-identical, and
+   deployed contract/delegate WASM compiled against any earlier 0.x
+   stdlib continues to deserialize the existing variants unchanged.
+
+2. Bumping freenet-core to a new stdlib MAY require adding wildcard
+   arms to existing match sites in core. The compiler will tell you
+   exactly where — fix each site by deciding what the "unknown
+   variant" semantic should be (usually: log+reject, log+ignore, or
+   forward through the WASM boundary unmodified).
+
+3. The cheap-win pattern: list known variants exhaustively, then add
+   a wildcard arm with `#[allow(clippy::wildcard_enum_match_arm)]`
+   and a comment explaining that the wildcard exists ONLY to satisfy
+   `non_exhaustive`. Don't be tempted to expand the wildcard into a
+   `pat | _` listing — that defeats the safety net the wildcard
+   provides for future variants.
+
+4. Wire-format pin tests in stdlib (`*_wire_format_is_stable`) lock
+   variant tag numbers. Reordering enum variants is a wire-format
+   break and MUST trip these tests during PR review.
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "freenet",
- "freenet-stdlib 0.5.0",
+ "freenet-stdlib 0.6.0",
  "futures 0.3.32",
  "glob",
  "hex",
@@ -2074,7 +2074,7 @@ dependencies = [
  "flatbuffers 25.12.19",
  "flate2",
  "freenet-macros 0.1.0",
- "freenet-stdlib 0.5.0",
+ "freenet-stdlib 0.6.0",
  "freenet-test-network",
  "futures 0.3.32",
  "gag",
@@ -2188,7 +2188,7 @@ dependencies = [
  "clap",
  "freenet",
  "freenet-ping-types",
- "freenet-stdlib 0.5.0",
+ "freenet-stdlib 0.6.0",
  "freenet-test-network",
  "futures 0.3.32",
  "humantime",
@@ -2210,7 +2210,7 @@ name = "freenet-ping-contract"
 version = "0.1.11"
 dependencies = [
  "freenet-ping-types",
- "freenet-stdlib 0.5.0",
+ "freenet-stdlib 0.6.0",
  "serde_json",
 ]
 
@@ -2220,7 +2220,7 @@ version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
- "freenet-stdlib 0.5.0",
+ "freenet-stdlib 0.6.0",
  "humantime",
  "humantime-serde",
  "serde",
@@ -2257,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2475e70183cf53033735bd4a794d7875d0b125f9369bd463dc30c83424dcbea6"
+checksum = "0c4a5632deb1066bb756949f37fa9a92a79a7b710a2015ec02bb315d0f598629"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -2322,7 +2322,7 @@ dependencies = [
  "byteorder",
  "ciborium",
  "ed25519-dalek",
- "freenet-stdlib 0.5.0",
+ "freenet-stdlib 0.6.0",
  "rand 0.8.5",
  "serde",
 ]
@@ -6790,7 +6790,7 @@ dependencies = [
 name = "test-contract-integration"
 version = "0.1.11"
 dependencies = [
- "freenet-stdlib 0.5.0",
+ "freenet-stdlib 0.6.0",
  "serde",
  "serde_json",
 ]
@@ -6800,14 +6800,14 @@ name = "test-contract-mock-aligned"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "freenet-stdlib 0.5.0",
+ "freenet-stdlib 0.6.0",
 ]
 
 [[package]]
 name = "test-contract-update-nochange"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib 0.5.0",
+ "freenet-stdlib 0.6.0",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,7 +2170,8 @@ dependencies = [
 [[package]]
 name = "freenet-macros"
 version = "0.2.0"
-source = "git+https://github.com/freenet/freenet-stdlib?branch=feat-message-origin-delegate#7840137a1368731fd8420e522b586268cc8a75dd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26e5c6bee9ffa0e2683bc8b41a7bd9f1e57e7fd49ac4f6ae433e5a82e9006df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2257,7 +2258,8 @@ dependencies = [
 [[package]]
 name = "freenet-stdlib"
 version = "0.5.0"
-source = "git+https://github.com/freenet/freenet-stdlib?branch=feat-message-origin-delegate#7840137a1368731fd8420e522b586268cc8a75dd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2475e70183cf53033735bd4a794d7875d0b125f9369bd463dc30c83424dcbea6"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,6 +2170,7 @@ dependencies = [
 [[package]]
 name = "freenet-macros"
 version = "0.2.0"
+source = "git+https://github.com/freenet/freenet-stdlib?branch=feat-message-origin-delegate#7840137a1368731fd8420e522b586268cc8a75dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2256,6 +2257,7 @@ dependencies = [
 [[package]]
 name = "freenet-stdlib"
 version = "0.5.0"
+source = "git+https://github.com/freenet/freenet-stdlib?branch=feat-message-origin-delegate#7840137a1368731fd8420e522b586268cc8a75dd"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "freenet",
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
  "futures 0.3.32",
  "glob",
  "hex",
@@ -2074,7 +2074,7 @@ dependencies = [
  "flatbuffers 25.12.19",
  "flate2",
  "freenet-macros 0.1.0",
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
  "freenet-test-network",
  "futures 0.3.32",
  "gag",
@@ -2170,8 +2170,6 @@ dependencies = [
 [[package]]
 name = "freenet-macros"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26e5c6bee9ffa0e2683bc8b41a7bd9f1e57e7fd49ac4f6ae433e5a82e9006df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2188,7 +2186,7 @@ dependencies = [
  "clap",
  "freenet",
  "freenet-ping-types",
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
  "freenet-test-network",
  "futures 0.3.32",
  "humantime",
@@ -2210,7 +2208,7 @@ name = "freenet-ping-contract"
 version = "0.1.11"
 dependencies = [
  "freenet-ping-types",
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
  "serde_json",
 ]
 
@@ -2220,7 +2218,7 @@ version = "0.1.11"
 dependencies = [
  "chrono",
  "clap",
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
  "humantime",
  "humantime-serde",
  "serde",
@@ -2257,9 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b38e67bb1e2d2a9962880731aace112c1e03d9ea55c99469dab7056695e5197"
+version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -2322,7 +2318,7 @@ dependencies = [
  "byteorder",
  "ciborium",
  "ed25519-dalek",
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
  "rand 0.8.5",
  "serde",
 ]
@@ -6790,7 +6786,7 @@ dependencies = [
 name = "test-contract-integration"
 version = "0.1.11"
 dependencies = [
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
  "serde",
  "serde_json",
 ]
@@ -6800,14 +6796,14 @@ name = "test-contract-mock-aligned"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
 ]
 
 [[package]]
 name = "test-contract-update-nochange"
 version = "0.1.0"
 dependencies = [
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,11 +152,13 @@ zip = { version = "8", default-features = false, features = ["deflate", "time"] 
 # Freenet
 freenet-stdlib = "0.5.0"
 
-# Local override for issue #3860 — points at the freenet-stdlib branch that
-# adds `MessageOrigin::Delegate(DelegateKey)`. MUST be removed before this PR
-# can merge — replace with the published 0.5.0 from crates.io.
+# Temporary git override for issue #3860 — points at the freenet-stdlib
+# branch that adds `MessageOrigin::Delegate(DelegateKey)` so CI can build
+# this PR before stdlib publishes to crates.io. MUST be removed before this
+# PR can merge — replace with the published 0.5.0 from crates.io. Tracked
+# in the PR pre-merge checklist on freenet/freenet-core#3865.
 [patch.crates-io]
-freenet-stdlib = { path = "../../freenet-stdlib-3860/rust" }
+freenet-stdlib = { git = "https://github.com/freenet/freenet-stdlib", branch = "feat-message-origin-delegate" }
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,14 +152,6 @@ zip = { version = "8", default-features = false, features = ["deflate", "time"] 
 # Freenet
 freenet-stdlib = "0.5.0"
 
-# Temporary git override for issue #3860 — points at the freenet-stdlib
-# branch that adds `MessageOrigin::Delegate(DelegateKey)` so CI can build
-# this PR before stdlib publishes to crates.io. MUST be removed before this
-# PR can merge — replace with the published 0.5.0 from crates.io. Tracked
-# in the PR pre-merge checklist on freenet/freenet-core#3865.
-[patch.crates-io]
-freenet-stdlib = { git = "https://github.com/freenet/freenet-stdlib", branch = "feat-message-origin-delegate" }
-
 [profile.dev.package."*"]
 opt-level = 3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,13 @@ muda = "0.17"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet
-freenet-stdlib = "0.4.0"
+freenet-stdlib = "0.5.0"
+
+# Local override for issue #3860 — points at the freenet-stdlib branch that
+# adds `MessageOrigin::Delegate(DelegateKey)`. MUST be removed before this PR
+# can merge — replace with the published 0.5.0 from crates.io.
+[patch.crates-io]
+freenet-stdlib = { path = "../../freenet-stdlib-3860/rust" }
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ muda = "0.17"
 zip = { version = "8", default-features = false, features = ["deflate", "time"] }
 
 # Freenet
-freenet-stdlib = "0.5.0"
+freenet-stdlib = "0.6.0"
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/apps/freenet-ping/Cargo.lock
+++ b/apps/freenet-ping/Cargo.lock
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "freenet"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1627,7 +1627,7 @@ dependencies = [
  "event-listener",
  "flatbuffers 25.12.19",
  "flate2",
- "freenet-stdlib 0.4.0",
+ "freenet-stdlib 0.5.0",
  "futures",
  "gag",
  "headers",
@@ -1812,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b38e67bb1e2d2a9962880731aace112c1e03d9ea55c99469dab7056695e5197"
+checksum = "2475e70183cf53033735bd4a794d7875d0b125f9369bd463dc30c83424dcbea6"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/apps/freenet-ping/Cargo.toml
+++ b/apps/freenet-ping/Cargo.toml
@@ -2,16 +2,6 @@
 resolver = "2"
 members = ["contracts/ping", "app", "types"]
 
-# Temporary git override for issue #3860 — the path-dep on freenet-core in
-# `app/` transitively requires freenet-stdlib 0.5.0, which is not yet on
-# crates.io. This `[patch.crates-io]` is a duplicate of the one in the root
-# freenet-core `Cargo.toml`; nested workspaces do not inherit `[patch]` from
-# their parent, so it must be repeated here for the ping contract build to
-# resolve dependencies in CI. MUST be removed before merge — replace with
-# the published 0.5.0 from crates.io. Tracked in freenet/freenet-core#3865.
-[patch.crates-io]
-freenet-stdlib = { git = "https://github.com/freenet/freenet-stdlib", branch = "feat-message-origin-delegate" }
-
 [workspace.dependencies]
 # freenet-stdlib = { path = "./../../stdlib/rust", features = ["contract"] }
 freenet-stdlib = { version = "0.3.5" }

--- a/apps/freenet-ping/Cargo.toml
+++ b/apps/freenet-ping/Cargo.toml
@@ -2,6 +2,16 @@
 resolver = "2"
 members = ["contracts/ping", "app", "types"]
 
+# Temporary git override for issue #3860 — the path-dep on freenet-core in
+# `app/` transitively requires freenet-stdlib 0.5.0, which is not yet on
+# crates.io. This `[patch.crates-io]` is a duplicate of the one in the root
+# freenet-core `Cargo.toml`; nested workspaces do not inherit `[patch]` from
+# their parent, so it must be repeated here for the ping contract build to
+# resolve dependencies in CI. MUST be removed before merge — replace with
+# the published 0.5.0 from crates.io. Tracked in freenet/freenet-core#3865.
+[patch.crates-io]
+freenet-stdlib = { git = "https://github.com/freenet/freenet-stdlib", branch = "feat-message-origin-delegate" }
+
 [workspace.dependencies]
 # freenet-stdlib = { path = "./../../stdlib/rust", features = ["contract"] }
 freenet-stdlib = { version = "0.3.5" }

--- a/crates/core/src/client_events.rs
+++ b/crates/core/src/client_events.rs
@@ -980,6 +980,30 @@ async fn process_open_request(
                                 state: State::from(state.into_bytes()),
                                 delta: StateDelta::from(delta.into_bytes()),
                             },
+                            // `UpdateData` is `#[non_exhaustive]` since
+                            // stdlib 0.6.0. Future variants reach this
+                            // arm because the compiler requires it; until
+                            // they are explicitly handled (each variant
+                            // has its own owned-bytes conversion), reject
+                            // them here rather than silently dropping the
+                            // payload further down the operation pipeline.
+                            other => {
+                                tracing::error!(
+                                    client_id = %client_id,
+                                    request_id = %request_id,
+                                    contract = %key,
+                                    variant = ?std::mem::discriminant(&other),
+                                    "Rejecting UPDATE: unknown UpdateData variant — \
+                                     freenet-core was built against an older stdlib than \
+                                     the client expected; rebuild the host to handle this variant"
+                                );
+                                return Err(Error::Node(
+                                    "UPDATE rejected: unknown UpdateData variant from client; \
+                                     rebuild freenet-core against the stdlib version emitting \
+                                     this variant"
+                                        .to_string(),
+                                ));
+                            }
                         };
 
                         tracing::debug!(

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -101,7 +101,7 @@ where
         // Execute the delegate request
         let values = match contract_handler
             .executor()
-            .execute_delegate_request(current_req, origin_contract)
+            .execute_delegate_request(current_req, origin_contract, None)
             .await
         {
             Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse { key: _, values }) => {
@@ -454,8 +454,10 @@ where
         //   delegate registry — they are passed per-request at the API layer. If a target
         //   delegate's process() relies on params, the caller must use ApplicationMessages
         //   directly. This is a known v1 limitation.
-        // - origin_contract is None for inter-delegate delivery since the message
-        //   originates from another delegate, not from a contract attestation context.
+        // - The caller's delegate key is passed as `caller_delegate` so the receiver
+        //   sees `MessageOrigin::Delegate(caller_key)` and can authorize on it
+        //   (issue #3860). The runtime attests this identity — the calling delegate
+        //   cannot forge it.
         // - Inter-delegate messaging only works via ApplicationMessages path; messages
         //   from handle_delegate_notification (contract state change callbacks) do not
         //   trigger delegate-to-delegate delivery.
@@ -476,7 +478,7 @@ where
                 };
                 match contract_handler
                     .executor()
-                    .execute_delegate_request(target_req, None)
+                    .execute_delegate_request(target_req, None, Some(delegate_key))
                     .await
                 {
                     Ok(freenet_stdlib::client_api::HostResponse::DelegateResponse {

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -317,7 +317,10 @@ where
                             }
                             // StateAndDelta, RelatedState, RelatedDelta, RelatedStateAndDelta
                             // are not supported because the delegate API doesn't provide the
-                            // related contract context needed to resolve them.
+                            // related contract context needed to resolve them. Future
+                            // `UpdateData` variants (the enum is `#[non_exhaustive]` since
+                            // stdlib 0.6.0) fall through the same "unsupported" branch and
+                            // are similarly rejected with a warn-level log.
                             other @ freenet_stdlib::prelude::UpdateData::StateAndDelta {
                                 ..
                             }
@@ -325,7 +328,8 @@ where
                             | other @ freenet_stdlib::prelude::UpdateData::RelatedDelta { .. }
                             | other @ freenet_stdlib::prelude::UpdateData::RelatedStateAndDelta {
                                 ..
-                            } => {
+                            }
+                            | other => {
                                 tracing::warn!(
                                     contract = %contract_id,
                                     variant = ?std::mem::discriminant(&other),
@@ -1020,6 +1024,15 @@ where
                 | freenet_stdlib::prelude::UpdateData::RelatedStateAndDelta { .. } => {
                     unreachable!()
                 }
+                // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0.
+                // Future variants must be explicitly handled before they
+                // flow through `UpdateQuery`; the producer at the edge
+                // should reject unknown variants rather than routing them
+                // here.
+                _ => unreachable!(
+                    "Unknown UpdateData variant reached ContractHandlerEvent::UpdateQuery; \
+                     add explicit handling before landing the new variant upstream"
+                ),
             };
             let update_result = contract_handler
                 .executor()

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -766,10 +766,23 @@ pub(crate) trait ContractExecutor: Send + 'static {
         summary: Option<StateSummary<'_>>,
     ) -> Result<(), Box<RequestError>>;
 
+    /// Execute a delegate request.
+    ///
+    /// `origin_contract` carries the WebApp attestation when a contract-backed
+    /// web app dispatches a request to a delegate.
+    ///
+    /// `caller_delegate` carries the runtime-attested identity of a calling
+    /// delegate when one delegate sends a message to another via
+    /// [`OutboundDelegateMsg::SendDelegateMessage`]. When `Some`, it takes
+    /// precedence over `origin_contract` (and over inherited origins) for
+    /// the receiver's `MessageOrigin`. At most one of these two arguments is
+    /// expected to be `Some` at a given call site, and only `caller_delegate`
+    /// is used for inter-delegate dispatch (issue #3860).
     fn execute_delegate_request(
         &mut self,
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
+        caller_delegate: Option<&DelegateKey>,
     ) -> impl Future<Output = Response> + Send;
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo>;

--- a/crates/core/src/contract/executor/mock_runtime.rs
+++ b/crates/core/src/contract/executor/mock_runtime.rs
@@ -702,6 +702,7 @@ where
         &mut self,
         _req: DelegateRequest<'_>,
         _origin_contract: Option<&ContractInstanceId>,
+        _caller_delegate: Option<&DelegateKey>,
     ) -> Response {
         Err(ExecutorError::other(anyhow::anyhow!(
             "not supported in mock runtime"

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -189,6 +189,7 @@ impl ContractExecutor for Executor<MockWasmRuntime, MockStateStorage> {
         &mut self,
         _req: DelegateRequest<'_>,
         _origin_contract: Option<&ContractInstanceId>,
+        _caller_delegate: Option<&DelegateKey>,
     ) -> Response {
         Err(ExecutorError::other(anyhow::anyhow!(
             "delegates not supported in MockWasmRuntime"

--- a/crates/core/src/contract/executor/mock_wasm_runtime.rs
+++ b/crates/core/src/contract/executor/mock_wasm_runtime.rs
@@ -92,6 +92,9 @@ impl ContractRuntimeInterface for MockWasmRuntime {
                 | UpdateData::RelatedStateAndDelta { .. } => {
                     // Ignore related data for the merge
                 }
+                // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0.
+                // Mock-only path: ignore future variants for the merge.
+                _ => {}
             }
         }
         match new_state {

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -666,9 +666,10 @@ impl ContractExecutor for RuntimePool {
         &mut self,
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
+        caller_delegate: Option<&DelegateKey>,
     ) -> Response {
         let mut executor = self.pop_executor().await;
-        let result = executor.delegate_request(req, origin_contract);
+        let result = executor.delegate_request(req, origin_contract, caller_delegate);
         self.return_checked(executor, "execute_delegate_request")
             .await;
         result
@@ -2366,8 +2367,9 @@ impl ContractExecutor for Executor<Runtime> {
         &mut self,
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
+        caller_delegate: Option<&DelegateKey>,
     ) -> Response {
-        self.delegate_request(req, origin_contract)
+        self.delegate_request(req, origin_contract, caller_delegate)
     }
 
     fn get_subscription_info(&self) -> Vec<crate::message::SubscriptionInfo> {
@@ -2513,7 +2515,7 @@ impl Executor<Runtime> {
     ) -> Response {
         match req {
             ClientRequest::ContractOp(op) => self.contract_requests(op, id, updates).await,
-            ClientRequest::DelegateOp(op) => self.delegate_request(op, None),
+            ClientRequest::DelegateOp(op) => self.delegate_request(op, None, None),
             ClientRequest::Disconnect { cause } => {
                 if let Some(cause) = cause {
                     tracing::info!("disconnecting cause: {cause}");
@@ -2661,9 +2663,11 @@ impl Executor<Runtime> {
         &mut self,
         req: DelegateRequest<'_>,
         origin_contract: Option<&ContractInstanceId>,
+        caller_delegate: Option<&DelegateKey>,
     ) -> Response {
         tracing::debug!(
             origin_contract = ?origin_contract,
+            caller_delegate = ?caller_delegate.map(|k| k.to_string()),
             "received delegate request"
         );
         match req {
@@ -2741,9 +2745,19 @@ impl Executor<Runtime> {
                 inbound,
                 params,
             } => {
-                // Resolve the message origin: use the direct origin_contract, falling back
-                // to inherited origin from parent delegates created via create_delegate host function.
-                let origin: Option<MessageOrigin> = if let Some(contract_id) = origin_contract {
+                // Resolve the message origin in priority order:
+                //   1. `caller_delegate` — set when another delegate dispatched
+                //      this message via `SendDelegateMessage` (issue #3860).
+                //      The runtime attests the caller's identity so the
+                //      receiver can authorize on it.
+                //   2. `origin_contract` — set when a contract-backed web app
+                //      dispatched this message via the WebSocket API.
+                //   3. `DELEGATE_INHERITED_ORIGINS` — set when a parent
+                //      delegate created this delegate via `create_delegate`,
+                //      inheriting its WebApp attestation.
+                let origin: Option<MessageOrigin> = if let Some(caller) = caller_delegate {
+                    Some(MessageOrigin::Delegate(caller.clone()))
+                } else if let Some(contract_id) = origin_contract {
                     Some(MessageOrigin::WebApp(*contract_id))
                 } else {
                     crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS

--- a/crates/core/src/contract/executor/runtime.rs
+++ b/crates/core/src/contract/executor/runtime.rs
@@ -2665,6 +2665,20 @@ impl Executor<Runtime> {
         origin_contract: Option<&ContractInstanceId>,
         caller_delegate: Option<&DelegateKey>,
     ) -> Response {
+        // Mutual exclusion invariant: a single inbound delegate request is
+        // either dispatched on behalf of a contract-backed web app
+        // (`origin_contract = Some`) or on behalf of another delegate
+        // (`caller_delegate = Some`), never both. The doc comment on
+        // `ContractExecutor::execute_delegate_request` states this. The
+        // `debug_assert!` turns the convention into a tripwire so a future
+        // call site that violates it fails loudly in debug/test builds; in
+        // release builds the precedence below silently picks `caller_delegate`
+        // (fail-safe in the direction of "least surprising attestation").
+        debug_assert!(
+            !(origin_contract.is_some() && caller_delegate.is_some()),
+            "execute_delegate_request: at most one of origin_contract and \
+             caller_delegate may be Some (got both)"
+        );
         tracing::debug!(
             origin_contract = ?origin_contract,
             caller_delegate = ?caller_delegate.map(|k| k.to_string()),
@@ -2745,25 +2759,7 @@ impl Executor<Runtime> {
                 inbound,
                 params,
             } => {
-                // Resolve the message origin in priority order:
-                //   1. `caller_delegate` — set when another delegate dispatched
-                //      this message via `SendDelegateMessage` (issue #3860).
-                //      The runtime attests the caller's identity so the
-                //      receiver can authorize on it.
-                //   2. `origin_contract` — set when a contract-backed web app
-                //      dispatched this message via the WebSocket API.
-                //   3. `DELEGATE_INHERITED_ORIGINS` — set when a parent
-                //      delegate created this delegate via `create_delegate`,
-                //      inheriting its WebApp attestation.
-                let origin: Option<MessageOrigin> = if let Some(caller) = caller_delegate {
-                    Some(MessageOrigin::Delegate(caller.clone()))
-                } else if let Some(contract_id) = origin_contract {
-                    Some(MessageOrigin::WebApp(*contract_id))
-                } else {
-                    crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS
-                        .get(&key)
-                        .and_then(|ids| ids.first().map(|c| MessageOrigin::WebApp(*c)))
-                };
+                let origin = resolve_message_origin(caller_delegate, origin_contract, &key);
                 match self.runtime.inbound_app_message(
                     &key,
                     &params,
@@ -3508,5 +3504,124 @@ impl Executor<Runtime> {
         };
         let get_result: operations::get::GetResult = self.op_request(request).await?;
         Ok(Either::Right(get_result))
+    }
+}
+
+/// Resolve a [`MessageOrigin`] for a delegate `ApplicationMessages` request,
+/// in priority order:
+///
+/// 1. `caller_delegate` — set when another delegate dispatched this request
+///    via `OutboundDelegateMsg::SendDelegateMessage` (issue #3860). The
+///    runtime attests the caller's identity, so the receiver can authorize
+///    on it. This wins unconditionally — an inter-delegate message
+///    deliberately replaces (not composes with) any inherited WebApp origin.
+/// 2. `origin_contract` — set when a contract-backed web app dispatched
+///    this request via the WebSocket API.
+/// 3. `DELEGATE_INHERITED_ORIGINS[delegate_key]` — set when a parent
+///    delegate created this delegate via `create_delegate`, inheriting its
+///    WebApp attestation.
+///
+/// Extracted as a free function so the precedence rules can be unit-tested
+/// directly without standing up a full `Executor`.
+fn resolve_message_origin(
+    caller_delegate: Option<&DelegateKey>,
+    origin_contract: Option<&ContractInstanceId>,
+    delegate_key: &DelegateKey,
+) -> Option<MessageOrigin> {
+    if let Some(caller) = caller_delegate {
+        Some(MessageOrigin::Delegate(caller.clone()))
+    } else if let Some(contract_id) = origin_contract {
+        Some(MessageOrigin::WebApp(*contract_id))
+    } else {
+        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS
+            .get(delegate_key)
+            .and_then(|ids| ids.first().map(|c| MessageOrigin::WebApp(*c)))
+    }
+}
+
+#[cfg(test)]
+mod resolve_message_origin_tests {
+    use super::*;
+    use freenet_stdlib::prelude::CodeHash;
+
+    fn dkey(seed: u8) -> DelegateKey {
+        DelegateKey::new([seed; 32], CodeHash::new([seed; 32]))
+    }
+
+    /// Caller delegate identity wins over a concurrently-supplied WebApp
+    /// contract (regression for issue #3860 precedence rule).
+    #[test]
+    fn caller_delegate_takes_precedence_over_origin_contract() {
+        let caller = dkey(0xA1);
+        let recipient = dkey(0xB2);
+        let app_contract = ContractInstanceId::new([0xC3; 32]);
+
+        let origin = resolve_message_origin(Some(&caller), Some(&app_contract), &recipient);
+
+        match origin {
+            Some(MessageOrigin::Delegate(k)) => assert_eq!(k, caller),
+            other => panic!("Expected Delegate(caller), got {other:?}"),
+        }
+    }
+
+    /// With only `origin_contract` set, the receiver sees `WebApp(..)` —
+    /// the historical behavior for web-app-driven dispatch must be
+    /// preserved.
+    #[test]
+    fn origin_contract_alone_yields_webapp() {
+        let recipient = dkey(0xB2);
+        let app_contract = ContractInstanceId::new([0xC3; 32]);
+
+        let origin = resolve_message_origin(None, Some(&app_contract), &recipient);
+
+        match origin {
+            Some(MessageOrigin::WebApp(id)) => assert_eq!(id, app_contract),
+            other => panic!("Expected WebApp(app_contract), got {other:?}"),
+        }
+    }
+
+    /// With neither argument set and no inherited origin in the static
+    /// map, the receiver sees `None` (matches pre-#3860 behavior for
+    /// orphaned dispatches and the fall-through case for unrelated
+    /// recipients in tests).
+    #[test]
+    fn no_arguments_and_no_inherited_yields_none() {
+        // Pick a recipient key with no entry in DELEGATE_INHERITED_ORIGINS.
+        // Using a randomized seed avoids collision with anything another
+        // test populated in the same process.
+        let recipient = dkey(0xEE);
+        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS.remove(&recipient);
+
+        let origin = resolve_message_origin(None, None, &recipient);
+        assert!(origin.is_none(), "Expected None, got {origin:?}");
+    }
+
+    /// Caller delegate identity also wins over an inherited WebApp origin
+    /// in `DELEGATE_INHERITED_ORIGINS`. This documents the deliberate
+    /// "inter-delegate calls revoke inherited contract access" semantics
+    /// from the `MessageOrigin::Delegate` rustdoc.
+    #[test]
+    fn caller_delegate_overrides_inherited_origin() {
+        let caller = dkey(0xA1);
+        let recipient = dkey(0xB3);
+        let inherited_contract = ContractInstanceId::new([0xDD; 32]);
+
+        // Plant an inherited WebApp origin for the recipient so the
+        // fallback branch would have something to return.
+        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS
+            .entry(recipient.clone())
+            .or_default()
+            .push(inherited_contract);
+
+        let origin = resolve_message_origin(Some(&caller), None, &recipient);
+
+        // Cleanup before assertions so a panic doesn't leak state into
+        // sibling tests sharing the same process.
+        crate::wasm_runtime::DELEGATE_INHERITED_ORIGINS.remove(&recipient);
+
+        match origin {
+            Some(MessageOrigin::Delegate(k)) => assert_eq!(k, caller),
+            other => panic!("Expected Delegate(caller), got {other:?}"),
+        }
     }
 }

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -2294,7 +2294,7 @@ pub async fn run_local_node(
                     ?origin_contract,
                     "Handling ClientRequest::DelegateOp"
                 );
-                executor.delegate_request(op, origin_contract.as_ref())
+                executor.delegate_request(op, origin_contract.as_ref(), None)
             }
             ClientRequest::Disconnect { cause } => {
                 if let Some(cause) = cause {

--- a/crates/core/src/node/request_router.rs
+++ b/crates/core/src/node/request_router.rs
@@ -136,6 +136,17 @@ impl Hash for RequestResource {
                         state.hash(&mut hasher);
                         delta.hash(&mut hasher);
                     }
+                    // `UpdateData` is `#[non_exhaustive]` since stdlib
+                    // 0.6.0. Future variants reach this arm via the
+                    // compiler's exhaustiveness requirement. Hash them
+                    // under a sentinel discriminant (255) so dedup at
+                    // least never collides with a known variant; if a
+                    // new variant ships, this arm should be specialized
+                    // alongside the upstream change so dedup keys stay
+                    // distinct per content.
+                    _ => {
+                        255u8.hash(&mut hasher);
+                    }
                 }
                 hasher.finish().hash(state);
             }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1712,6 +1712,11 @@ async fn update_contract(
                         Some(WrappedState::from(state.clone().into_bytes()))
                     }
                     UpdateData::Delta(_) | UpdateData::RelatedDelta { .. } => None,
+                    // `UpdateData` is `#[non_exhaustive]` since stdlib
+                    // 0.6.0. We can't materialize state from an unknown
+                    // variant, so return None and let the caller treat
+                    // it as "no state to extract."
+                    _ => None,
                 }
             }
 

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -271,7 +271,7 @@ pub mod local_node {
                             .get(&token)
                             .map(|entry| entry.contract_id)
                     });
-                    executor.delegate_request(op, origin_contract.as_ref())
+                    executor.delegate_request(op, origin_contract.as_ref(), None)
                 }
                 ClientRequest::Disconnect { cause } => {
                     if let Some(cause) = cause {

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -99,10 +99,21 @@ impl Runtime {
         let origin_contracts = match origin {
             Some(MessageOrigin::WebApp(contract_id)) => vec![*contract_id],
             Some(MessageOrigin::Delegate(_)) | None => Vec::new(),
-            // MessageOrigin is `#[non_exhaustive]`; future variants must
-            // explicitly decide whether they grant contract access. Until
-            // then, default to "no access" — fail closed.
-            Some(_) => Vec::new(),
+            // MessageOrigin is `#[non_exhaustive]`; future variants reach
+            // this arm because the compiler requires it. Default to "no
+            // contract access" (fail closed) AND log a warning so the gap
+            // is visible during the PR that adds the new variant — the
+            // catch-all should not silently default in production.
+            Some(other) => {
+                tracing::warn!(
+                    delegate_key = %delegate_key,
+                    origin = ?other,
+                    "Unknown MessageOrigin variant reached fail-closed default; \
+                     wasm_runtime::delegate::Runtime::inbound_app_message must \
+                     decide explicitly whether this variant grants contract access"
+                );
+                Vec::new()
+            }
         };
 
         // SAFETY: The `DelegateCallEnv` does not outlive `self`. The raw pointers to

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -91,10 +91,18 @@ impl Runtime {
         // SAFETY: `self.secret_store` and `self.contract_store` are valid for the
         // duration of the WASM `process()` call below, and the `DelegateEnvGuard`
         // ensures the env is removed from `DELEGATE_ENV` before this function returns.
-        // Build the origin_contracts list from the MessageOrigin.
+        // Build the origin_contracts list from the MessageOrigin. Only WebApp
+        // attestations grant the receiving delegate access to a contract on
+        // behalf of the caller; an inter-delegate caller (Delegate variant)
+        // does not propagate contract access — its identity is conveyed only
+        // via the `origin` argument forwarded into the WASM `process()` call.
         let origin_contracts = match origin {
             Some(MessageOrigin::WebApp(contract_id)) => vec![*contract_id],
-            None => Vec::new(),
+            Some(MessageOrigin::Delegate(_)) | None => Vec::new(),
+            // MessageOrigin is `#[non_exhaustive]`; future variants must
+            // explicitly decide whether they grant contract access. Until
+            // then, default to "no access" — fail closed.
+            Some(_) => Vec::new(),
         };
 
         // SAFETY: The `DelegateCallEnv` does not outlive `self`. The raw pointers to
@@ -3665,6 +3673,10 @@ mod test {
             DelegateMessageReceived {
                 sender_key_bytes: Vec<u8>,
                 payload: Vec<u8>,
+                /// Mirror of the same field in the WASM-side
+                /// `OutboundAppMessage`; populated when the runtime delivered
+                /// this message with `MessageOrigin::Delegate(k)` (#3860).
+                origin_delegate_key_bytes: Option<Vec<u8>>,
             },
             PingResponse {
                 data: Vec<u8>,
@@ -3820,13 +3832,77 @@ mod test {
             OutboundAppMessage::DelegateMessageReceived {
                 sender_key_bytes,
                 payload,
+                origin_delegate_key_bytes,
             } => {
                 assert_eq!(sender_key_bytes, sender_key.bytes());
                 assert_eq!(payload, b"hello");
+                assert!(
+                    origin_delegate_key_bytes.is_none(),
+                    "origin was None, so receiver should see no Delegate origin"
+                );
             }
             OutboundAppMessage::MessageSent | OutboundAppMessage::PingResponse { .. } => {
                 panic!("Expected DelegateMessageReceived, got {:?}", response)
             }
+        }
+
+        Ok(())
+    }
+
+    /// Regression test for issue #3860: when the runtime delivers an inbound
+    /// `DelegateMessage` with `Some(MessageOrigin::Delegate(caller_key))`, the
+    /// receiving delegate's `process()` MUST see exactly that origin in its
+    /// `origin` parameter. Previously the inter-delegate dispatch path passed
+    /// `None`, leaving the receiver unable to authorize on caller identity.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_inbound_app_message_propagates_delegate_origin()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use messaging_messages::*;
+
+        let (delegate_b, mut runtime, _temp_dir) =
+            setup_runtime_with_params(TEST_DELEGATE_MESSAGING, vec![2]).await?;
+        let key_b = delegate_b.key().clone();
+
+        // Synthetic caller delegate A — its key is what we expect the
+        // receiver to observe via MessageOrigin::Delegate.
+        let caller_a = DelegateKey::new([0xA1u8; 32], CodeHash::new([0xA2u8; 32]));
+
+        // Build an inbound DelegateMessage for B, with `sender` distinct from
+        // `caller_a` so the test cannot pass by accident if the receiver
+        // confuses `msg.sender` with the runtime-attested origin.
+        let inband_sender = DelegateKey::new([0xBBu8; 32], CodeHash::new([0xCCu8; 32]));
+        let delegate_msg =
+            DelegateMessage::new(key_b.clone(), inband_sender, b"attest-me".to_vec());
+
+        let origin = MessageOrigin::Delegate(caller_a.clone());
+        let outbound = runtime.inbound_app_message(
+            &key_b,
+            &vec![2u8].into(),
+            Some(&origin),
+            vec![InboundDelegateMsg::DelegateMessage(delegate_msg)],
+        )?;
+
+        assert_eq!(outbound.len(), 1, "Expected exactly one outbound message");
+
+        let app_msg = match &outbound[0] {
+            OutboundDelegateMsg::ApplicationMessage(m) => m,
+            other => panic!("Expected ApplicationMessage, got {other:?}"),
+        };
+        let response: OutboundAppMessage = bincode::deserialize(&app_msg.payload)?;
+        match response {
+            OutboundAppMessage::DelegateMessageReceived {
+                origin_delegate_key_bytes,
+                ..
+            } => {
+                let observed = origin_delegate_key_bytes
+                    .expect("Receiver should see Some(MessageOrigin::Delegate(..))");
+                assert_eq!(
+                    observed,
+                    caller_a.bytes(),
+                    "Receiver must see the runtime-attested caller key, not msg.sender"
+                );
+            }
+            other => panic!("Expected DelegateMessageReceived, got {other:?}"),
         }
 
         Ok(())
@@ -3910,6 +3986,7 @@ mod test {
             OutboundAppMessage::DelegateMessageReceived {
                 sender_key_bytes,
                 payload,
+                origin_delegate_key_bytes,
             } => {
                 assert_eq!(
                     sender_key_bytes,
@@ -3917,6 +3994,13 @@ mod test {
                     "B should see A as the sender"
                 );
                 assert_eq!(payload, b"inter-delegate");
+                // Origin not asserted here: this roundtrip test calls
+                // inbound_app_message with origin=None (it bypasses the
+                // executor that injects MessageOrigin::Delegate). End-to-end
+                // propagation of MessageOrigin::Delegate through the WASM
+                // boundary is covered by
+                // `test_inbound_app_message_propagates_delegate_origin`.
+                let _ = origin_delegate_key_bytes;
             }
             OutboundAppMessage::MessageSent | OutboundAppMessage::PingResponse { .. } => {
                 panic!("Expected DelegateMessageReceived, got {:?}", response)

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -196,6 +196,11 @@ impl Runtime {
             InboundDelegateMsg::SubscribeContractResponse(_) => "SubscribeContractResponse",
             InboundDelegateMsg::ContractNotification(_) => "ContractNotification",
             InboundDelegateMsg::DelegateMessage(_) => "DelegateMessage",
+            // `InboundDelegateMsg` is `#[non_exhaustive]` (stdlib 0.6.0+).
+            // Future variants land here for tracing only — they still flow
+            // through the wasm boundary as raw bincode below; classifying
+            // them as "Unknown" affects logs only, not delivery.
+            _ => "Unknown",
         };
         tracing::debug!(
             inbound_msg_name,
@@ -506,6 +511,14 @@ impl DelegateRuntimeInterface for Runtime {
         // Cleanup happens after the loop regardless of success/failure.
         let process_result: RuntimeResult<()> = (|| {
             for msg in inbound {
+                // The wildcard arm at the bottom of this match exists
+                // solely because `InboundDelegateMsg` is `#[non_exhaustive]`
+                // (stdlib 0.6.0+); every currently-known variant is
+                // enumerated above. Re-listing them in a `pat | _` shape
+                // (as `wildcard_enum_match_arm` would prefer) is needless
+                // duplication that defeats the safety net the wildcard
+                // provides for future variants.
+                #[allow(clippy::wildcard_enum_match_arm)]
                 match msg {
                     InboundDelegateMsg::ApplicationMessage(ApplicationMessage {
                         payload,
@@ -602,6 +615,36 @@ impl DelegateRuntimeInterface for Runtime {
                             params,
                             origin,
                             &msg,
+                            context.clone(),
+                            &running.handle,
+                            instance_id,
+                            api_version,
+                        )?;
+                        context = updated_context;
+
+                        let mut outbound_queue = VecDeque::from(outbound);
+                        self.process_outbound(
+                            delegate_key,
+                            &running.handle,
+                            instance_id,
+                            params,
+                            origin,
+                            &mut outbound_queue,
+                            &mut context,
+                            &mut results,
+                        )?;
+                    }
+                    // `InboundDelegateMsg` is `#[non_exhaustive]` (stdlib
+                    // 0.6.0+). Future variants are forwarded to the WASM
+                    // through the same generic exec path so a delegate
+                    // built against a newer stdlib can handle them; the
+                    // host neither inspects nor classifies their payload.
+                    other => {
+                        let (outbound, updated_context) = self.exec_inbound_with_env(
+                            delegate_key,
+                            params,
+                            origin,
+                            &other,
                             context.clone(),
                             &running.handle,
                             instance_id,

--- a/crates/core/tests/connectivity.rs
+++ b/crates/core/tests/connectivity.rs
@@ -688,7 +688,10 @@ async fn test_three_node_network_connectivity(ctx: &mut TestContext) -> TestResu
                     | other @ UpdateData::StateAndDelta { .. }
                     | other @ UpdateData::RelatedState { .. }
                     | other @ UpdateData::RelatedDelta { .. }
-                    | other @ UpdateData::RelatedStateAndDelta { .. } => {
+                    | other @ UpdateData::RelatedStateAndDelta { .. }
+                    // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0;
+                    // future variants are also unexpected here.
+                    | other => {
                         bail!("Unexpected update data type: {:?}", other)
                     }
                 }

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -2463,6 +2463,7 @@ async fn test_attested_contract_passed_to_delegate(ctx: &mut TestContext) -> Tes
                                 "MessageOrigin contract ID does not match expected"
                             );
                         }
+                        other => bail!("Expected MessageOrigin::WebApp, got {other:?}"),
                     }
                     tracing::info!(
                         "SUCCESS: MessageOrigin correctly passed to delegate process function"

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -1018,7 +1018,11 @@ async fn test_multiple_clients_subscription(ctx: &mut TestContext) -> TestResult
                         | UpdateData::StateAndDelta { .. }
                         | UpdateData::RelatedState { .. }
                         | UpdateData::RelatedDelta { .. }
-                        | UpdateData::RelatedStateAndDelta { .. } => {
+                        | UpdateData::RelatedStateAndDelta { .. }
+                        // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0;
+                        // the wildcard handles future variants the same way as
+                        // any other unexpected variant in this assertion.
+                        | _ => {
                             tracing::warn!(
                                 "Client 1: Received unexpected update type: {:?}",
                                 update
@@ -1093,7 +1097,11 @@ async fn test_multiple_clients_subscription(ctx: &mut TestContext) -> TestResult
                         | UpdateData::StateAndDelta { .. }
                         | UpdateData::RelatedState { .. }
                         | UpdateData::RelatedDelta { .. }
-                        | UpdateData::RelatedStateAndDelta { .. } => {
+                        | UpdateData::RelatedStateAndDelta { .. }
+                        // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0;
+                        // the wildcard handles future variants the same way as
+                        // any other unexpected variant in this assertion.
+                        | _ => {
                             tracing::warn!(
                                 "Client 2: Received unexpected update type: {:?}",
                                 update
@@ -1169,7 +1177,11 @@ async fn test_multiple_clients_subscription(ctx: &mut TestContext) -> TestResult
                         | UpdateData::StateAndDelta { .. }
                         | UpdateData::RelatedState { .. }
                         | UpdateData::RelatedDelta { .. }
-                        | UpdateData::RelatedStateAndDelta { .. } => {
+                        | UpdateData::RelatedStateAndDelta { .. }
+                        // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0;
+                        // the wildcard handles future variants the same way as
+                        // any other unexpected variant in this assertion.
+                        | _ => {
                             tracing::warn!(
                                 "Client 3: Received unexpected update type: {:?}",
                                 update
@@ -1450,7 +1462,10 @@ async fn test_get_with_subscribe_flag(ctx: &mut TestContext) -> TestResult {
                     | UpdateData::StateAndDelta { .. }
                     | UpdateData::RelatedState { .. }
                     | UpdateData::RelatedDelta { .. }
-                    | UpdateData::RelatedStateAndDelta { .. } => {
+                    | UpdateData::RelatedStateAndDelta { .. }
+                    // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0;
+                    // wildcard handles future variants as unexpected.
+                    | _ => {
                         tracing::warn!("Client 1: Received unexpected update type: {:?}", update);
                     }
                 }
@@ -1890,7 +1905,10 @@ async fn test_put_with_subscribe_flag(ctx: &mut TestContext) -> TestResult {
                     | UpdateData::StateAndDelta { .. }
                     | UpdateData::RelatedState { .. }
                     | UpdateData::RelatedDelta { .. }
-                    | UpdateData::RelatedStateAndDelta { .. } => {
+                    | UpdateData::RelatedStateAndDelta { .. }
+                    // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0;
+                    // wildcard handles future variants as unexpected.
+                    | _ => {
                         tracing::warn!(
                             contract = %contract_key,
                             client = 1,

--- a/crates/fdev/src/commands.rs
+++ b/crates/fdev/src/commands.rs
@@ -546,6 +546,11 @@ pub(crate) async fn close_api_client(client: &mut WebApi) {
 }
 
 /// Extract the primary state or delta bytes from an update notification.
+///
+/// `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0; the wildcard arm
+/// returns an empty slice for unknown variants. fdev consumers display this
+/// as "no payload" — they should be rebuilt against the stdlib version that
+/// emits the new variant if the bytes are needed.
 fn extract_update_bytes<'a>(update: &'a UpdateData<'_>) -> &'a [u8] {
     match update {
         UpdateData::State(state) => state.as_ref(),
@@ -554,9 +559,12 @@ fn extract_update_bytes<'a>(update: &'a UpdateData<'_>) -> &'a [u8] {
         UpdateData::RelatedState { state, .. } => state.as_ref(),
         UpdateData::RelatedDelta { delta, .. } => delta.as_ref(),
         UpdateData::RelatedStateAndDelta { state, .. } => state.as_ref(),
+        _ => &[],
     }
 }
 
+/// `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0; the wildcard arm
+/// returns "unknown" for future variants.
 fn describe_update_variant(update: &UpdateData<'_>) -> &'static str {
     match update {
         UpdateData::State(_) => "state",
@@ -565,6 +573,7 @@ fn describe_update_variant(update: &UpdateData<'_>) -> &'static str {
         UpdateData::RelatedState { .. } => "related-state",
         UpdateData::RelatedDelta { .. } => "related-delta",
         UpdateData::RelatedStateAndDelta { .. } => "related-state+delta",
+        _ => "unknown",
     }
 }
 

--- a/tests/test-contract-mock-aligned/src/lib.rs
+++ b/tests/test-contract-mock-aligned/src/lib.rs
@@ -51,6 +51,9 @@ impl ContractInterface for Contract {
                 | UpdateData::RelatedStateAndDelta { .. } => {
                     // Ignore related data for the merge
                 }
+                // `UpdateData` is `#[non_exhaustive]` since stdlib 0.6.0.
+                // Test fixture only — ignore unknown variants for the merge.
+                _ => {}
             }
         }
         match new_state {

--- a/tests/test-delegate-messaging/Cargo.lock
+++ b/tests/test-delegate-messaging/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
 [[package]]
 name = "freenet-macros"
 version = "0.2.0"
+source = "git+https://github.com/freenet/freenet-stdlib?branch=feat-message-origin-delegate#7840137a1368731fd8420e522b586268cc8a75dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -267,6 +268,7 @@ dependencies = [
 [[package]]
 name = "freenet-stdlib"
 version = "0.5.0"
+source = "git+https://github.com/freenet/freenet-stdlib?branch=feat-message-origin-delegate#7840137a1368731fd8420e522b586268cc8a75dd"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-messaging/Cargo.lock
+++ b/tests/test-delegate-messaging/Cargo.lock
@@ -258,8 +258,6 @@ dependencies = [
 [[package]]
 name = "freenet-macros"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26e5c6bee9ffa0e2683bc8b41a7bd9f1e57e7fd49ac4f6ae433e5a82e9006df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -268,9 +266,7 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3ac04f50790cc912697afa60d303a9d3efff2a70e5f787192b7cd053ae2fb9"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-messaging/Cargo.lock
+++ b/tests/test-delegate-messaging/Cargo.lock
@@ -258,7 +258,8 @@ dependencies = [
 [[package]]
 name = "freenet-macros"
 version = "0.2.0"
-source = "git+https://github.com/freenet/freenet-stdlib?branch=feat-message-origin-delegate#7840137a1368731fd8420e522b586268cc8a75dd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26e5c6bee9ffa0e2683bc8b41a7bd9f1e57e7fd49ac4f6ae433e5a82e9006df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -268,7 +269,8 @@ dependencies = [
 [[package]]
 name = "freenet-stdlib"
 version = "0.5.0"
-source = "git+https://github.com/freenet/freenet-stdlib?branch=feat-message-origin-delegate#7840137a1368731fd8420e522b586268cc8a75dd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2475e70183cf53033735bd4a794d7875d0b125f9369bd463dc30c83424dcbea6"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-messaging/Cargo.lock
+++ b/tests/test-delegate-messaging/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-stdlib"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2475e70183cf53033735bd4a794d7875d0b125f9369bd463dc30c83424dcbea6"
+checksum = "0c4a5632deb1066bb756949f37fa9a92a79a7b710a2015ec02bb315d0f598629"
 dependencies = [
  "bincode",
  "blake3",

--- a/tests/test-delegate-messaging/Cargo.toml
+++ b/tests/test-delegate-messaging/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.5.0", features = ["contract"] }
+freenet-stdlib = { version = "0.6.0", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 

--- a/tests/test-delegate-messaging/Cargo.toml
+++ b/tests/test-delegate-messaging/Cargo.toml
@@ -9,12 +9,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-# Temporary git pin: this fixture's parent workspace is separate from the
-# root freenet-core workspace, so the `[patch.crates-io]` override in the
-# root Cargo.toml does NOT apply here — we must point at the stdlib branch
-# directly. Must be replaced with the published 0.5.0 from crates.io once
-# stdlib is released. Tracked in freenet/freenet-core#3865.
-freenet-stdlib = { git = "https://github.com/freenet/freenet-stdlib", branch = "feat-message-origin-delegate", features = ["contract"] }
+freenet-stdlib = { version = "0.5.0", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 

--- a/tests/test-delegate-messaging/Cargo.toml
+++ b/tests/test-delegate-messaging/Cargo.toml
@@ -9,10 +9,12 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-# Point at the local freenet-stdlib worktree carrying the
-# MessageOrigin::Delegate variant (issue #3860). Must be replaced with
-# the published 0.5.0 from crates.io once stdlib is released.
-freenet-stdlib = { path = "../../../../freenet-stdlib-3860/rust", features = ["contract"] }
+# Temporary git pin: this fixture's parent workspace is separate from the
+# root freenet-core workspace, so the `[patch.crates-io]` override in the
+# root Cargo.toml does NOT apply here — we must point at the stdlib branch
+# directly. Must be replaced with the published 0.5.0 from crates.io once
+# stdlib is released. Tracked in freenet/freenet-core#3865.
+freenet-stdlib = { git = "https://github.com/freenet/freenet-stdlib", branch = "feat-message-origin-delegate", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 

--- a/tests/test-delegate-messaging/Cargo.toml
+++ b/tests/test-delegate-messaging/Cargo.toml
@@ -9,7 +9,10 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-freenet-stdlib = { version = "0.3.5", features = ["contract"] }
+# Point at the local freenet-stdlib worktree carrying the
+# MessageOrigin::Delegate variant (issue #3860). Must be replaced with
+# the published 0.5.0 from crates.io once stdlib is released.
+freenet-stdlib = { path = "../../../../freenet-stdlib-3860/rust", features = ["contract"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 

--- a/tests/test-delegate-messaging/src/lib.rs
+++ b/tests/test-delegate-messaging/src/lib.rs
@@ -19,6 +19,10 @@ pub enum OutboundAppMessage {
     DelegateMessageReceived {
         sender_key_bytes: Vec<u8>,
         payload: Vec<u8>,
+        /// Runtime-attested caller key extracted from the `origin` parameter
+        /// passed to `process()`. `Some` when origin was
+        /// `MessageOrigin::Delegate(k)` (issue #3860); `None` otherwise.
+        origin_delegate_key_bytes: Option<Vec<u8>>,
     },
     PingResponse {
         data: Vec<u8>,
@@ -32,7 +36,7 @@ impl DelegateInterface for Delegate {
     fn process(
         _ctx: &mut DelegateCtx,
         _params: Parameters<'static>,
-        _origin: Option<MessageOrigin>,
+        origin: Option<MessageOrigin>,
         messages: InboundDelegateMsg,
     ) -> Result<Vec<OutboundDelegateMsg>, DelegateError> {
         match messages {
@@ -80,10 +84,20 @@ impl DelegateInterface for Delegate {
             }
             InboundDelegateMsg::DelegateMessage(msg) => {
                 let sender_key_bytes = msg.sender.bytes().to_vec();
+                // Echo the runtime-attested origin so the test can assert that
+                // `MessageOrigin::Delegate(caller_key)` reaches the receiver
+                // (issue #3860). Match exhaustively so a future MessageOrigin
+                // variant isn't silently dropped.
+                let origin_delegate_key_bytes = match &origin {
+                    Some(MessageOrigin::Delegate(k)) => Some(k.bytes().to_vec()),
+                    Some(MessageOrigin::WebApp(_)) | None => None,
+                    Some(_) => None,
+                };
                 let response_payload =
                     bincode::serialize(&OutboundAppMessage::DelegateMessageReceived {
                         sender_key_bytes,
                         payload: msg.payload,
+                        origin_delegate_key_bytes,
                     })
                     .map_err(|err| DelegateError::Other(format!("{err}")))?;
 


### PR DESCRIPTION
## Problem

When delegate A sends a message to delegate B via
`OutboundDelegateMsg::SendDelegateMessage`, B's `process()` is invoked with
`origin = None`. B has no way to learn which delegate (if any) called it.
The dispatch site at `crates/core/src/contract.rs:479` explicitly passed
`None` and the comment acknowledged the gap:

> origin_contract is None for inter-delegate delivery since the message
> originates from another delegate, not from a contract attestation context.

This blocks any trust policy that depends on caller delegate identity, and
prevents the permission prompt UI added in #3857 from showing the actual
caller for delegate-to-delegate `RequestUserInput` requests.

## Approach

Add a `Delegate(DelegateKey)` variant to `freenet-stdlib::MessageOrigin`
(see freenet/freenet-stdlib#65) and plumb a runtime-attested caller delegate
key through the inter-delegate dispatch path so the receiver sees
`Some(MessageOrigin::Delegate(caller_key))` instead of `None`.

`ContractExecutor::execute_delegate_request` gains a
`caller_delegate: Option<&DelegateKey>` parameter alongside the existing
`origin_contract`. The two are mutually exclusive at the call sites:

- Web app → delegate (via WebSocket): `origin_contract = Some(...)`,
  `caller_delegate = None`. Receiver sees `MessageOrigin::WebApp(contract_id)`.
- Delegate A → delegate B (`SendDelegateMessage`): `origin_contract = None`,
  `caller_delegate = Some(&A_key)`. Receiver sees
  `MessageOrigin::Delegate(A_key)`. The runtime fills this in from the
  caller's executing context (`delegate_key` is bound from `req.key()` —
  trustworthy because the runtime sets it, not from caller-controlled WASM
  output) — so the calling delegate cannot forge it.

Origin resolution lives in a new free function `resolve_message_origin` so
the precedence rules are unit-testable directly:

  1. `caller_delegate` (Delegate variant) — wins unconditionally.
  2. `origin_contract` (WebApp variant).
  3. `DELEGATE_INHERITED_ORIGINS` lookup (inherited WebApp).

A `debug_assert!` enforces the mutual-exclusion invariant on the two
arguments. The wasm_runtime layer matches the new `MessageOrigin::Delegate(_)`
variant explicitly: only `WebApp` propagates contract access into
`origin_contracts`; `Delegate` carries identity only. The
`#[non_exhaustive]` catch-all logs a `tracing::warn!` so any future variant
that reaches the fail-closed default is visible during the PR that adds it
rather than silently denying contract access in production.

## Compatibility

The companion stdlib change is a source-level break (variant added,
`#[non_exhaustive]`) but **not** a wire-format break — bincode discriminants
for existing variants are unchanged, and stdlib pins both `WebApp` and
`Delegate` byte layouts in `delegate_interface.rs` tests. `MessageOrigin`
is delegate-only, so:

- **Contracts: unaffected entirely.** Contracts never see `MessageOrigin`.
- **Deployed delegates that receive only `WebApp` or `None` origins:
  unaffected.** They continue to deserialize identically.
- **Deployed delegates that begin receiving inter-delegate calls: would
  fail to deserialize `Delegate(..)`.** This requires another delegate to
  call them via `SendDelegateMessage`, which no production delegate
  exercises today (river chat delegate, ghostkey, etc.).

A delegate that wants to start participating in inter-delegate messaging
after this lands must be rebuilt against stdlib 0.5.x.

## Testing

- `resolve_message_origin_tests` (new, 4 unit tests) — pin the precedence
  rules directly: caller_delegate wins over origin_contract, origin_contract
  alone yields WebApp, neither + no inherited yields None, caller_delegate
  also overrides an inherited WebApp origin (documents revocation semantics).
- `test_inbound_app_message_propagates_delegate_origin` (new) — calls
  `runtime.inbound_app_message` with `Some(MessageOrigin::Delegate(caller_a))`
  and asserts the test delegate's `process()` echoes that exact caller key
  back via a new `origin_delegate_key_bytes` field on
  `DelegateMessageReceived`. The in-band `msg.sender` is set to a different
  key so the assertion cannot pass by accident if the receiver confuses
  `msg.sender` with the runtime-attested origin.
- The existing `test_delegate_emits_send_delegate_message`,
  `test_delegate_receives_delegate_message`, and
  `test_delegate_to_delegate_roundtrip` tests continue to pass.
- All 2241 lib tests in `cargo test -p freenet --lib` pass locally.
- `cargo clippy --locked -- -D warnings` clean.

### Why didn't CI catch this?

The bug was a missing capability, not a regression — `origin = None` was
returning a documented limitation. CI couldn't catch it because the contract
surface didn't exist yet. The new `resolve_message_origin_tests` now fail
without the `caller_delegate` plumbing, so any regression that drops the
attestation will be caught at the unit-test level.

## Pre-merge checklist (release coordination)

⚠️ **Draft** — must not merge until the items below are checked off.

There are **three** `freenet-stdlib` references that currently point at
the `feat-message-origin-delegate` branch on github via `git = ...` so CI
can build this PR before stdlib publishes. All three must be removed
before merge:

- [ ] freenet/freenet-stdlib#65 published to crates.io as **0.5.0**
- [ ] Root `Cargo.toml`: delete the `[patch.crates-io]` block (regular
  `freenet-stdlib = "0.5.0"` from crates.io takes over).
- [ ] `apps/freenet-ping/Cargo.toml`: delete the `[patch.crates-io]` block
  (added in this PR because the nested ping workspace transitively
  requires `freenet-stdlib = "0.5.0"` via the `freenet` path-dep, and
  Cargo's `[patch.crates-io]` is not inherited by nested workspaces).
- [ ] `tests/test-delegate-messaging/Cargo.toml`: replace the
  `git = ..., branch = ...` line with `version = "0.5.0", features = ["contract"]`.
- [ ] All affected `Cargo.lock` files regenerated against crates.io
- [ ] `riverctl member list` smoke test against a gateway running the
  rebuilt binary (per `.claude/rules/bug-prevention-patterns.md` — "Protocol
  enum changes" rule learned from the v0.2.11 streaming incident). River's
  current source does not reference `MessageOrigin` so source-compat risk
  is nil, but the runtime smoke test should still happen.
- [ ] Audit `tests/test-delegate-capabilities/src/lib.rs` — it pattern-matches
  `MessageOrigin` exhaustively against only the `WebApp` arm. That crate
  currently pins `freenet-stdlib = "0.3.5"` in its own workspace, so it does
  not break this PR's build, but the moment its stdlib bumps to 0.5 it fails
  to compile. Either update in this PR or file a follow-up issue.
- [ ] Mark PR ready for review (un-draft) once the items above are done

## Fixes

Closes #3860

[AI-assisted - Claude]