### PR TITLE
ci: isolate and contain fdev simulation hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,72 +450,124 @@ jobs:
         env:
           RUST_LOG: info,turmoil=warn
         run: |
+          # Each fdev sim runs under `timeout` so one hanging sim cannot eat the
+          # entire 30m budget silently. Each sim writes to its own log file so
+          # we can upload them as artifacts and tell which one wedged.
+          mkdir -p sim-logs
+
           # Nextest simulation tests (already built above with --no-run).
-          cargo nextest run -p freenet --locked \
-            --test simulation_integration \
-            --test simulation_smoke \
-            --test streaming_e2e \
-            --test state_verification \
-            --features simulation_tests,testing --profile ci &
+          {
+            echo "== $(date -u +%H:%M:%S) nextest starting"
+            cargo nextest run -p freenet --locked \
+              --test simulation_integration \
+              --test simulation_smoke \
+              --test streaming_e2e \
+              --test state_verification \
+              --features simulation_tests,testing --profile ci 2>&1
+            rc=$?
+            echo "== $(date -u +%H:%M:%S) nextest done rc=${rc}"
+            exit $rc
+          } > sim-logs/nextest.log 2>&1 &
           NEXTEST_PID=$!
 
-          # fdev simulation tests run in parallel with nextest above.
-          # Each fdev invocation uses unique network names and dynamic ports.
-          target/release/fdev test \
-            --name "ci-medium-50" \
-            --seed 0xDEADBEEF \
-            --gateways 4 --nodes 46 --events 2000 \
-            --ring-max-htl 12 --max-connections 20 --min-connections 6 \
-            --latency-min 10 --latency-max 50 \
-            --min-success-rate 1.0 \
-            --print-summary --print-network-stats \
-            single-process &
+          # 8 minute cap per sim, SIGKILL 30s later if it refuses to die.
+          # Background directly (no function) so $! refers to the actual child
+          # of this shell, which `wait` can then reap.
+          {
+            echo "== $(date -u +%H:%M:%S) ci-medium-50 starting"
+            timeout --kill-after=30s 8m target/release/fdev test \
+              --name "ci-medium-50" \
+              --seed 0xDEADBEEF \
+              --gateways 4 --nodes 46 --events 2000 \
+              --ring-max-htl 12 --max-connections 20 --min-connections 6 \
+              --latency-min 10 --latency-max 50 \
+              --min-success-rate 1.0 \
+              --print-summary --print-network-stats \
+              single-process 2>&1
+            rc=$?
+            echo "== $(date -u +%H:%M:%S) ci-medium-50 done rc=${rc}"
+            exit $rc
+          } > sim-logs/ci-medium-50.log 2>&1 &
           PID1=$!
 
-          target/release/fdev test \
-            --name "ci-fault-loss" \
-            --seed 0xFA017001 \
-            --gateways 3 --nodes 27 --events 1000 \
-            --message-loss 0.15 \
-            --latency-min 10 --latency-max 50 \
-            --min-success-rate 0.80 \
-            --print-summary --print-network-stats \
-            single-process &
+          {
+            echo "== $(date -u +%H:%M:%S) ci-fault-loss starting"
+            timeout --kill-after=30s 8m target/release/fdev test \
+              --name "ci-fault-loss" \
+              --seed 0xFA017001 \
+              --gateways 3 --nodes 27 --events 1000 \
+              --message-loss 0.15 \
+              --latency-min 10 --latency-max 50 \
+              --min-success-rate 0.80 \
+              --print-summary --print-network-stats \
+              single-process 2>&1
+            rc=$?
+            echo "== $(date -u +%H:%M:%S) ci-fault-loss done rc=${rc}"
+            exit $rc
+          } > sim-logs/ci-fault-loss.log 2>&1 &
           PID2=$!
 
-          target/release/fdev test \
-            --name "ci-high-latency" \
-            --seed 0x1A7E0C71 \
-            --gateways 2 --nodes 12 --events 500 \
-            --latency-min 50 --latency-max 200 \
-            --min-success-rate 0.95 \
-            --print-summary --print-network-stats \
-            single-process &
+          {
+            echo "== $(date -u +%H:%M:%S) ci-high-latency starting"
+            timeout --kill-after=30s 8m target/release/fdev test \
+              --name "ci-high-latency" \
+              --seed 0x1A7E0C71 \
+              --gateways 2 --nodes 12 --events 500 \
+              --latency-min 50 --latency-max 200 \
+              --min-success-rate 0.95 \
+              --print-summary --print-network-stats \
+              single-process 2>&1
+            rc=$?
+            echo "== $(date -u +%H:%M:%S) ci-high-latency done rc=${rc}"
+            exit $rc
+          } > sim-logs/ci-high-latency.log 2>&1 &
           PID3=$!
 
