### PR TITLE
fix: populate Delegate and Caller in permission prompt UI

### DIFF
--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -518,10 +518,10 @@ where
             // renders. Today the only attested non-None caller is a web app
             // (via `MessageOrigin::WebApp`); delegate-to-delegate attestation
             // is tracked by #3860 and will appear here as a new variant.
-            let caller = match origin_contract {
-                Some(id) => CallerIdentity::WebApp(id.to_string()),
-                None => CallerIdentity::None,
-            };
+            //
+            // The actual mapping lives in `caller_identity_from_origin` so it
+            // can be unit-tested independently of the executor plumbing.
+            let caller = caller_identity_from_origin(origin_contract);
             let delegate_key_str = delegate_key.to_string();
 
             for req in user_input_requests {
@@ -585,6 +585,28 @@ fn try_recv_delegate_notification(
     match rx {
         Some(rx) => rx.try_recv().ok(),
         None => None,
+    }
+}
+
+/// Build a `CallerIdentity` for the permission prompt UI from the executor's
+/// runtime origin context (see #3857).
+///
+/// The mapping is intentionally narrow: today the only attested non-`None`
+/// caller is a web app via `MessageOrigin::WebApp(..)`. Every other path
+/// (delegate-to-delegate, local client, missing attestation) collapses to
+/// `CallerIdentity::None` and renders as `"No app caller"` in the UI.
+/// Issue #3860 tracks adding a `MessageOrigin::Delegate(DelegateKey)` variant
+/// and the corresponding `CallerIdentity::Delegate` row; until that lands,
+/// inter-delegate calls are not distinguishable here from "no caller at all".
+///
+/// Extracted as a free function (rather than inlined at the call site) so
+/// the mapping can be unit-tested in isolation. Without this, swapping the
+/// `Some` and `None` arms — or accidentally wiring a delegate-controlled
+/// value into the prompter — would not fail any test.
+fn caller_identity_from_origin(origin: Option<&ContractInstanceId>) -> CallerIdentity {
+    match origin {
+        Some(id) => CallerIdentity::WebApp(id.to_string()),
+        None => CallerIdentity::None,
     }
 }
 
@@ -1327,6 +1349,32 @@ mod tests {
         let code = ContractCode::from(vec![42u8; 32]);
         let params = Parameters::from(vec![7u8; 8]);
         ContractKey::from_params_and_code(&params, &code)
+    }
+
+    // Regression test for issue #3857: the executor's origin context must be
+    // mapped onto the prompter's CallerIdentity correctly. Without this test,
+    // accidentally swapping the Some/None arms — or wiring the wrong
+    // variable into the prompter call — would not fail any other test in
+    // the suite (the prompter unit tests pass `CallerIdentity` in directly).
+    #[test]
+    fn test_caller_identity_from_origin() {
+        // None origin (delegate-to-delegate, local client, missing
+        // attestation) collapses to CallerIdentity::None.
+        assert_eq!(caller_identity_from_origin(None), CallerIdentity::None);
+
+        // Some(ContractInstanceId) becomes CallerIdentity::WebApp(<id>),
+        // with the id stringified via its Display impl.
+        let key = make_contract_key();
+        let id = *key.id();
+        let mapped = caller_identity_from_origin(Some(&id));
+        assert_eq!(mapped, CallerIdentity::WebApp(id.to_string()));
+
+        // Sanity check: the produced string must not be empty (would
+        // render as "Freenet app " with a dangling space in the UI).
+        match mapped {
+            CallerIdentity::WebApp(s) => assert!(!s.is_empty()),
+            other => panic!("expected WebApp, got {other:?}"),
+        }
     }
 
     /// Helper: send an event through the sender halve and receive it on the handler side,

--- a/crates/core/src/contract.rs
+++ b/crates/core/src/contract.rs
@@ -39,7 +39,7 @@ use freenet_stdlib::client_api::DelegateRequest;
 use tracing::Instrument;
 
 use self::executor::DelegateNotificationReceiver;
-use self::user_input::UserInputPrompter;
+use self::user_input::{CallerIdentity, UserInputPrompter};
 
 /// Maximum iterations when handling contract requests to prevent infinite loops
 const MAX_CONTRACT_REQUEST_ITERATIONS: usize = 100;
@@ -511,9 +511,25 @@ where
                 "Processing UserInputRequest messages from delegate"
             );
 