-          # Churn resilience: tests network behavior under node crashes/restarts.
-          # Only takes a few seconds, so cheap to run on every PR.
-          target/release/fdev test \
-            --name "ci-churn-20" \
-            --seed 0xC102FEED \
-            --gateways 2 --nodes 18 --events 500 \
-            --ring-max-htl 10 --max-connections 15 --min-connections 4 \
-            --latency-min 10 --latency-max 50 \
-            --churn-rate 0.1 --churn-recovery-delay-ms 3000 \
-            --churn-permanent-rate 0.05 --churn-tick-ms 5000 \
-            --min-success-rate 0.80 \
-            --print-summary --print-network-stats \
-            single-process &
+          {
+            echo "== $(date -u +%H:%M:%S) ci-churn-20 starting"
+            timeout --kill-after=30s 8m target/release/fdev test \
+              --name "ci-churn-20" \
+              --seed 0xC102FEED \
+              --gateways 2 --nodes 18 --events 500 \
+              --ring-max-htl 10 --max-connections 15 --min-connections 4 \
+              --latency-min 10 --latency-max 50 \
+              --churn-rate 0.1 --churn-recovery-delay-ms 3000 \
+              --churn-permanent-rate 0.05 --churn-tick-ms 5000 \
+              --min-success-rate 0.80 \
+              --print-summary --print-network-stats \
+              single-process 2>&1
+            rc=$?
+            echo "== $(date -u +%H:%M:%S) ci-churn-20 done rc=${rc}"
+            exit $rc
+          } > sim-logs/ci-churn-20.log 2>&1 &
           PID4=$!
+
+          echo "Started: nextest=$NEXTEST_PID medium=$PID1 fault=$PID2 latency=$PID3 churn=$PID4"
 
           # Wait for all and fail if any failed
           FAILED=0
-          wait $NEXTEST_PID || FAILED=1
-          wait $PID1 || FAILED=1
-          wait $PID2 || FAILED=1
-          wait $PID3 || FAILED=1
-          wait $PID4 || FAILED=1
+          wait $NEXTEST_PID || { echo "nextest FAILED"; FAILED=1; }
+          wait $PID1 || { echo "ci-medium-50 FAILED"; FAILED=1; }
+          wait $PID2 || { echo "ci-fault-loss FAILED"; FAILED=1; }
+          wait $PID3 || { echo "ci-high-latency FAILED"; FAILED=1; }
+          wait $PID4 || { echo "ci-churn-20 FAILED"; FAILED=1; }
+
+          echo "===== sim log tails ====="
+          for f in sim-logs/*.log; do
+            echo "----- $f (last 40 lines) -----"
+            tail -n 40 "$f" || true
+          done
+
           exit $FAILED
+
+      - name: Upload simulation logs
+        if: always() && steps.release_check.outputs.is_release != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: simulation-logs
+          path: sim-logs/
+          if-no-files-found: ignore
+          retention-days: 7
 
   nat_validation:
     name: NAT Validation


### PR DESCRIPTION
## Problem

The Simulation job has hung silently at least once (PR #3861 libc bump, run 24365113346 attempt 1 — Simulation job 71154729735 ran 20:26–21:01 UTC, ~35 min, killed at the 30m timeout).

Investigation of the hung job log:

- Stdout stops at wall-clock `20:35:24` with `ci-medium-50` still active
- The last ~3.5M log lines are a flood of `connect: at terminus, cannot accept, uphill budget or TTL exhausted — rejecting` messages from `operations/connect.rs:733`
- **All share a single CONNECT transaction** `01E0YHAGAQ5N6DTVPA9BM7W000`
- All target the same location `0.5769556738838244`
- Bouncing between the same 3 peers (`ci-medium-50-node-27/28/35`)
- `ttl = 0 | 1`, `uphill_budget = 3` consistently
- `visited` bloom filter oscillates between 81 and 84 set bits — i.e. the visited set is **not monotonically growing** across hops, which should not happen if each forward added the sender before re-emitting
- After `20:35:24`, stdout is silent for ~26 minutes until the runner kills the job

This has the shape of an infinite CONNECT forwarding loop among a small peer set, eventually deadlocking the tracing layer / stdout writer once the log backlog exceeds some buffer.

Because the 4 fdev sims run in parallel via `&` + single `wait`, we cannot tell from the aggregated log which sim wedged, and there is no per-sim bound — a hang in any one silently eats the whole 30m job budget.

## Solution

Minimal diagnostic CI change (no core code touched):

- Each fdev sim runs inside `timeout --kill-after=30s 8m` — one hang cannot steal the whole job budget
- Each sim + the nextest batch write stdout/stderr to a per-sim `sim-logs/<name>.log`
- `sim-logs/` is uploaded as a CI artifact on every run, success or failure
- `== HH:MM:SS <name> starting|done rc=N` markers let us tell at a glance which sim hit the 8m cap
- Sims are backgrounded directly as `{ ...; } &` brace groups (not via a helper + command substitution), so `$!` in the parent shell yields PIDs that `wait` can actually reap — an earlier revision of this PR got that wrong
- Inline log tails at the end of the step for quick inspection in the Actions UI

The per-sim timeout is worth keeping even after the underlying hang is root-caused: any future hang will now fail fast and be uniquely identified instead of burning 30 minutes of runner time.

## Not included

Root cause and fix for the underlying hang. The hang is **intermittent** — it reproduced once in the last 50+ CI runs and does not reproduce locally on the same commit and seed (0xDEADBEEF) on a 32-core workstation (`ci-medium-50` finishes in ~60s locally). Without a deterministic repro, bisecting the suspect commits (#3850, #3803, #3806, #3643) is not actionable. The per-sim artifacts landed here are the prerequisite: with them, the next occurrence will give us the exact sim, the full trailing tracing output, and precise wall-clock-vs-sim-clock timings needed to identify the loop.

## Testing

This IS CI diagnostic infrastructure, validated on the PR's own CI run. The first revision of this diagnostic had a bash bug (command-substitution subshells orphaned the PIDs, making `wait` return 127 for successful sims) which is why the first CI run here reported all sims as FAILED even though every sim printed `rc=0` in its artifact. That bug is fixed in the squashed commit in this PR.

[AI-assisted - Claude]