+            // The caller identity passed to the prompter is built from the
+            // executor's runtime context, NOT from anything the delegate could
+            // influence — so a malicious delegate cannot spoof another app's
+            // or delegate's identity in the structured fields the prompt UI
+            // renders. Today the only attested non-None caller is a web app
+            // (via `MessageOrigin::WebApp`); delegate-to-delegate attestation
+            // is tracked by #3860 and will appear here as a new variant.
+            let caller = match origin_contract {
+                Some(id) => CallerIdentity::WebApp(id.to_string()),
+                None => CallerIdentity::None,
+            };
+            let delegate_key_str = delegate_key.to_string();
+
             for req in user_input_requests {
                 let request_id = req.request_id;
-                let response = match prompter.prompt(&req).await {
+                let response = match prompter
+                    .prompt(&req, &delegate_key_str, caller.clone())
+                    .await
+                {
                     Some((_, response)) => response,
                     None => {
                         tracing::warn!(

--- a/crates/core/src/contract/user_input.rs
+++ b/crates/core/src/contract/user_input.rs
@@ -15,11 +15,44 @@ const MAX_LABEL_LEN: usize = 64;
 /// Maximum number of response buttons. Keeps the UI usable.
 const MAX_LABELS: usize = 10;
 
+/// Runtime-attested identity of the entity that triggered a permission prompt.
+///
+/// This is a display-layer representation: it lives only between the executor
+/// (which knows the typed `ContractInstanceId` / future `DelegateKey`) and the
+/// permission-prompt UI. Stringification happens at the boundary so the UI
+/// doesn't depend on stdlib types and the stored prompt can be serialised to
+/// the dashboard JSON without any further conversion.
+///
+/// Variants reflect what `MessageOrigin` in freenet-stdlib can carry today.
+/// A `Delegate(String)` variant is reserved for #3860 (extending
+/// `MessageOrigin` to attest delegate-to-delegate callers); the prompt UI is
+/// already shaped to render it without further changes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CallerIdentity {
+    /// No structured caller was recorded for this request. Today this covers
+    /// both "no web app involved" and "delegate-to-delegate call" — those are
+    /// not currently distinguishable at the API level (see #3860).
+    None,
+    /// The request came from a web app whose contract id was attested by
+    /// `MessageOrigin::WebApp(..)`. The string is the `ContractInstanceId`
+    /// in its canonical display form.
+    WebApp(String),
+}
+
 /// Abstracts user prompting for delegate `RequestUserInput` messages.
+///
+/// Implementations receive the runtime-attested identity of the calling
+/// delegate and (when known) of the originating web app. These identities are
+/// rendered in the permission prompt UI so the user can see *who* is asking
+/// and *which* app triggered the request. The identities MUST come from the
+/// runtime context, never from the delegate's own message payload — a rogue
+/// delegate must not be able to spoof another delegate's or app's identity.
 pub trait UserInputPrompter: Send + Sync {
     fn prompt(
         &self,
         request: &UserInputRequest<'static>,
+        delegate_key: &str,
+        caller: CallerIdentity,
     ) -> impl std::future::Future<Output = Option<(usize, ClientResponse<'static>)>> + Send;
 }
 
@@ -28,7 +61,7 @@ pub(crate) struct PendingPrompt {
     pub message: String,
     pub labels: Vec<String>,
     pub delegate_key: String,
-    pub contract_id: String,
+    pub caller: CallerIdentity,
     pub response_tx: oneshot::Sender<usize>,
 }
 
@@ -69,6 +102,8 @@ impl UserInputPrompter for DashboardPrompter {
     async fn prompt(
         &self,
         request: &UserInputRequest<'static>,
+        delegate_key: &str,
+        caller: CallerIdentity,
     ) -> Option<(usize, ClientResponse<'static>)> {
         if request.responses.is_empty() {
             tracing::warn!("RequestUserInput has no response options");
@@ -96,8 +131,8 @@ impl UserInputPrompter for DashboardPrompter {
             PendingPrompt {
                 message,
                 labels,
-                delegate_key: "Unknown".to_string(), // TODO: pass from executor context
-                contract_id: "Unknown".to_string(),  // TODO: pass from executor context
+                delegate_key: delegate_key.to_string(),
+                caller,
                 response_tx: tx,
             },
         );
@@ -184,6 +219,8 @@ impl UserInputPrompter for AutoApprovePrompter {
     async fn prompt(
         &self,
         request: &UserInputRequest<'static>,
+        _delegate_key: &str,
+        _caller: CallerIdentity,
     ) -> Option<(usize, ClientResponse<'static>)> {
         request
             .responses
@@ -201,6 +238,8 @@ impl UserInputPrompter for AutoDenyPrompter {
     async fn prompt(
         &self,
         _request: &UserInputRequest<'static>,
+        _delegate_key: &str,
+        _caller: CallerIdentity,
     ) -> Option<(usize, ClientResponse<'static>)> {
         None
     }
@@ -226,10 +265,16 @@ pub(crate) fn make_test_request(message: &str, responses: Vec<&str>) -> UserInpu
 mod tests {
     use super::*;
 
+    fn webapp(s: &str) -> CallerIdentity {
+        CallerIdentity::WebApp(s.to_string())
+    }
+
     #[tokio::test]
     async fn test_auto_approve_returns_first_response() {
         let req = make_test_request("Allow this?", vec!["Allow", "Deny"]);
-        let result = AutoApprovePrompter.prompt(&req).await;
+        let result = AutoApprovePrompter
+            .prompt(&req, "dkey", webapp("cid"))
+            .await;
         let (idx, response) = result.unwrap();
         assert_eq!(idx, 0);
         assert_eq!(&*response, b"Allow");
@@ -238,14 +283,16 @@ mod tests {
     #[tokio::test]
     async fn test_auto_approve_empty_responses() {
         let req = make_test_request("Allow this?", vec![]);
-        let result = AutoApprovePrompter.prompt(&req).await;
+        let result = AutoApprovePrompter
+            .prompt(&req, "dkey", webapp("cid"))
+            .await;
         assert!(result.is_none());
     }
 
     #[tokio::test]
     async fn test_auto_deny_always_returns_none() {
         let req = make_test_request("Allow this?", vec!["Allow", "Deny"]);
-        let result = AutoDenyPrompter.prompt(&req).await;
+        let result = AutoDenyPrompter.prompt(&req, "dkey", webapp("cid")).await;
         assert!(result.is_none());
     }
 
@@ -290,14 +337,14 @@ mod tests {
                     message: "test".to_string(),
                     labels: vec!["OK".to_string()],
                     delegate_key: String::new(),
-                    contract_id: String::new(),
+                    caller: CallerIdentity::None,
                     response_tx: tx,
                 },
             );
         }
 
         let req = make_test_request("Over limit", vec!["Allow"]);
-        let result = prompter.prompt(&req).await;
+        let result = prompter.prompt(&req, "dkey", webapp("cid")).await;
         assert!(result.is_none());
     }
 
@@ -356,7 +403,9 @@ mod tests {
     #[tokio::test]
     async fn test_auto_approve_with_three_responses() {
         let req = make_test_request("Allow?", vec!["Allow Once", "Always Allow", "Deny"]);
-        let result = AutoApprovePrompter.prompt(&req).await;
+        let result = AutoApprovePrompter
+            .prompt(&req, "dkey", webapp("cid"))
+            .await;
         let (idx, response) = result.unwrap();
         assert_eq!(idx, 0);
         assert_eq!(&*response, b"Allow Once");
@@ -365,8 +414,78 @@ mod tests {
     #[tokio::test]
     async fn test_auto_deny_with_multiple_responses() {
         let req = make_test_request("Allow?", vec!["Allow Once", "Always Allow", "Deny"]);
-        let result = AutoDenyPrompter.prompt(&req).await;
+        let result = AutoDenyPrompter.prompt(&req, "dkey", webapp("cid")).await;
         assert!(result.is_none());
+    }
+
+    // Regression test for issue #3857: the dashboard prompter MUST populate
+    // PendingPrompt's identity fields from the runtime-attested values passed
+    // into prompt(), not hardcode them to "Unknown". Without this, the
+    // permission overlay renders "Unknown" in the structured identity slots,
+    // forcing the user to trust the delegate's self-authored message for
+    // attribution, which a malicious delegate could spoof.
+    #[tokio::test]
+    async fn test_dashboard_prompter_populates_webapp_caller() {
+        let pending: PendingPrompts = Arc::new(DashMap::new());
+        let prompter = DashboardPrompter::new(pending.clone());
+
+        let req = make_test_request("Approve?", vec!["Allow", "Deny"]);
+        let pending_clone = pending.clone();
+        let handle = tokio::spawn(async move {
+            prompter
+                .prompt(&req, "DLGKEY123", webapp("CONTRACT456"))
+                .await
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let entry = pending_clone
+            .iter()
+            .next()
+            .expect("prompt should be registered");
+        assert_eq!(entry.value().delegate_key, "DLGKEY123");
+        assert_eq!(
+            entry.value().caller,
+            CallerIdentity::WebApp("CONTRACT456".to_string())
+        );
+
+        let nonce = entry.key().clone();
+        drop(entry);
+        let (_, prompt) = pending_clone.remove(&nonce).unwrap();
+        prompt.response_tx.send(1).unwrap();
+        let _ = handle.await.unwrap();
+    }
+
+    // When no web-app caller is attested (delegate-to-delegate, local client,
+    // or any other non-WebApp invocation path), the prompt should record
+    // CallerIdentity::None — distinct from WebApp(""), so the UI can render a
+    // dedicated "No app caller" line rather than a blank field.
+    #[tokio::test]
+    async fn test_dashboard_prompter_records_none_caller() {
+        let pending: PendingPrompts = Arc::new(DashMap::new());
+        let prompter = DashboardPrompter::new(pending.clone());
+
+        let req = make_test_request("Approve?", vec!["Allow"]);
+        let pending_clone = pending.clone();
+        let handle =
+            tokio::spawn(
+                async move { prompter.prompt(&req, "DLGKEY", CallerIdentity::None).await },
+            );
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let entry = pending_clone
+            .iter()
+            .next()
+            .expect("prompt should be registered");
+        assert_eq!(entry.value().delegate_key, "DLGKEY");
+        assert_eq!(entry.value().caller, CallerIdentity::None);
+
+        let nonce = entry.key().clone();
+        drop(entry);
+        let (_, prompt) = pending_clone.remove(&nonce).unwrap();
+        prompt.response_tx.send(0).unwrap();
+        let _ = handle.await.unwrap();
     }
 
     #[tokio::test]
@@ -378,7 +497,8 @@ mod tests {
 
         // Spawn the prompt in a task
         let pending_clone = pending.clone();
-        let handle = tokio::spawn(async move { prompter.prompt(&req).await });
+        let handle =
+            tokio::spawn(async move { prompter.prompt(&req, "dkey", webapp("cid")).await });
 
         // Wait briefly for the prompt to be inserted
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/crates/core/src/contract/user_input.rs
+++ b/crates/core/src/contract/user_input.rs
@@ -14,6 +14,16 @@ const MAX_MESSAGE_LEN: usize = 2048;
 const MAX_LABEL_LEN: usize = 64;
 /// Maximum number of response buttons. Keeps the UI usable.
 const MAX_LABELS: usize = 10;
+/// Maximum stored length of a runtime-attested identity hash.
+///
+/// Defense-in-depth: today both `delegate_key` and `CallerIdentity::WebApp`
+/// hashes come from runtime context that is bounded at the source (BLAKE3
+/// hex / base58 contract id, both well under this limit). Capping at the
+/// insertion point keeps the prompt store from holding arbitrarily large
+/// strings if a future caller passes something larger, and matches the
+/// downstream cap applied in `permission_prompts.rs` at the JSON / HTML
+/// boundary so the two layers can never disagree about the maximum.
+const MAX_IDENTITY_HASH_CHARS: usize = 256;
 
 /// Runtime-attested identity of the entity that triggered a permission prompt.
 ///
@@ -126,13 +136,23 @@ impl UserInputPrompter for DashboardPrompter {
 
         let (tx, rx) = oneshot::channel();
 
+        // Cap stored identity hashes at MAX_IDENTITY_HASH_CHARS at the
+        // insertion boundary (not just at the JSON/HTML layer). Defense-in-
+        // depth: real-world delegate keys are BLAKE3 hex (~64 chars) and
+        // contract ids are base58 (~44 chars), both well under the cap.
+        let stored_delegate_key = cap_identity_chars(delegate_key);
+        let stored_caller = match caller {
+            CallerIdentity::None => CallerIdentity::None,
+            CallerIdentity::WebApp(hash) => CallerIdentity::WebApp(cap_identity_chars(&hash)),
+        };
+
         self.pending.insert(
             nonce.clone(),
             PendingPrompt {
                 message,
                 labels,
-                delegate_key: delegate_key.to_string(),
-                caller,
+                delegate_key: stored_delegate_key,
+                caller: stored_caller,
                 response_tx: tx,
             },
         );
@@ -168,6 +188,12 @@ impl UserInputPrompter for DashboardPrompter {
             }
         }
     }
+}
+
+/// Truncate a runtime-attested identity hash to `MAX_IDENTITY_HASH_CHARS`
+/// codepoints. Char-based so multi-byte content doesn't get split mid-grapheme.
+fn cap_identity_chars(s: &str) -> String {
+    s.chars().take(MAX_IDENTITY_HASH_CHARS).collect()
 }
 
 /// Generate a 128-bit cryptographic hex nonce.

--- a/crates/core/src/operations/get.rs
+++ b/crates/core/src/operations/get.rs
@@ -5758,14 +5758,13 @@ mod tests {
     /// only), defer to the network with local fallback.
     ///
     /// Returns (local_value, local_fallback) after applying the decision.
+    type LocalValue = Option<(ContractKey, WrappedState, Option<ContractContainer>)>;
+
     fn apply_relay_cache_decision(
         is_relay: bool,
         has_local_interest: bool,
-        local_value: Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
-    ) -> (
-        Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
-        Option<(ContractKey, WrappedState, Option<ContractContainer>)>,
-    ) {
+        local_value: LocalValue,
+    ) -> (LocalValue, LocalValue) {
         // This mirrors the logic at get.rs ~line 1404.
         let mut local_fallback = None;
         let local_value = if is_relay {

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -10,6 +10,65 @@
 //!
 //! The standalone `/permission/{nonce}` HTML page is retained as a fallback
 //! (e.g. if JS is disabled in the shell, or for debugging / manual testing).
+//!
+//! # Trust model and UI rationale (#3857)
+//!
+//! The user installed the delegate. It is their agent; its per-key storage is
+//! cryptographically isolated, so an impostor delegate with a different
+//! `DelegateKey` cannot read or sign with the real delegate's secrets. That
+//! limits one class of spoofing — but it does not make the prompt safe to
+//! ship without identity attestation. A malicious-but-installed delegate can
+//! still:
+//!
+//! - sign actions with its own (fake) key and trick the user into thinking
+//!   they signed as their real identity (downstream verifiers that don't
+//!   know the real public key would accept it);
+//! - condition the user toward "Always allow" on a hostile request;
+//! - exfiltrate user input via the response channel;
+//! - write text in the message that looks like Freenet UI chrome (e.g.
+//!   `"Freenet verified this request"`).
+//!
+//! The prompt UI defends against these the same way a hardware key does:
+//! by surfacing a stable, runtime-attested fingerprint the user can
+//! recognise across sessions. The runtime-attested `DelegateKey` is the one
+//! signal that a returning user can passively use to spot an impostor; the
+//! attested caller (today only `MessageOrigin::WebApp(..)`, see #3860) tells
+//! the user *which* application is asking right now.
+//!
+//! Concrete UI choices that follow from this:
+//!
+//! 1. **The delegate's message ("Delegate says:") stays.** It is the most
+//!    informative thing on the screen for the *honest* delegate case (which
+//!    is the common case). Removing the authorship label was tempting but
+//!    is wrong: it is the only thing on the page distinguishing
+//!    delegate-authored text from Freenet UI chrome, and HTML-escaping does
+//!    not protect against text deception.
+//! 2. **The truncated delegate hash is shown inline, always visible**,
+//!    under the buttons in muted monospace. A user who recognises their
+//!    delegate's fingerprint can spot an impostor without expanding any
+//!    disclosure.
+//! 3. **A `<details>` "Technical details" disclosure** holds the full
+//!    delegate hash and the Caller row (`Freenet app <truncated>` or
+//!    `No app caller` for the `None` case). Closed by default — the user's
+//!    real decision is timing/intent ("did I just trigger this?"), not
+//!    hash matching.
+//! 4. **No human-readable names.** Any name would have to come from
+//!    app-controlled metadata and would be spoofable by a malicious
+//!    contract publishing a manifest named after a popular app. Showing a
+//!    name beside an unverified hash would pretend they are equally
+//!    verified. Names are deferred until there is a real provenance story
+//!    (signed manifests, or trust-on-first-use state).
+//! 5. **`No app caller` rather than `Unknown` or `(not recorded)`** for
+//!    the `CallerIdentity::None` case. `Unknown` reads like a failure;
+//!    `No app caller` is accurate and neutral.
+//! 6. **No `"Freenet confirmed these identities"` badge.** Such a badge
+//!    would oversell the defensive value of the Delegate field (see above)
+//!    and underlabel the Caller field. The information is presented
+//!    factually and the user evaluates it against their own context.
+//!
+//! The shell-page overlay JS in `crates/core/src/server/path_handlers.rs`
+//! mirrors this same layout. Both code paths must stay in sync — the
+//! standalone page and the in-page overlay are both regression-tested.
 
 use axum::extract::Path;
 use axum::http::HeaderMap;
@@ -215,7 +274,13 @@ async fn permission_page(
     let delegate_trunc_html = html_escape(&delegate_trunc);
 
     let (caller_display_text, caller_full) = caller_display(&entry.caller);
-    let caller_full_attr = caller_full.as_deref().map(html_escape).unwrap_or_default();
+    // When the caller is None there's no full hash to surface, so omit the
+    // title attribute entirely rather than rendering `title=""`. Empty
+    // tooltips are noise and one fewer thing for users to wonder about.
+    let caller_title_html = caller_full
+        .as_deref()
+        .map(|h| format!(" title=\"{}\"", html_escape(h)))
+        .unwrap_or_default();
     let caller_display_html = html_escape(&caller_display_text);
 
     (
@@ -287,7 +352,7 @@ async fn permission_page(
       <dt>Delegate</dt>
       <dd title="{delegate_full_attr}">{delegate_full_attr}</dd>
       <dt>Caller</dt>
-      <dd title="{caller_full_attr}">{caller_display_html}</dd>
+      <dd{caller_title_html}>{caller_display_html}</dd>
     </dl>
   </details>
   <div class="timer">Auto-deny in <span id="countdown">60</span>s</div>
@@ -553,10 +618,21 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_hash_boundary() {
+    fn test_truncate_hash_boundary_at_threshold() {
         // Exactly prefix+suffix+1 chars: returning unchanged saves no space, return as-is.
         let h = "1234567890ABCD"; // 14 chars: 8 + 5 + 1
         assert_eq!(truncate_hash(h), h);
+    }
+
+    #[test]
+    fn test_truncate_hash_first_truncated_length() {
+        // The first input length that *should* actually get truncated. A
+        // one-off bug shifting the boundary by one would only be caught
+        // here, not by the at-threshold test above.
+        let h = "1234567890ABCDE"; // 15 chars: prefix(8) + suffix(5) + 2
+        let t = truncate_hash(h);
+        assert_eq!(t, "12345678…ABCDE");
+        assert_ne!(t, h, "15-char input must actually be truncated");
     }
 
     #[test]
@@ -948,6 +1024,14 @@ mod tests {
             html.contains("Delegate says:"),
             "authorship label must be present even with no app caller"
         );
+        // A regression that rendered `Freenet app ` (empty hash) for the
+        // None variant would still pass the positive assertion above
+        // because "No app caller" might also be present elsewhere. Pin it
+        // negatively too.
+        assert!(
+            !html.contains("Freenet app"),
+            "None caller must NOT render the 'Freenet app' prefix"
+        );
     }
 
     // Hostile delegate text must be HTML-escaped so it cannot inject markup
@@ -968,5 +1052,45 @@ mod tests {
         assert!(!html.contains("<img src=x"));
         assert!(html.contains("&lt;script&gt;"));
         assert!(html.contains("&lt;b&gt;Allow&lt;/b&gt;"));
+    }
+
+    // Hostile content in the runtime-attested hash strings (delegate_key
+    // and caller hash) must also be HTML-escaped — those values flow into
+    // the page body AND into `title="..."` attributes, so a missed escape
+    // could break out of the attribute value. Realistic threat model: a
+    // future code path that writes attacker-influenced data into these
+    // fields. Sanitization strips control/bidi chars; html_escape handles
+    // quote/angle injection.
+    #[tokio::test]
+    async fn test_permission_page_escapes_hostile_hash_fields() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(
+            &pending,
+            "n",
+            "ok",
+            vec!["Allow"],
+            r#"<script>alert(1)</script>"#,
+            webapp_caller(r#""onload="evil()"#),
+        );
+        let html = call_permission_page("n", pending).await;
+        // Raw markup must not appear anywhere in the rendered page.
+        assert!(
+            !html.contains("<script>alert(1)</script>"),
+            "raw <script> from delegate_key must not appear in HTML"
+        );
+        assert!(
+            !html.contains(r#""onload="evil()"#),
+            "raw quote-bearing payload from caller hash must not appear unescaped"
+        );
+        // Escaped forms must be present, demonstrating that the values
+        // flowed through html_escape on every render path.
+        assert!(
+            html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"),
+            "escaped delegate_key markup must appear"
+        );
+        assert!(
+            html.contains("&quot;onload=&quot;evil()"),
+            "escaped caller hash quotes must appear"
+        );
     }
 }

--- a/crates/core/src/server/client_api/permission_prompts.rs
+++ b/crates/core/src/server/client_api/permission_prompts.rs
@@ -18,7 +18,7 @@ use axum::routing::{get, post};
 use axum::{Extension, Json, Router};
 use serde::Deserialize;
 
-use crate::contract::user_input::PendingPrompts;
+use crate::contract::user_input::{CallerIdentity, PendingPrompts};
 
 /// Register permission prompt routes.
 pub(super) fn routes() -> Router {
@@ -37,10 +37,33 @@ const OVERLAY_MESSAGE_MAX: usize = 2048;
 const OVERLAY_LABELS_MAX: usize = 8;
 /// Maximum length of each individual button label.
 const OVERLAY_LABEL_CHARS_MAX: usize = 64;
-/// Maximum length of `delegate_key` / `contract_id` rendered on the overlay.
+/// Maximum length of `delegate_key` / caller hash rendered on the overlay.
 /// These are normally short keys; the cap bounds the amplification surface if
 /// the producer populates them from untrusted data in the future.
 const OVERLAY_KEY_CHARS_MAX: usize = 256;
+
+/// Number of leading characters of a hash to show in the truncated form.
+const HASH_PREFIX_CHARS: usize = 8;
+/// Number of trailing characters of a hash to show in the truncated form.
+const HASH_SUFFIX_CHARS: usize = 5;
+
+/// Truncate a hash for display: `first8…last5`. Falls back to the full string
+/// if it's already short enough that truncating would lose nothing useful
+/// (i.e. when prefix + suffix + ellipsis ≥ original length).
+///
+/// The truncated form is what the user sees in the prompt UI; the full hash
+/// is preserved separately and surfaced via the `title` attribute on the
+/// rendered span so power users can hover to read the unabbreviated value.
+fn truncate_hash(s: &str) -> String {
+    let total: usize = s.chars().count();
+    if total <= HASH_PREFIX_CHARS + HASH_SUFFIX_CHARS + 1 {
+        return s.to_string();
+    }
+    let prefix: String = s.chars().take(HASH_PREFIX_CHARS).collect();
+    let suffix_rev: String = s.chars().rev().take(HASH_SUFFIX_CHARS).collect();
+    let suffix: String = suffix_rev.chars().rev().collect();
+    format!("{prefix}…{suffix}")
+}
 
 /// Strip characters that can visually spoof or hide delegate identity in the
 /// overlay: ASCII control characters (except `\t`, `\n`, `\r`) and Unicode
@@ -68,9 +91,23 @@ fn sanitize_display(s: &str, max_chars: usize) -> String {
     out
 }
 
+/// Build the JSON representation of the caller identity for the overlay
+/// endpoint. Tagged shape so a future `delegate` variant (issue #3860) is
+/// purely additive — the shell-page JS can switch on `kind` and fall through
+/// safely on unknown values.
+fn caller_to_json(caller: &CallerIdentity) -> serde_json::Value {
+    match caller {
+        CallerIdentity::None => serde_json::json!({ "kind": "none", "hash": null }),
+        CallerIdentity::WebApp(hash) => serde_json::json!({
+            "kind": "webapp",
+            "hash": sanitize_display(hash, OVERLAY_KEY_CHARS_MAX),
+        }),
+    }
+}
+
 /// Return the list of pending prompts for the shell page to render as
 /// in-page overlays (see issue #3836). Each entry includes the sanitized
-/// message, button labels, and delegate/contract context.
+/// message, button labels, and delegate/caller context.
 ///
 /// The endpoint is protected by the same Origin check as
 /// `/permission/{nonce}/respond`: since this response now carries the full
@@ -111,11 +148,25 @@ async fn pending_prompts(
                 "message": message,
                 "labels": labels,
                 "delegate_key": sanitize_display(&prompt.delegate_key, OVERLAY_KEY_CHARS_MAX),
-                "contract_id": sanitize_display(&prompt.contract_id, OVERLAY_KEY_CHARS_MAX),
+                "caller": caller_to_json(&prompt.caller),
             })
         })
         .collect();
     (axum::http::StatusCode::OK, Json(serde_json::json!(prompts)))
+}
+
+/// Format the caller identity for the standalone HTML page's details
+/// disclosure. The variant tag determines the prefix word (`Freenet app`
+/// or `No app caller`) that appears next to the truncated hash.
+fn caller_display(caller: &CallerIdentity) -> (String, Option<String>) {
+    match caller {
+        CallerIdentity::None => ("No app caller".to_string(), None),
+        CallerIdentity::WebApp(hash) => {
+            let sanitized = sanitize_display(hash, OVERLAY_KEY_CHARS_MAX);
+            let truncated = truncate_hash(&sanitized);
+            (format!("Freenet app {truncated}"), Some(sanitized))
+        }
+    }
 }
 
 /// Serve the HTML permission prompt page.
@@ -154,8 +205,18 @@ async fn permission_page(
         .collect::<Vec<_>>()
         .join("\n            ");
 
-    let delegate_key_display = html_escape(&entry.delegate_key);
-    let contract_id_display = html_escape(&entry.contract_id);
+    // Delegate identity: always shown, both inline (truncated, under the
+    // buttons) and in the Technical details disclosure (full + truncated,
+    // copyable). The inline placement gives the user a passive anomaly
+    // signal without making them open the disclosure — codex review point 3.
+    let delegate_full = sanitize_display(&entry.delegate_key, OVERLAY_KEY_CHARS_MAX);
+    let delegate_trunc = truncate_hash(&delegate_full);
+    let delegate_full_attr = html_escape(&delegate_full);
+    let delegate_trunc_html = html_escape(&delegate_trunc);
+
+    let (caller_display_text, caller_full) = caller_display(&entry.caller);
+    let caller_full_attr = caller_full.as_deref().map(html_escape).unwrap_or_default();
+    let caller_display_html = html_escape(&caller_display_text);
 
     (
         headers,
@@ -182,21 +243,25 @@ async fn permission_page(
   .header {{ display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }}
   .icon {{ font-size: 32px; }}
   h1 {{ font-size: 18px; font-weight: 600; }}
-  .context {{ background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
-              padding: 12px; margin-bottom: 16px; font-size: 13px; color: var(--muted); }}
-  .context dt {{ font-weight: 600; color: var(--fg); }}
-  .context dd {{ margin-bottom: 8px; font-family: monospace; font-size: 12px; word-break: break-all; }}
-  .message {{ font-size: 15px; line-height: 1.5; margin-bottom: 24px; padding: 16px;
-              background: var(--bg); border-left: 3px solid var(--warn); border-radius: 4px; }}
   .message-label {{ font-size: 12px; color: var(--muted); margin-bottom: 4px; text-transform: uppercase;
                     letter-spacing: 0.5px; }}
-  .buttons {{ display: flex; gap: 12px; flex-wrap: wrap; }}
+  .message {{ font-size: 15px; line-height: 1.5; margin-bottom: 24px; padding: 16px;
+              background: var(--bg); border-left: 3px solid var(--warn); border-radius: 4px; }}
+  .buttons {{ display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 16px; }}
   .btn {{ padding: 10px 24px; border: 1px solid var(--border); border-radius: 8px;
           background: var(--card); color: var(--fg); font-size: 14px; cursor: pointer;
           transition: all 0.15s; flex: 1; min-width: 100px; font-weight: 500; }}
   .btn.primary {{ background: var(--accent); color: white; border-color: var(--accent); }}
   .btn:hover {{ opacity: 0.85; transform: translateY(-1px); }}
   .btn:disabled {{ opacity: 0.5; cursor: not-allowed; transform: none; }}
+  .delegate-line {{ font-size: 12px; color: var(--muted); margin-top: 8px;
+                    font-family: monospace; }}
+  .delegate-line .hash {{ user-select: all; }}
+  details.tech {{ margin-top: 12px; font-size: 12px; color: var(--muted); }}
+  details.tech summary {{ cursor: pointer; user-select: none; }}
+  details.tech dl {{ margin-top: 8px; padding-left: 16px; }}
+  details.tech dt {{ font-weight: 600; color: var(--fg); margin-top: 6px; }}
+  details.tech dd {{ font-family: monospace; word-break: break-all; user-select: all; }}
   .timer {{ margin-top: 16px; font-size: 13px; color: var(--muted); text-align: center; }}
   .result {{ text-align: center; padding: 24px 0; }}
   .result .icon {{ font-size: 48px; margin-bottom: 12px; }}
@@ -208,19 +273,23 @@ async fn permission_page(
     <span class="icon">&#x1f512;</span>
     <h1>Permission Request</h1>
   </div>
-  <div class="context">
-    <dl>
-      <dt>Delegate</dt>
-      <dd>{delegate_key_display}</dd>
-      <dt>Requesting contract</dt>
-      <dd>{contract_id_display}</dd>
-    </dl>
-  </div>
   <div class="message-label">Delegate says:</div>
   <p class="message">{message}</p>
   <div class="buttons">
     {buttons_html}
   </div>
+  <div class="delegate-line">
+    Delegate: <span class="hash" title="{delegate_full_attr}">{delegate_trunc_html}</span>
+  </div>
+  <details class="tech">
+    <summary>Technical details</summary>
+    <dl>
+      <dt>Delegate</dt>
+      <dd title="{delegate_full_attr}">{delegate_full_attr}</dd>
+      <dt>Caller</dt>
+      <dd title="{caller_full_attr}">{caller_display_html}</dd>
+    </dl>
+  </details>
   <div class="timer">Auto-deny in <span id="countdown">60</span>s</div>
 </div>
 <div class="card result" id="done" style="display:none">
@@ -470,6 +539,36 @@ mod tests {
         assert_eq!(html_escape("a & b"), "a &amp; b");
     }
 
+    #[test]
+    fn test_truncate_hash_long_input() {
+        let h = "DLog47hEabcdefghijk8vK2";
+        let t = truncate_hash(h);
+        assert_eq!(t, "DLog47hE…k8vK2");
+    }
+
+    #[test]
+    fn test_truncate_hash_short_input_unchanged() {
+        let h = "abc";
+        assert_eq!(truncate_hash(h), "abc");
+    }
+
+    #[test]
+    fn test_truncate_hash_boundary() {
+        // Exactly prefix+suffix+1 chars: returning unchanged saves no space, return as-is.
+        let h = "1234567890ABCD"; // 14 chars: 8 + 5 + 1
+        assert_eq!(truncate_hash(h), h);
+    }
+
+    #[test]
+    fn test_truncate_hash_unicode() {
+        // Multi-byte chars must be counted by `char`, not byte.
+        let h = "🔥".repeat(16);
+        let t = truncate_hash(&h);
+        assert!(t.contains('…'));
+        assert!(t.starts_with(&"🔥".repeat(8)));
+        assert!(t.ends_with(&"🔥".repeat(5)));
+    }
+
     fn empty_pending() -> PendingPrompts {
         use dashmap::DashMap;
         use std::sync::Arc;
@@ -482,7 +581,7 @@ mod tests {
         message: &str,
         labels: Vec<&str>,
         delegate_key: &str,
-        contract_id: &str,
+        caller: CallerIdentity,
     ) -> tokio::sync::oneshot::Receiver<usize> {
         use crate::contract::user_input::PendingPrompt;
         let (tx, rx) = tokio::sync::oneshot::channel::<usize>();
@@ -492,11 +591,15 @@ mod tests {
                 message: message.to_string(),
                 labels: labels.into_iter().map(String::from).collect(),
                 delegate_key: delegate_key.to_string(),
-                contract_id: contract_id.to_string(),
+                caller,
                 response_tx: tx,
             },
         );
         rx
+    }
+
+    fn webapp_caller(s: &str) -> CallerIdentity {
+        CallerIdentity::WebApp(s.to_string())
     }
 
     fn trusted_header() -> HeaderMap {
@@ -520,9 +623,19 @@ mod tests {
         (status, value)
     }
 
+    async fn call_permission_page(nonce: &str, pending: PendingPrompts) -> String {
+        use axum::body::to_bytes;
+        use axum::response::IntoResponse;
+        let resp = permission_page(Path(nonce.to_string()), Extension(pending))
+            .await
+            .into_response();
+        let body = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        String::from_utf8(body.to_vec()).unwrap()
+    }
+
     // Regression test for issue #3836: the /permission/pending JSON must
     // carry enough data for the shell-page overlay to render the prompt
-    // (message, labels, delegate key, contract id), not just a preview.
+    // (message, labels, delegate key, caller), not just a preview.
     #[tokio::test]
     async fn test_pending_prompts_includes_overlay_fields() {
         let pending = empty_pending();
@@ -532,7 +645,7 @@ mod tests {
             "Approve this?",
             vec!["Allow Once", "Always Allow", "Deny"],
             "dkey",
-            "cid",
+            webapp_caller("cid"),
         );
 
         let (status, value) = call_pending(trusted_header(), pending).await;
@@ -547,7 +660,22 @@ mod tests {
             serde_json::json!(["Allow Once", "Always Allow", "Deny"])
         );
         assert_eq!(entry["delegate_key"], "dkey");
-        assert_eq!(entry["contract_id"], "cid");
+        assert_eq!(entry["caller"]["kind"], "webapp");
+        assert_eq!(entry["caller"]["hash"], "cid");
+    }
+
+    // Regression test for issue #3857: when the prompt has no web-app
+    // caller (CallerIdentity::None), the overlay JSON must encode that
+    // explicitly as a tagged "none" variant rather than omitting the field
+    // or sending "Unknown" as a hash. The shell JS switches on `kind` to
+    // decide what to render, so the tag must be present and stable.
+    #[tokio::test]
+    async fn test_pending_prompts_none_caller_encoding() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(&pending, "n", "m", vec!["OK"], "dkey", CallerIdentity::None);
+        let (_, value) = call_pending(trusted_header(), pending).await;
+        assert_eq!(value[0]["caller"]["kind"], "none");
+        assert!(value[0]["caller"]["hash"].is_null());
     }
 
     // Oversized delegate messages must be clipped so a malicious delegate
@@ -556,7 +684,7 @@ mod tests {
     async fn test_pending_prompts_message_capped() {
         let pending = empty_pending();
         let huge = "a".repeat(OVERLAY_MESSAGE_MAX * 4);
-        let _rx = insert_prompt(&pending, "n", &huge, vec!["OK"], "d", "c");
+        let _rx = insert_prompt(&pending, "n", &huge, vec!["OK"], "d", webapp_caller("c"));
 
         let (_, value) = call_pending(trusted_header(), pending).await;
         assert_eq!(
@@ -570,11 +698,8 @@ mod tests {
     #[tokio::test]
     async fn test_pending_prompts_message_cap_is_char_based() {
         let pending = empty_pending();
-        // Each fire emoji is 4 UTF-8 bytes; OVERLAY_MESSAGE_MAX * 4 bytes
-        // would be the naive byte budget. Char-based truncation keeps them
-        // all intact.
         let emoji = "\u{1F525}".repeat(OVERLAY_MESSAGE_MAX);
-        let _rx = insert_prompt(&pending, "n", &emoji, vec!["OK"], "d", "c");
+        let _rx = insert_prompt(&pending, "n", &emoji, vec!["OK"], "d", webapp_caller("c"));
         let (_, value) = call_pending(trusted_header(), pending).await;
         let got = value[0]["message"].as_str().unwrap();
         assert_eq!(got.chars().count(), OVERLAY_MESSAGE_MAX);
@@ -600,7 +725,7 @@ mod tests {
                     message: "m".to_string(),
                     labels,
                     delegate_key: "d".to_string(),
-                    contract_id: "c".to_string(),
+                    caller: webapp_caller("c"),
                     response_tx: tx,
                 },
             );
@@ -618,13 +743,13 @@ mod tests {
     #[tokio::test]
     async fn test_pending_prompts_empty_labels_round_trip() {
         let pending = empty_pending();
-        let _rx = insert_prompt(&pending, "n", "m", vec![], "d", "c");
+        let _rx = insert_prompt(&pending, "n", "m", vec![], "d", webapp_caller("c"));
         let (_, value) = call_pending(trusted_header(), pending).await;
         assert_eq!(value[0]["labels"], serde_json::json!([]));
     }
 
-    // Unicode right-to-left override in delegate_key / contract_id must
-    // be stripped so a hostile delegate can't visually reverse the key
+    // Unicode right-to-left override in delegate_key / caller hash must be
+    // stripped so a hostile delegate can't visually reverse the key
     // displayed in the overlay's context panel and spoof identity.
     #[tokio::test]
     async fn test_pending_prompts_strips_bidi_and_controls() {
@@ -636,13 +761,13 @@ mod tests {
             "Hello\u{202E}evil\u{202A}!",
             vec!["\u{202E}Allow\u{202C}"],
             "\u{FEFF}key\u{200B}123",
-            "c\u{0007}id",
+            webapp_caller("c\u{0007}id"),
         );
         let (_, value) = call_pending(trusted_header(), pending).await;
         assert_eq!(value[0]["message"], "Helloevil!");
         assert_eq!(value[0]["labels"], serde_json::json!(["Allow"]));
         assert_eq!(value[0]["delegate_key"], "key123");
-        assert_eq!(value[0]["contract_id"], "cid");
+        assert_eq!(value[0]["caller"]["hash"], "cid");
     }
 
     // /permission/pending now returns full delegate-controlled text, so
@@ -652,7 +777,7 @@ mod tests {
     #[tokio::test]
     async fn test_pending_prompts_rejects_untrusted_origin() {
         let pending = empty_pending();
-        let _rx = insert_prompt(&pending, "n", "m", vec!["OK"], "d", "c");
+        let _rx = insert_prompt(&pending, "n", "m", vec!["OK"], "d", webapp_caller("c"));
         let mut headers = HeaderMap::new();
         headers.insert("origin", "http://evil.com".parse().unwrap());
         let (status, _) = call_pending(headers, pending).await;
@@ -665,7 +790,7 @@ mod tests {
     #[tokio::test]
     async fn test_pending_prompts_allows_missing_origin() {
         let pending = empty_pending();
-        let _rx = insert_prompt(&pending, "n", "m", vec!["OK"], "d", "c");
+        let _rx = insert_prompt(&pending, "n", "m", vec!["OK"], "d", webapp_caller("c"));
         let (status, _) = call_pending(HeaderMap::new(), pending).await;
         assert_eq!(status, axum::http::StatusCode::OK);
     }
@@ -677,8 +802,22 @@ mod tests {
     #[tokio::test]
     async fn test_respond_consumes_nonce_and_second_response_404s() {
         let pending = empty_pending();
-        let rx_a = insert_prompt(&pending, "a", "mA", vec!["Yes", "No"], "d", "c");
-        let _rx_b = insert_prompt(&pending, "b", "mB", vec!["Yes", "No"], "d", "c");
+        let rx_a = insert_prompt(
+            &pending,
+            "a",
+            "mA",
+            vec!["Yes", "No"],
+            "d",
+            webapp_caller("c"),
+        );
+        let _rx_b = insert_prompt(
+            &pending,
+            "b",
+            "mB",
+            vec!["Yes", "No"],
+            "d",
+            webapp_caller("c"),
+        );
 
         let (_, value) = call_pending(trusted_header(), pending.clone()).await;
         let nonces: Vec<&str> = value
@@ -729,5 +868,105 @@ mod tests {
         .await
         .into_response();
         assert_eq!(resp.status(), axum::http::StatusCode::NOT_FOUND);
+    }
+
+    // Regression tests for issue #3857 — behavioural assertions on the
+    // standalone HTML page (no structural assertions, per codex review
+    // point 7).
+    //
+    // What we check:
+    // 1. The "Delegate says:" authorship label is present next to the
+    //    message (codex point 2: removing it was a UX/security regression).
+    // 2. The truncated delegate hash is visible in the page body without
+    //    requiring the user to expand any disclosure (codex point 3:
+    //    preserves a passive anomaly signal for users who recognise their
+    //    delegate's fingerprint).
+    // 3. The full delegate hash is present in a `title=` attribute so power
+    //    users can hover or copy the unabbreviated value.
+    // 4. The caller's display string includes "Freenet app" so the user can
+    //    tell what kind of caller it is.
+    // 5. Delegate-supplied content is HTML-escaped (existing behaviour,
+    //    re-verified now that the template was rewritten).
+    #[tokio::test]
+    async fn test_permission_page_renders_webapp_caller() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(
+            &pending,
+            "abc",
+            "Approve signing this document.",
+            vec!["Allow", "Deny"],
+            "DLog47hEverylongdelegatekeyhashk8vK2",
+            webapp_caller("CONTRACTabcdefghijklmnopqZ"),
+        );
+        let html = call_permission_page("abc", pending).await;
+
+        assert!(
+            html.contains("Delegate says:"),
+            "authorship label must be present (codex point 2)"
+        );
+        assert!(
+            html.contains("Approve signing this document."),
+            "delegate message must be rendered"
+        );
+        assert!(
+            html.contains("DLog47hE…k8vK2"),
+            "truncated delegate hash must appear in body (codex point 3)"
+        );
+        assert!(
+            html.contains(r#"title="DLog47hEverylongdelegatekeyhashk8vK2""#),
+            "full delegate hash must be present in a title attribute"
+        );
+        assert!(
+            html.contains("Freenet app"),
+            "caller kind label must be present"
+        );
+        assert!(
+            html.contains("CONTRACT…nopqZ"),
+            "truncated caller hash must appear in body, got HTML: {html}"
+        );
+    }
+
+    // None caller renders as "No app caller" rather than a blank field or
+    // the misleading "(not recorded)" we considered earlier (codex point 4).
+    #[tokio::test]
+    async fn test_permission_page_renders_none_caller() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(
+            &pending,
+            "n",
+            "m",
+            vec!["OK"],
+            "DLGKEYabcdefghk8vK2",
+            CallerIdentity::None,
+        );
+        let html = call_permission_page("n", pending).await;
+        assert!(
+            html.contains("No app caller"),
+            "None caller must render as 'No app caller'"
+        );
+        assert!(
+            html.contains("Delegate says:"),
+            "authorship label must be present even with no app caller"
+        );
+    }
+
+    // Hostile delegate text must be HTML-escaped so it cannot inject markup
+    // into the prompt page or break out of the message paragraph.
+    #[tokio::test]
+    async fn test_permission_page_escapes_hostile_message() {
+        let pending = empty_pending();
+        let _rx = insert_prompt(
+            &pending,
+            "n",
+            r#"<script>alert('xss')</script><img src=x onerror=evil()>"#,
+            vec!["<b>Allow</b>"],
+            "dkey",
+            webapp_caller("cid"),
+        );
+        let html = call_permission_page("n", pending).await;
+        assert!(!html.contains("<script>alert"));
+        assert!(!html.contains("<img src=x"));
+        assert!(html.contains("&lt;script&gt;"));
+        assert!(html.contains("&lt;b&gt;Allow&lt;/b&gt;"));
     }
 }

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -771,14 +771,6 @@ function freenetBridge(authToken) {
     '#__freenet_perm_overlay .fn-icon{font-size:28px;line-height:1;}' +
     '#__freenet_perm_overlay .fn-title{font-size:18px;font-weight:600;margin:0;' +
     'color:var(--fg);}' +
-    '#__freenet_perm_overlay .fn-ctx{background:var(--bg);border:1px solid var(--border);' +
-    'border-radius:8px;padding:12px 14px;margin-bottom:16px;font-size:12px;' +
-    'color:var(--muted);}' +
-    '#__freenet_perm_overlay .fn-ctx dt{font-weight:600;color:var(--fg);' +
-    'font-family:inherit;margin-top:6px;}' +
-    '#__freenet_perm_overlay .fn-ctx dt:first-child{margin-top:0;}' +
-    '#__freenet_perm_overlay .fn-ctx dd{margin:2px 0 0 0;font-family:ui-monospace,' +
-    'SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;word-break:break-all;}' +
     '#__freenet_perm_overlay .fn-msg-label{font-size:11px;color:var(--muted);' +
     'text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px;}' +
     '#__freenet_perm_overlay .fn-msg{font-size:15px;line-height:1.5;margin:0 0 22px 0;' +
@@ -794,6 +786,15 @@ function freenetBridge(authToken) {
     '#__freenet_perm_overlay .fn-btn:hover:not(:disabled){transform:translateY(-1px);' +
     'filter:brightness(1.08);}' +
     '#__freenet_perm_overlay .fn-btn:disabled{opacity:0.55;cursor:not-allowed;}' +
+    '#__freenet_perm_overlay .fn-delegate-line{font-size:12px;color:var(--muted);' +
+    'margin-top:10px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;}' +
+    '#__freenet_perm_overlay .fn-delegate-line .hash{user-select:all;}' +
+    '#__freenet_perm_overlay .fn-tech{margin-top:10px;font-size:12px;color:var(--muted);}' +
+    '#__freenet_perm_overlay .fn-tech summary{cursor:pointer;user-select:none;}' +
+    '#__freenet_perm_overlay .fn-tech dl{margin:8px 0 0 16px;}' +
+    '#__freenet_perm_overlay .fn-tech dt{font-weight:600;color:var(--fg);margin-top:6px;}' +
+    '#__freenet_perm_overlay .fn-tech dd{margin:2px 0 0 0;font-family:ui-monospace,' +
+    'SFMono-Regular,Menlo,Consolas,monospace;word-break:break-all;user-select:all;}' +
     '#__freenet_perm_overlay .fn-timer{margin-top:14px;font-size:12px;' +
     'color:var(--muted);text-align:center;}';
   // Auto-deny duration in seconds, mirroring the standalone /permission/{nonce}
@@ -834,6 +835,36 @@ function freenetBridge(authToken) {
     // strings. Delegate-provided fields are never parsed as markup.
     el.textContent = text == null ? '' : String(text);
   }
+  // Truncate a hash for display: first8…last5. Mirrors truncate_hash() in
+  // crates/core/src/server/client_api/permission_prompts.rs so the overlay
+  // and the standalone /permission/{nonce} fallback page render identically.
+  // Handles multi-byte unicode by iterating Array.from(...) which gives
+  // codepoints, not UTF-16 code units.
+  function truncateHash(s) {
+    if (typeof s !== 'string' || s.length === 0) return '';
+    var chars = Array.from(s);
+    if (chars.length <= 14) return s;
+    return chars.slice(0, 8).join('') + '\u2026' + chars.slice(chars.length - 5).join('');
+  }
+  // Render the Caller row from the tagged caller object. Forward-compatible:
+  // an unknown `kind` (e.g. a future "delegate" variant from issue #3860)
+  // falls through to a neutral "Unknown caller" so the overlay does NOT
+  // pretend to render an identity it doesn't understand.
+  function formatCaller(caller) {
+    if (!caller || typeof caller !== 'object') {
+      return { display: 'No app caller', full: '' };
+    }
+    if (caller.kind === 'webapp' && typeof caller.hash === 'string') {
+      return {
+        display: 'Freenet app ' + truncateHash(caller.hash),
+        full: caller.hash,
+      };
+    }
+    if (caller.kind === 'none') {
+      return { display: 'No app caller', full: '' };
+    }
+    return { display: 'Unknown caller', full: '' };
+  }
   function createCard(p) {
     var card = document.createElement('div');
     card.className = 'fn-card';
@@ -851,25 +882,14 @@ function freenetBridge(authToken) {
     header.appendChild(title);
     card.appendChild(header);
 
-    var ctx = document.createElement('dl');
-    ctx.className = 'fn-ctx';
-    var dkLabel = document.createElement('dt');
-    dkLabel.textContent = 'Delegate';
-    var dkVal = document.createElement('dd');
-    setText(dkVal, p.delegate_key || 'Unknown');
-    var ciLabel = document.createElement('dt');
-    ciLabel.textContent = 'Requesting contract';
-    var ciVal = document.createElement('dd');
-    setText(ciVal, p.contract_id || 'Unknown');
-    ctx.appendChild(dkLabel);
-    ctx.appendChild(dkVal);
-    ctx.appendChild(ciLabel);
-    ctx.appendChild(ciVal);
-    card.appendChild(ctx);
-
+    // "Delegate says:" authorship label is non-negotiable: a malicious
+    // delegate would otherwise be able to write text like "Freenet verified
+    // this request" with no way for the user to tell who authored it. The
+    // text below the label is delegate-controlled; the label tells the user
+    // that. See the trust-model rationale in permission_prompts.rs.
     var msgLabel = document.createElement('div');
     msgLabel.className = 'fn-msg-label';
-    msgLabel.textContent = 'Delegate says';
+    msgLabel.textContent = 'Delegate says:';
     card.appendChild(msgLabel);
     var msg = document.createElement('p');
     msg.className = 'fn-msg';
@@ -889,6 +909,58 @@ function freenetBridge(authToken) {
       buttons.appendChild(b);
     });
     card.appendChild(buttons);
+
+    // Inline truncated delegate hash, always visible. Gives the user a
+    // passive anomaly signal: a returning user who recognises their
+    // delegate's fingerprint can spot an impostor without expanding the
+    // Technical details disclosure. Full hash is in the Technical details
+    // pane below and copyable via user-select: all on .hash.
+    var delegateLine = document.createElement('div');
+    delegateLine.className = 'fn-delegate-line';
+    var delegateLabel = document.createElement('span');
+    delegateLabel.textContent = 'Delegate: ';
+    delegateLine.appendChild(delegateLabel);
+    var delegateHashSpan = document.createElement('span');
+    delegateHashSpan.className = 'hash';
+    var delegateFull = typeof p.delegate_key === 'string' ? p.delegate_key : '';
+    setText(delegateHashSpan, truncateHash(delegateFull) || '(none)');
+    if (delegateFull) {
+      delegateHashSpan.setAttribute('title', delegateFull);
+    }
+    delegateLine.appendChild(delegateHashSpan);
+    card.appendChild(delegateLine);
+
+    // Technical details disclosure. Holds the full delegate hash and the
+    // Caller row. Closed by default — the user's decision is timing/intent
+    // ("did I just trigger this?"), not hash matching. Power users hover or
+    // copy via user-select: all to audit the unabbreviated value.
+    var details = document.createElement('details');
+    details.className = 'fn-tech';
+    var summary = document.createElement('summary');
+    summary.textContent = 'Technical details';
+    details.appendChild(summary);
+    var dl = document.createElement('dl');
+    var dtDelegate = document.createElement('dt');
+    dtDelegate.textContent = 'Delegate';
+    var ddDelegate = document.createElement('dd');
+    setText(ddDelegate, delegateFull || '(none)');
+    if (delegateFull) {
+      ddDelegate.setAttribute('title', delegateFull);
+    }
+    var dtCaller = document.createElement('dt');
+    dtCaller.textContent = 'Caller';
+    var ddCaller = document.createElement('dd');
+    var callerRendered = formatCaller(p.caller);
+    setText(ddCaller, callerRendered.display);
+    if (callerRendered.full) {
+      ddCaller.setAttribute('title', callerRendered.full);
+    }
+    dl.appendChild(dtDelegate);
+    dl.appendChild(ddDelegate);
+    dl.appendChild(dtCaller);
+    dl.appendChild(ddCaller);
+    details.appendChild(dl);
+    card.appendChild(details);
 
     // Countdown mirroring the standalone permission page. The real timeout
     // lives server-side; this is a hint for the user that the prompt won't
@@ -1458,6 +1530,73 @@ mod tests {
         assert!(
             html.contains("visibilityState"),
             "overlay polling should be gated on document.visibilityState"
+        );
+
+        // Regression test for issue #3857: the overlay must read the new
+        // tagged `caller` JSON shape and render the same Delegate /
+        // Technical details treatment as the standalone /permission/{nonce}
+        // page. A previous version of this code read `p.contract_id` and
+        // fell through to "Unknown" — which silently re-shipped the bug
+        // for the in-page overlay path even after the standalone page was
+        // fixed. Tests below pin every replacement contract:
+        //   1. The "Delegate says:" authorship label must survive (codex
+        //      review point 2: removing it is a UX/security regression).
+        //   2. The truncated-hash helper and tagged-caller formatter must
+        //      both be present in the JS.
+        //   3. The old `p.contract_id` field name must be gone.
+        //   4. The old `<dl class="fn-ctx">` container must be gone.
+        //   5. The new `formatCaller` helper must handle "webapp", "none",
+        //      and unknown-kind variants so a future MessageOrigin variant
+        //      (issue #3860) doesn't render as a bogus identity.
+        assert!(
+            html.contains("'Delegate says:'") || html.contains("\"Delegate says:\""),
+            "shell overlay must render the 'Delegate says:' authorship label (#3857)"
+        );
+        assert!(
+            html.contains("function truncateHash("),
+            "shell overlay must define a truncateHash helper for the new disclosure (#3857)"
+        );
+        assert!(
+            html.contains("function formatCaller("),
+            "shell overlay must define a formatCaller helper for the tagged caller object (#3857)"
+        );
+        assert!(
+            html.contains("p.caller"),
+            "shell overlay must read p.caller from /permission/pending (#3857)"
+        );
+        assert!(
+            !html.contains("p.contract_id"),
+            "shell overlay must not read the removed p.contract_id field (#3857)"
+        );
+        assert!(
+            !html.contains("'fn-ctx'") && !html.contains("\"fn-ctx\""),
+            "shell overlay must not build the removed <dl class=\"fn-ctx\"> container (#3857)"
+        );
+        assert!(
+            html.contains("'Freenet app '") || html.contains("\"Freenet app \""),
+            "formatCaller must render webapp callers as 'Freenet app <hash>' (#3857)"
+        );
+        assert!(
+            html.contains("'No app caller'") || html.contains("\"No app caller\""),
+            "formatCaller must render the None / no-app case as 'No app caller' (#3857)"
+        );
+        assert!(
+            html.contains("'Unknown caller'") || html.contains("\"Unknown caller\""),
+            "formatCaller must have a forward-compatible fallback for unknown caller kinds (#3857)"
+        );
+        // The Technical details disclosure is the one the standalone page
+        // also exposes; the overlay must mirror it so both code paths show
+        // the user the same information.
+        assert!(
+            html.contains("'Technical details'") || html.contains("\"Technical details\""),
+            "shell overlay must include a 'Technical details' disclosure (#3857)"
+        );
+        // The inline truncated delegate line is the always-visible passive
+        // anomaly signal (codex review point 3). It must appear above the
+        // Technical details disclosure, not only inside it.
+        assert!(
+            html.contains("'fn-delegate-line'") || html.contains("\"fn-delegate-line\""),
+            "shell overlay must render the inline truncated delegate hash line (#3857)"
         );
     }
 


### PR DESCRIPTION
## Problem

The delegate permission prompt rendered hardcoded `"Unknown"` for both the **Delegate** and **Requesting contract** identity fields. The structured slots existed in the HTML template but were never populated with real runtime values, so the user saw:

```
Delegate              Unknown
Requesting contract   Unknown

Delegate says:
A Freenet application (DLog47hE...) is requesting access to your
ghostkey identity (ciQaxxSwKF8).
```

The only identifying info was the short fragment embedded in the delegate's free-form "Delegate says" message — which is delegate-controlled and could in principle be spoofed by a malicious delegate.

Source of the bug: `crates/core/src/contract/user_input.rs:99-100` had two TODOs hardcoding `"Unknown"` instead of threading executor context through.

## Solution

Wire the calling delegate's key and the originating web-app contract id from the executor — both are already in scope at `handle_delegate_with_contract_requests` in `contract.rs`. `UserInputPrompter::prompt` now takes `delegate_key: &str` plus a `CallerIdentity` enum (`None` or `WebApp(String)`). The enum is a small display-layer representation that lives only inside the prompt subsystem; a future `Delegate(String)` variant for #3860 can be added with no changes to the trait surface or the dashboard JSON.

The HTML template was rebuilt around a deliberate trust model:

- The user's installed delegate **is** their agent and **is** trusted, so its message can be read at face value.
- But because a *malicious* installed delegate can still cause real damage under its own key (leak input, condition the user toward "Always allow", fool downstream verifiers that don't check the public key), the runtime-attested Delegate field has real defensive value beyond pure auditability — it's the one passive anomaly signal a returning user has.

The new layout:
- **`Delegate says:` authorship label is preserved** above the message, so a malicious delegate can't write `"Freenet verified this request"` and have it look like Freenet UI chrome.
- **Delegate-supplied content is HTML-escaped** (existing behaviour, re-verified by a new test).
- **Truncated delegate hash** (`first8…last5`) is shown inline under the buttons in muted monospace, **always visible** — passive anomaly signal without requiring disclosure expansion.
- **`<details>` "Technical details" disclosure** holds the full Delegate hash and the Caller row (`Freenet app <truncated>` for WebApp origin, `No app caller` for None). Full hashes are in `title=` attributes and copyable via `user-select: all`.
- The misleading `"Unknown"` placeholder is gone.

The `/permission/pending` JSON shape adds a tagged `caller` object `{ "kind": "none" | "webapp", "hash": "..." | null }` so the shell-page overlay JS can `switch` on `kind`, and adding a future `delegate` variant is purely additive.

### Design review

This fix went through a skeptical design review (Codex CLI / GPT-5) before implementation. Several choices in the final design are direct responses to that review:

| Codex point | Plan change |
|---|---|
| Trust argument too narrow (impostor can still cause real harm even without the real key) | Reframed: runtime-attested Delegate field has defensive value, not just audit value. |
| Removing "Delegate says:" is a UX/security regression | **Kept the label** — non-negotiable; HTML-escaping is XSS protection, not text-deception protection. |
| Hiding all hashes hides the one passive anomaly signal | **Show truncated delegate hash inline** under the buttons; full hashes still go in `<details>`. |
| `(not recorded)` sounds like telemetry loss | **Use `No app caller`** for the `None` origin case. |
| Brittle markup assertions in tests | HTML page tests assert behaviour (label present, hash visible, full hash in `title=`, escaping works), not structure. |

## Why not show human-readable names

We considered showing a human-readable name next to each hash. We rejected it: any name would have to come from app-controlled metadata (a manifest field), and a malicious contract publishing a manifest named `"Harvest"` would get a free pass. Only the hash is runtime-attested. Showing a name alongside the hash would pretend the name is equally verified. Until there's a real provenance story (signed publisher manifests, or trust-on-first-use state that remembers the hash a user saw the first time an app worked), names mislead more than they help.

## Scope

This PR fixes #3857 only. Follow-up issue #3860 covers extending stdlib's `MessageOrigin` with a `Delegate(DelegateKey)` variant so delegate-to-delegate calls can attest the calling delegate. The UI in this PR is already shaped to render a `Caller: Delegate <hash>` row when that variant lands — no further template changes needed.

#3860 was split out because:
- It crosses the stdlib release boundary (cross-repo coordination cost)
- Adding a variant to `MessageOrigin` is source-breaking for downstream exhaustive matches (the bincode wire-format break is narrower — only delegate-to-delegate recipients — but still real)
- Delegate-to-delegate messaging is unused by deployed delegates today
- This UI doesn't need the new variant to be honest in the meantime

## Test plan

- [x] `cargo test -p freenet --lib contract::user_input` — 16/16 pass
- [x] `cargo test -p freenet --lib permission_prompts` — 29/29 pass
- [x] `cargo test -p freenet --lib contract::` — 188/188 pass
- [x] `cargo clippy -p freenet --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [ ] Manual smoke test against a running gateway with a delegate that emits `RequestUserInput` (will do post-merge or as part of multi-model review)

### New regression tests

- `test_dashboard_prompter_populates_webapp_caller`: WebApp origin reaches `PendingPrompt.caller` as `CallerIdentity::WebApp(hash)`, not `"Unknown"`.
- `test_dashboard_prompter_records_none_caller`: missing origin records `CallerIdentity::None` rather than collapsing to a blank/Unknown string.
- `test_pending_prompts_none_caller_encoding`: `/permission/pending` JSON encodes `None` as `{"kind":"none","hash":null}`.
- `test_permission_page_renders_webapp_caller`: behavioural assertions on the standalone HTML page — `Delegate says:` label present, message rendered, truncated delegate hash visible, full hash in `title=`, `Freenet app` caller prefix present, truncated caller hash visible.
- `test_permission_page_renders_none_caller`: None caller renders as `No app caller` with the `Delegate says:` label still present.
- `test_permission_page_escapes_hostile_message`: hostile delegate text and labels are HTML-escaped; no `<script>` or `<img>` injection possible.
- `test_truncate_hash_*`: helper produces `first8…last5`, returns short inputs unchanged, handles multi-byte chars correctly.

Closes #3857
Related: #3860

[AI-assisted - Claude]