### PR TITLE
feat: add --allowed-source-cidrs opt-in for local API access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ dependencies = [
  "hickory-resolver",
  "hostname",
  "httptest",
+ "ipnet",
  "libc",
  "lru",
  "moka",
@@ -3470,6 +3471,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,6 +2124,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.27.0",
  "toml 1.1.2+spec-1.1.0",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-appender",

--- a/apps/freenet-ping/app/tests/common/mod.rs
+++ b/apps/freenet-ping/app/tests/common/mod.rs
@@ -154,6 +154,7 @@ pub async fn base_node_test_config_with_rng<R: Rng>(
             token_ttl_seconds: None,
             token_cleanup_interval_seconds: None,
             allowed_host: None,
+            allowed_source_cidrs: None,
         },
         network_api: NetworkArgs {
             // Use varied IP for network socket to get unique ring locations

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -151,6 +151,7 @@ which = { workspace = true }
 regex = { workspace = true }
 serial_test = { workspace = true }
 url = "2"
+tower = { version = "0.5", features = ["util"] }
 
 # CI-optimized benchmark suite (~5 min, deterministic)
 [[bench]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -55,6 +55,7 @@ headers = { workspace = true }
 hex = { workspace = true }
 hickory-resolver = { workspace = true }
 hostname = "0.4"
+ipnet = { version = "2", features = ["serde"] }
 notify = { workspace = true }
 pav_regression = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -135,6 +135,7 @@ impl Default for ConfigArgs {
                 token_ttl_seconds: None,
                 token_cleanup_interval_seconds: None,
                 allowed_host: None,
+                allowed_source_cidrs: None,
             },
             secrets: Default::default(),
             log_level: Some(tracing::log::LevelFilter::Info),
@@ -637,6 +638,24 @@ impl ConfigArgs {
                     .token_cleanup_interval_seconds
                     .unwrap_or(default_token_cleanup_interval_seconds()),
                 allowed_hosts: self.ws_api.allowed_host.unwrap_or_default(),
+                allowed_source_cidrs: self
+                    .ws_api
+                    .allowed_source_cidrs
+                    .as_ref()
+                    .map(|cidrs| {
+                        cidrs
+                            .iter()
+                            .map(|s| {
+                                s.parse::<ipnet::IpNet>().map_err(|e| {
+                                    anyhow::anyhow!(
+                                        "invalid CIDR `{s}` in allowed-source-cidrs: {e}"
+                                    )
+                                })
+                            })
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?
+                    .unwrap_or_default(),
             },
             secrets,
             log_level: self.log_level.unwrap_or(tracing::log::LevelFilter::Info),
@@ -1274,6 +1293,29 @@ pub struct WebsocketApiArgs {
     #[arg(long, env = "ALLOWED_HOST")]
     #[serde(rename = "allowed-host", skip_serializing_if = "Option::is_none")]
     pub allowed_host: Option<Vec<String>>,
+
+    /// Additional source IP ranges (CIDR notation) permitted to reach the
+    /// local HTTP/WebSocket API.
+    ///
+    /// By default, only loopback and RFC1918 / IPv6 ULA ranges are accepted.
+    /// Use this to grant access from VPN overlays you control (e.g. Tailscale:
+    /// `--allowed-source-cidrs 100.64.0.0/10`). Can be specified multiple times.
+    ///
+    /// SECURITY: Only add ranges you fully control. CGNAT space like
+    /// `100.64.0.0/10` is shared between subscribers of some ISPs (Starlink,
+    /// T-Mobile, many cable carriers) and is only safe on an overlay network
+    /// such as Tailscale or WireGuard. Anything that can reach the API port
+    /// can access your contract state, keys, and client API.
+    #[arg(
+        long = "allowed-source-cidrs",
+        env = "ALLOWED_SOURCE_CIDRS",
+        value_delimiter = ','
+    )]
+    #[serde(
+        rename = "allowed-source-cidrs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allowed_source_cidrs: Option<Vec<String>>,
 }
 
 /// Default telemetry endpoint (nova.locut.us OTLP collector).
@@ -1393,6 +1435,12 @@ pub struct WebsocketApiConfig {
     /// Empty means only auto-detected hostnames (machine hostname + bound IP) are allowed.
     #[serde(default, rename = "allowed-host")]
     pub allowed_hosts: Vec<String>,
+
+    /// Additional source IP ranges (CIDR) permitted to reach the API.
+    /// Stored as parsed `IpNet` so config errors surface at startup.
+    /// Empty means only loopback + RFC1918 / IPv6 ULA are accepted.
+    #[serde(default, rename = "allowed-source-cidrs")]
+    pub allowed_source_cidrs: Vec<ipnet::IpNet>,
 }
 
 #[inline]
@@ -1413,6 +1461,7 @@ impl From<SocketAddr> for WebsocketApiConfig {
             token_ttl_seconds: default_token_ttl_seconds(),
             token_cleanup_interval_seconds: default_token_cleanup_interval_seconds(),
             allowed_hosts: Vec::new(),
+            allowed_source_cidrs: Vec::new(),
         }
     }
 }
@@ -1426,6 +1475,7 @@ impl Default for WebsocketApiConfig {
             token_ttl_seconds: default_token_ttl_seconds(),
             token_cleanup_interval_seconds: default_token_cleanup_interval_seconds(),
             allowed_hosts: Vec::new(),
+            allowed_source_cidrs: Vec::new(),
         }
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -646,11 +646,15 @@ impl ConfigArgs {
                         cidrs
                             .iter()
                             .map(|s| {
-                                s.parse::<ipnet::IpNet>().map_err(|e| {
+                                let net = s.parse::<ipnet::IpNet>().map_err(|e| {
                                     anyhow::anyhow!(
                                         "invalid CIDR `{s}` in allowed-source-cidrs: {e}"
                                     )
-                                })
+                                })?;
+                                crate::server::validate_source_cidr(&net).map_err(|msg| {
+                                    anyhow::anyhow!("allowed-source-cidrs: {msg}")
+                                })?;
+                                Ok::<_, anyhow::Error>(net)
                             })
                             .collect::<Result<Vec<_>, _>>()
                     })
@@ -2653,6 +2657,91 @@ mod tests {
         let cfg = args.build().await.unwrap();
         let serialized = toml::to_string(&cfg).unwrap();
         let _: Config = toml::from_str(&serialized).unwrap();
+    }
+
+    /// Build a minimal local-mode ConfigArgs with the given CIDR list and
+    /// return the result of `build().await`. The allowed_source_cidrs path
+    /// is the only interesting variation; everything else is defaulted.
+    async fn build_with_cidrs(cidrs: Option<Vec<String>>) -> anyhow::Result<Config> {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let args = ConfigArgs {
+            mode: Some(OperationMode::Local),
+            config_paths: ConfigPathsArgs {
+                config_dir: Some(temp_dir.path().to_path_buf()),
+                data_dir: Some(temp_dir.path().to_path_buf()),
+                log_dir: Some(temp_dir.path().to_path_buf()),
+            },
+            ws_api: WebsocketApiArgs {
+                allowed_source_cidrs: cidrs,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        args.build().await
+    }
+
+    #[tokio::test]
+    async fn allowed_source_cidrs_round_trip_through_build() {
+        let cfg = build_with_cidrs(Some(vec![
+            "100.64.0.0/10".to_string(),
+            "fd7a:115c:a1e0::/48".to_string(),
+        ]))
+        .await
+        .unwrap();
+        assert_eq!(cfg.ws_api.allowed_source_cidrs.len(), 2);
+        assert_eq!(
+            cfg.ws_api.allowed_source_cidrs[0],
+            "100.64.0.0/10".parse::<ipnet::IpNet>().unwrap()
+        );
+        assert_eq!(
+            cfg.ws_api.allowed_source_cidrs[1],
+            "fd7a:115c:a1e0::/48".parse::<ipnet::IpNet>().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn allowed_source_cidrs_default_is_empty() {
+        // Regression guard: if the user configures nothing, the built
+        // config must carry an empty vec so the server-side filter falls
+        // back to private-only behavior.
+        let cfg = build_with_cidrs(None).await.unwrap();
+        assert!(cfg.ws_api.allowed_source_cidrs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn allowed_source_cidrs_rejects_malformed() {
+        let err = build_with_cidrs(Some(vec!["not-a-cidr".to_string()]))
+            .await
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("allowed-source-cidrs") && msg.contains("not-a-cidr"),
+            "error should name the field and the offending value: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn allowed_source_cidrs_rejects_whole_internet_catchall() {
+        // 0.0.0.0/0 parses fine as IpNet but the validator must reject
+        // it — this is the footgun the middleware can't defend against
+        // once the vec is populated.
+        let err = build_with_cidrs(Some(vec!["0.0.0.0/0".to_string()]))
+            .await
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("0.0.0.0/0") && msg.contains("/8"),
+            "error should explain why and name the minimum: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn allowed_source_cidrs_rejects_ipv6_catchall() {
+        let err = build_with_cidrs(Some(vec!["::/0".to_string()]))
+            .await
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("::/0") && msg.contains("/16"));
     }
 
     #[tokio::test]

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -392,6 +392,70 @@ impl AllowedSourceCidrs {
     }
 }
 
+/// Minimum IPv4 CIDR prefix length the operator allowlist will accept.
+///
+/// `/8` is the broadest reasonable range: it still covers `10.0.0.0/8`
+/// (RFC1918) and `100.64.0.0/10` (CGNAT / Tailscale). Anything shorter
+/// (`/7` through `/0`) would span enormous public space — `0.0.0.0/0`
+/// would expose the fully-privileged client API to the entire internet
+/// — so we refuse to load such configs at all rather than trust the
+/// operator typed what they meant.
+const MIN_IPV4_PREFIX_LEN: u8 = 8;
+
+/// Minimum IPv6 CIDR prefix length accepted for the same reason.
+/// `/16` still accommodates a /48 tailnet, /56 Hurricane Electric subnet,
+/// or /64 home LAN while refusing `::/0`-sized footguns.
+const MIN_IPV6_PREFIX_LEN: u8 = 16;
+
+/// Validates a single operator-supplied CIDR for the local-API allowlist.
+///
+/// Returns an error if the prefix length is shorter than
+/// [`MIN_IPV4_PREFIX_LEN`] / [`MIN_IPV6_PREFIX_LEN`], which would widen the
+/// trust boundary past anything the operator could plausibly own. This is a
+/// safety net, not a substitute for good judgment: a user can still pass
+/// `8.8.0.0/16` and reach the public internet on purpose. We just refuse to
+/// silently accept whole-internet footguns like `0.0.0.0/0`.
+pub fn validate_source_cidr(net: &ipnet::IpNet) -> Result<(), String> {
+    let (prefix, min) = match net {
+        ipnet::IpNet::V4(v4) => (v4.prefix_len(), MIN_IPV4_PREFIX_LEN),
+        ipnet::IpNet::V6(v6) => (v6.prefix_len(), MIN_IPV6_PREFIX_LEN),
+    };
+    if prefix < min {
+        return Err(format!(
+            "CIDR `{net}` has prefix /{prefix}; minimum accepted is /{min}. \
+             Shorter prefixes would trust too large a range for a \
+             fully-privileged local API."
+        ));
+    }
+    Ok(())
+}
+
+/// Pure decision function for the source-IP filter.
+///
+/// Extracted from [`private_network_filter`] so the boolean composition can
+/// be unit-tested directly — catching inverted-operator regressions that
+/// would turn a security bypass into a silent test pass.
+///
+/// The filter accepts traffic when the source IP is private (loopback,
+/// RFC1918, IPv6 ULA / link-local) **or** when it matches an operator-
+/// supplied CIDR. IPv4-mapped IPv6 sources (`::ffff:a.b.c.d`) are normalized
+/// to IPv4 before the CIDR check so operators can write CIDRs in natural v4
+/// notation even on a dual-stack socket. (`is_private_ip` already handles
+/// mapped-v6 internally.)
+pub(crate) fn is_source_allowed(ip: IpAddr, allowed: &AllowedSourceCidrs) -> bool {
+    if is_private_ip(&ip) {
+        return true;
+    }
+    let match_ip = match ip {
+        IpAddr::V6(v6) => v6
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(v6)),
+        v4 => v4,
+    };
+    allowed.contains(&match_ip)
+}
+
 /// Builds the allowlist of hostnames/IPs for WebSocket `Host` header validation.
 ///
 /// Each entry is stored with and without the port suffix so both
@@ -499,12 +563,16 @@ async fn serve_client_api_in_impl(
     tracing::info!(?allowed_hosts, "WebSocket Host header allowlist built");
 
     let allowed_source_cidrs = AllowedSourceCidrs(Arc::new(config.allowed_source_cidrs.clone()));
-    if !allowed_source_cidrs.0.is_empty() {
+    // Log each range on its own line so ops journald/grep output stays
+    // legible. `warn!` because granting non-private access to a fully-
+    // privileged API is a posture change the operator should see on every
+    // boot, not a silent tweak buried in info.
+    for cidr in allowed_source_cidrs.0.iter() {
         tracing::warn!(
-            cidrs = ?allowed_source_cidrs.0,
-            "Extra source CIDR ranges enabled for local API. \
-             Ensure these ranges are fully under your control; \
-             anything reachable in them can access contract state and keys."
+            %cidr,
+            "Local API source CIDR enabled: ensure this range is fully under \
+             your control. Anything reachable in it can access contract \
+             state and keys."
         );
     }
 
@@ -537,17 +605,7 @@ async fn private_network_filter(
     next: axum::middleware::Next,
 ) -> axum::response::Response {
     let ip = connect_info.0.ip();
-    // Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d) to IPv4 so operator-supplied
-    // CIDRs expressed in IPv4 notation match traffic arriving on a dual-stack
-    // socket.
-    let match_ip = match ip {
-        IpAddr::V6(v6) => v6
-            .to_ipv4_mapped()
-            .map(IpAddr::V4)
-            .unwrap_or(IpAddr::V6(v6)),
-        v4 => v4,
-    };
-    if !is_private_ip(&match_ip) && !allowed_source_cidrs.contains(&match_ip) {
+    if !is_source_allowed(ip, &allowed_source_cidrs) {
         tracing::warn!(
             remote_ip = %ip,
             "Rejected connection from non-private IP"
@@ -791,6 +849,132 @@ mod tests {
         assert!(!allow.contains(&IpAddr::V6(Ipv6Addr::new(
             0xfd7a, 0x115c, 0xa1e1, 0, 0, 0, 0, 1
         ))));
+    }
+
+    // Middleware decision tests: exercise the full boolean composition of
+    // `is_source_allowed`, not just `AllowedSourceCidrs::contains`. An
+    // inverted operator in the middleware would still pass the bare
+    // `contains` tests above, so these are the regression guards that
+    // actually prevent a security bypass.
+
+    #[test]
+    fn is_source_allowed_accepts_private_with_empty_allowlist() {
+        let empty = AllowedSourceCidrs::default();
+        assert!(is_source_allowed(IpAddr::V4(Ipv4Addr::LOCALHOST), &empty));
+        assert!(is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            &empty
+        ));
+        assert!(is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)),
+            &empty
+        ));
+        assert!(is_source_allowed(IpAddr::V6(Ipv6Addr::LOCALHOST), &empty));
+    }
+
+    #[test]
+    fn is_source_allowed_rejects_public_with_empty_allowlist() {
+        let empty = AllowedSourceCidrs::default();
+        assert!(!is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+            &empty
+        ));
+        assert!(!is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)),
+            &empty
+        ));
+        assert!(!is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 42)),
+            &empty
+        ));
+    }
+
+    #[test]
+    fn is_source_allowed_accepts_configured_tailscale_range() {
+        let tailnet = cidrs(&["100.64.0.0/10"]);
+        assert!(is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)),
+            &tailnet
+        ));
+        assert!(is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(100, 127, 0, 1)),
+            &tailnet
+        ));
+        // Outside the tailnet range, not private: must still reject.
+        assert!(!is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(100, 128, 0, 1)),
+            &tailnet
+        ));
+        assert!(!is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+            &tailnet
+        ));
+        // Private IPs still pass alongside the CIDR.
+        assert!(is_source_allowed(
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)),
+            &tailnet
+        ));
+    }
+
+    #[test]
+    fn is_source_allowed_normalizes_ipv4_mapped_ipv6_for_cidr_match() {
+        // An IPv4 client arriving on a dual-stack socket presents as
+        // ::ffff:a.b.c.d. Operators expect their v4 CIDRs to still match.
+        let tailnet = cidrs(&["100.64.0.0/10"]);
+        let mapped = IpAddr::V6(Ipv4Addr::new(100, 64, 0, 1).to_ipv6_mapped());
+        assert!(is_source_allowed(mapped, &tailnet));
+
+        // And the same normalization must NOT accidentally promote a
+        // public mapped v4 into the private set: ::ffff:8.8.8.8 stays
+        // rejected with an empty allowlist, and public with an unrelated
+        // allowlist.
+        let public_mapped = IpAddr::V6(Ipv4Addr::new(8, 8, 8, 8).to_ipv6_mapped());
+        assert!(!is_source_allowed(
+            public_mapped,
+            &AllowedSourceCidrs::default()
+        ));
+        assert!(!is_source_allowed(public_mapped, &tailnet));
+    }
+
+    #[test]
+    fn is_source_allowed_accepts_configured_ipv6_range() {
+        let tailnet_v6 = cidrs(&["fd7a:115c:a1e0::/48"]);
+        // fd7a:115c:a1e0::/48 is inside fc00::/7 (ULA) so is_private_ip
+        // already accepts it — the allowlist is a no-op for this case but
+        // the test documents the intent and guards against a future change
+        // that narrows `is_private_ip` and breaks this invariant.
+        let inside = IpAddr::V6(Ipv6Addr::new(0xfd7a, 0x115c, 0xa1e0, 0x0001, 0, 0, 0, 1));
+        assert!(is_source_allowed(inside, &tailnet_v6));
+    }
+
+    #[test]
+    fn validate_source_cidr_rejects_overly_broad_ipv4() {
+        // Whole-internet footguns must be rejected at parse time.
+        assert!(validate_source_cidr(&"0.0.0.0/0".parse().unwrap()).is_err());
+        assert!(validate_source_cidr(&"0.0.0.0/7".parse().unwrap()).is_err());
+        // /8 is the minimum accepted (covers 10.0.0.0/8 RFC1918).
+        assert!(validate_source_cidr(&"10.0.0.0/8".parse().unwrap()).is_ok());
+        // /10 allows Tailscale CGNAT.
+        assert!(validate_source_cidr(&"100.64.0.0/10".parse().unwrap()).is_ok());
+        // /32 (single host) is fine.
+        assert!(validate_source_cidr(&"203.0.113.5/32".parse().unwrap()).is_ok());
+    }
+
+    #[test]
+    fn validate_source_cidr_rejects_overly_broad_ipv6() {
+        assert!(validate_source_cidr(&"::/0".parse().unwrap()).is_err());
+        assert!(validate_source_cidr(&"::/15".parse().unwrap()).is_err());
+        assert!(validate_source_cidr(&"::/16".parse().unwrap()).is_ok());
+        assert!(validate_source_cidr(&"fd7a:115c:a1e0::/48".parse().unwrap()).is_ok());
+        assert!(validate_source_cidr(&"::1/128".parse().unwrap()).is_ok());
+    }
+
+    #[test]
+    fn validate_source_cidr_error_message_is_actionable() {
+        let err = validate_source_cidr(&"0.0.0.0/0".parse().unwrap()).unwrap_err();
+        assert!(err.contains("0.0.0.0/0"), "should quote the offending CIDR");
+        assert!(err.contains("/0"), "should state the offending prefix");
+        assert!(err.contains("/8"), "should state the minimum accepted");
     }
 
     #[test]

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -378,6 +378,20 @@ pub(crate) async fn serve_client_api_in(
 /// Hostnames and IPs accepted in the HTTP `Host` header for WebSocket connections.
 pub(crate) type AllowedHosts = Arc<HashSet<String>>;
 
+/// User-supplied source CIDRs that extend the built-in private-IP allowlist.
+///
+/// The filter accepts a request if the source IP is private (loopback / RFC1918 /
+/// link-local / IPv6 ULA) **or** matches any of these ranges. Empty by default;
+/// populated via `--allowed-source-cidrs` or `allowed-source-cidrs` in config.toml.
+#[derive(Clone, Default)]
+pub(crate) struct AllowedSourceCidrs(pub Arc<Vec<ipnet::IpNet>>);
+
+impl AllowedSourceCidrs {
+    fn contains(&self, ip: &IpAddr) -> bool {
+        self.0.iter().any(|net| net.contains(ip))
+    }
+}
+
 /// Builds the allowlist of hostnames/IPs for WebSocket `Host` header validation.
 ///
 /// Each entry is stored with and without the port suffix so both
@@ -484,12 +498,24 @@ async fn serve_client_api_in_impl(
     ));
     tracing::info!(?allowed_hosts, "WebSocket Host header allowlist built");
 
+    let allowed_source_cidrs = AllowedSourceCidrs(Arc::new(config.allowed_source_cidrs.clone()));
+    if !allowed_source_cidrs.0.is_empty() {
+        tracing::warn!(
+            cidrs = ?allowed_source_cidrs.0,
+            "Extra source CIDR ranges enabled for local API. \
+             Ensure these ranges are fully under your control; \
+             anything reachable in them can access contract state and keys."
+        );
+    }
+
     // When bound to a non-loopback address, reject connections from non-private
-    // source IPs. This is sufficient security: only LAN clients can connect.
+    // source IPs. Users may extend the allowlist with --allowed-source-cidrs
+    // (e.g. for a Tailscale tailnet range).
     let needs_lan_filter = !config.address.is_loopback();
     let router = if needs_lan_filter {
         ws_router
             .layer(Extension(allowed_hosts))
+            .layer(Extension(allowed_source_cidrs))
             .layer(axum::middleware::from_fn(private_network_filter))
             .layer(TraceLayer::new_for_http())
     } else {
@@ -502,15 +528,28 @@ async fn serve_client_api_in_impl(
     Ok((gw, ws_proxy))
 }
 
-/// Middleware that rejects requests from non-private IP addresses.
+/// Middleware that rejects requests from non-private IP addresses unless the
+/// source IP matches an operator-supplied CIDR in [`AllowedSourceCidrs`].
 async fn private_network_filter(
     connect_info: axum::extract::ConnectInfo<SocketAddr>,
+    Extension(allowed_source_cidrs): Extension<AllowedSourceCidrs>,
     req: axum::http::Request<axum::body::Body>,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    if !is_private_ip(&connect_info.0.ip()) {
+    let ip = connect_info.0.ip();
+    // Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d) to IPv4 so operator-supplied
+    // CIDRs expressed in IPv4 notation match traffic arriving on a dual-stack
+    // socket.
+    let match_ip = match ip {
+        IpAddr::V6(v6) => v6
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(v6)),
+        v4 => v4,
+    };
+    if !is_private_ip(&match_ip) && !allowed_source_cidrs.contains(&match_ip) {
         tracing::warn!(
-            remote_ip = %connect_info.0.ip(),
+            remote_ip = %ip,
             "Rejected connection from non-private IP"
         );
         return (
@@ -707,6 +746,76 @@ mod tests {
         let hosts = build_allowed_hosts(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 7509, &[]);
         assert!(!hosts.contains("0.0.0.0"));
         assert!(!hosts.contains("0.0.0.0:7509"));
+    }
+
+    fn cidrs(list: &[&str]) -> AllowedSourceCidrs {
+        AllowedSourceCidrs(Arc::new(list.iter().map(|s| s.parse().unwrap()).collect()))
+    }
+
+    #[test]
+    fn allowed_source_cidrs_empty_rejects_public() {
+        let allow = AllowedSourceCidrs::default();
+        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        // Empty list means default-deny. Private IPs still pass via is_private_ip
+        // at the call site, so we only assert the CIDR layer here.
+        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn allowed_source_cidrs_tailscale_cgnat() {
+        let allow = cidrs(&["100.64.0.0/10"]);
+        // Tailscale tailnet IPs
+        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))));
+        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 100, 50, 1))));
+        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 127, 255, 254))));
+        // Outside CGNAT
+        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 128, 0, 1))));
+        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 63, 255, 255))));
+        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+    }
+
+    #[test]
+    fn allowed_source_cidrs_narrow_tailnet() {
+        // A user pinning to their assigned tailnet subnet only
+        let allow = cidrs(&["100.64.1.0/24"]);
+        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 64, 1, 5))));
+        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 64, 2, 5))));
+    }
+
+    #[test]
+    fn allowed_source_cidrs_ipv6() {
+        let allow = cidrs(&["fd7a:115c:a1e0::/48"]);
+        assert!(allow.contains(&IpAddr::V6(Ipv6Addr::new(
+            0xfd7a, 0x115c, 0xa1e0, 0, 0, 0, 0, 1
+        ))));
+        assert!(!allow.contains(&IpAddr::V6(Ipv6Addr::new(
+            0xfd7a, 0x115c, 0xa1e1, 0, 0, 0, 0, 1
+        ))));
+    }
+
+    #[test]
+    fn allowed_source_cidrs_multiple_ranges() {
+        let allow = cidrs(&["100.64.0.0/10", "10.100.0.0/16"]);
+        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 64, 1, 1))));
+        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(10, 100, 5, 5))));
+        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(10, 101, 0, 1))));
+    }
+
+    #[test]
+    fn allowed_source_cidrs_does_not_accept_public_by_default() {
+        // Regression guard: the default (no CIDRs configured) MUST NOT
+        // trust CGNAT or any public space. Users must opt in explicitly.
+        let allow = AllowedSourceCidrs::default();
+        for ip in [
+            Ipv4Addr::new(100, 64, 0, 1),   // CGNAT
+            Ipv4Addr::new(8, 8, 8, 8),      // Public
+            Ipv4Addr::new(203, 0, 113, 42), // Public (TEST-NET-3)
+        ] {
+            assert!(
+                !allow.contains(&IpAddr::V4(ip)),
+                "{ip} must not be trusted by default",
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -581,10 +581,19 @@ async fn serve_client_api_in_impl(
     // (e.g. for a Tailscale tailnet range).
     let needs_lan_filter = !config.address.is_loopback();
     let router = if needs_lan_filter {
+        // Layer ordering matters: axum executes layers bottom-to-top per
+        // `Router::layer` docs, so the LAST `.layer(..)` call is the
+        // OUTERMOST and runs first in request flow. `private_network_filter`
+        // uses an `Extension<AllowedSourceCidrs>` extractor, so that
+        // Extension layer must be applied AFTER the `from_fn` layer here —
+        // otherwise the extension is injected after the filter runs and
+        // every request 500s because the extractor finds nothing. Docker
+        // NAT tests caught this (see regression in this module's `tests`
+        // submodule, `middleware_has_extension_injected`).
         ws_router
             .layer(Extension(allowed_hosts))
-            .layer(Extension(allowed_source_cidrs))
             .layer(axum::middleware::from_fn(private_network_filter))
+            .layer(Extension(allowed_source_cidrs))
             .layer(TraceLayer::new_for_http())
     } else {
         ws_router
@@ -808,6 +817,82 @@ mod tests {
 
     fn cidrs(list: &[&str]) -> AllowedSourceCidrs {
         AllowedSourceCidrs(Arc::new(list.iter().map(|s| s.parse().unwrap()).collect()))
+    }
+
+    /// Regression test for a layer-ordering bug that was only caught by the
+    /// Docker NAT CI job: axum executes `.layer(..)` calls bottom-to-top, so
+    /// the LAST `.layer(..)` call is the OUTERMOST and runs FIRST. If
+    /// `Extension(AllowedSourceCidrs)` is applied before `from_fn(filter)`
+    /// in the builder chain, the filter's `Extension<AllowedSourceCidrs>`
+    /// extractor runs before the extension is injected and every request
+    /// 500s — silently breaking every HTTP client including the in-test
+    /// connectivity probe. The test below builds the exact layer stack from
+    /// `serve_client_api_in_impl` and drives it with a synthetic request
+    /// from both an allowlisted source and a public one; if someone
+    /// reorders the layers again, the allowlisted request will stop
+    /// returning 200 and this test fails.
+    #[tokio::test]
+    async fn middleware_layer_stack_allows_configured_source() {
+        use axum::{Router, routing::get};
+        use tower::ServiceExt;
+
+        async fn handler() -> &'static str {
+            "ok"
+        }
+
+        let allowed = cidrs(&["100.64.0.0/10"]);
+        let app: Router = Router::new()
+            .route("/", get(handler))
+            .layer(axum::middleware::from_fn(private_network_filter))
+            .layer(Extension(allowed));
+
+        // A request with a ConnectInfo from inside the allowlist must
+        // pass through the middleware and reach the handler.
+        let req = axum::http::Request::builder()
+            .uri("/")
+            .extension(axum::extract::ConnectInfo(SocketAddr::from((
+                [100, 64, 0, 1],
+                12345,
+            ))))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            axum::http::StatusCode::OK,
+            "allowlisted CGNAT source must reach the handler; \
+             500 here means the middleware failed to extract the Extension \
+             (check layer ordering in serve_client_api_in_impl)"
+        );
+
+        // Public source outside the allowlist must be rejected with 403.
+        let req = axum::http::Request::builder()
+            .uri("/")
+            .extension(axum::extract::ConnectInfo(SocketAddr::from((
+                [8, 8, 8, 8],
+                12345,
+            ))))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::FORBIDDEN);
+
+        // Loopback with empty allowlist (separate router) must still pass
+        // via the private-IP branch — the OR composition guard.
+        let empty_app: Router = Router::new()
+            .route("/", get(handler))
+            .layer(axum::middleware::from_fn(private_network_filter))
+            .layer(Extension(AllowedSourceCidrs::default()));
+        let req = axum::http::Request::builder()
+            .uri("/")
+            .extension(axum::extract::ConnectInfo(SocketAddr::from((
+                [127, 0, 0, 1],
+                12345,
+            ))))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = empty_app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
     }
 
     #[test]

--- a/crates/core/tests/error_notification.rs
+++ b/crates/core/tests/error_notification.rs
@@ -427,6 +427,7 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
             token_ttl_seconds: None,
             token_cleanup_interval_seconds: None,
             allowed_host: None,
+            allowed_source_cidrs: None,
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -485,6 +486,7 @@ async fn test_connection_drop_error_notification() -> anyhow::Result<()> {
             token_ttl_seconds: None,
             token_cleanup_interval_seconds: None,
             allowed_host: None,
+            allowed_source_cidrs: None,
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),

--- a/crates/core/tests/operations_before_join.rs
+++ b/crates/core/tests/operations_before_join.rs
@@ -95,6 +95,7 @@ async fn test_operations_blocked_before_join() -> anyhow::Result<()> {
             token_ttl_seconds: None,
             token_cleanup_interval_seconds: None,
             allowed_host: None,
+            allowed_source_cidrs: None,
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -152,6 +153,7 @@ async fn test_operations_blocked_before_join() -> anyhow::Result<()> {
             token_ttl_seconds: None,
             token_cleanup_interval_seconds: None,
             allowed_host: None,
+            allowed_source_cidrs: None,
         },
         network_api: freenet::config::NetworkArgs {
             public_address: Some(Ipv4Addr::LOCALHOST.into()),

--- a/crates/core/tests/token_expiration.rs
+++ b/crates/core/tests/token_expiration.rs
@@ -35,6 +35,7 @@ async fn create_test_config(
             token_ttl_seconds: Some(token_ttl_seconds),
             token_cleanup_interval_seconds: Some(cleanup_interval_seconds),
             allowed_host: None,
+            allowed_source_cidrs: None,
         },
         network_api: NetworkArgs {
             address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -131,6 +132,7 @@ async fn test_default_token_configuration() -> TestResult {
                 token_ttl_seconds: None,
                 token_cleanup_interval_seconds: None,
                 allowed_host: None,
+                allowed_source_cidrs: None,
             },
             network_api: NetworkArgs {
                 address: Some(Ipv4Addr::LOCALHOST.into()),
@@ -211,6 +213,7 @@ async fn test_token_cleanup_removes_expired_tokens() -> TestResult {
             token_ttl_seconds: TOKEN_TTL_SECS,
             token_cleanup_interval_seconds: CLEANUP_INTERVAL_SECS,
             allowed_hosts: Vec::new(),
+            allowed_source_cidrs: Vec::new(),
         };
 
         // Start the client API server (which spawns the cleanup task)

--- a/crates/freenet-macros/src/codegen.rs
+++ b/crates/freenet-macros/src/codegen.rs
@@ -279,6 +279,7 @@ fn generate_node_setup(args: &FreenetTestArgs) -> TokenStream {
                             token_ttl_seconds: None,
                             token_cleanup_interval_seconds: None,
                             allowed_host: None,
+                            allowed_source_cidrs: None,
                         },
                         network_api: freenet::config::NetworkArgs {
                             // Use varied IP for public_address (affects location calculation)
@@ -418,6 +419,7 @@ fn generate_node_setup(args: &FreenetTestArgs) -> TokenStream {
                             token_ttl_seconds: None,
                             token_cleanup_interval_seconds: None,
                             allowed_host: None,
+                            allowed_source_cidrs: None,
                         },
                         network_api: freenet::config::NetworkArgs {
                             // Use varied IP for public_address (affects location calculation)


### PR DESCRIPTION
## Problem

The local HTTP/WebSocket API (port 7509) is hard-restricted to loopback + RFC1918 + IPv6 link-local / ULA via the `private_network_filter` middleware. Any other source IP is rejected with *"Only local network connections are allowed"*. There is no way to grant access from a private overlay network (Tailscale, WireGuard, Nebula) without either forking core or binding the API to an unrelated private address and hoping routing works out. For users who want to reach their own node from a phone while away from their LAN, the only supported path is an SSH tunnel.

Matrix user question that prompted this: *"Any chance of adding support for accessing a Freenet node running over tailscale?"* Right now `http://freenetnode:7509/` on a tailnet fails because the source IP (CGNAT 100.64.0.0/10) is neither RFC1918 nor loopback.

## Solution

Add an **opt-in** CIDR allowlist that extends the built-in private-IP check. Default behavior is unchanged (the field is empty), so users who don't configure anything see zero posture change.

- New CLI flag `--allowed-source-cidrs` (comma/repeat), env var `ALLOWED_SOURCE_CIDRS`, and `allowed-source-cidrs` field under `[ws-api]` in `config.toml`.
- Parsed at config-build time via `ipnet::IpNet` (already a transitive workspace dep), so bad CIDRs fail loudly at startup instead of silently at runtime.
- `private_network_filter` accepts a request if the source IP is private **or** matches any configured CIDR. IPv4-mapped IPv6 sources from the dual-stack socket are normalized to IPv4 before matching, so users can express `100.64.0.0/10` in natural v4 notation.
- Parsed CIDRs are logged at `warn!` on startup (with the list) so operators see their allowlist on every boot. The log message spells out the risk.

### Why no auto-trust of 100.64.0.0/10

It was tempting to auto-trust CGNAT space since Tailscale uses it, but CGNAT is **shared** between subscribers of some ISPs (Starlink, T-Mobile, many cable carriers). Auto-trusting would silently widen the trust boundary for those users from *their LAN only* to *every other customer on their ISP's CGNAT segment*. Keeping the opt-in explicit preserves the guarantee that the default posture is the one we audited: private RFC1918 space you control, nothing else.

### Alternatives considered

- **Interface-scoped binding alone.** Even if the socket is bound to `tailscale0`, the filter still rejects the 100.x source IP. The allowlist is still required. Docs recommend doing both for defense in depth.
- **Auth token for remote access.** Legitimate direction long-term, but orthogonal: the API has no authn today, so any path that reaches the port is already privileged. The opt-in CIDR list doesn't make that worse.

## Testing

New unit tests in `crates/core/src/server.rs`:

- `allowed_source_cidrs_empty_rejects_public`  (default-deny regression)
- `allowed_source_cidrs_does_not_accept_public_by_default` (explicit guard that CGNAT / public / TEST-NET-3 are NOT trusted with default config)
- `allowed_source_cidrs_tailscale_cgnat` (100.64.0.0/10 boundary: accepts 100.64/100.100/100.127.x, rejects 100.63 / 100.128 / public)
- `allowed_source_cidrs_narrow_tailnet` (narrower /24 works and excludes neighbors)
- `allowed_source_cidrs_ipv6` (fd7a:115c:a1e0::/48 Tailscale v6 range)
- `allowed_source_cidrs_multiple_ranges` (multi-range allowlist)

All existing `test_is_private_ip_*` tests unchanged and still green.

`cargo check -p freenet --tests`, `cargo clippy -p freenet --lib -- -D warnings`, and `cargo test -p freenet --lib server::` all pass. The new macro/test fixtures for `WebsocketApiArgs { allowed_source_cidrs: None }` and `WebsocketApiConfig { allowed_source_cidrs: Vec::new() }` are mechanical updates in `freenet-macros/src/codegen.rs` and `crates/core/tests/*.rs`.

### Why unit tests instead of simulation

The filter lives outside the DHT / routing / transport surface, so simulation tests give no extra signal. The logic under test is literally *"does this IP match one of these CIDRs"*, which is best expressed as boundary-focused table tests. Happy to add an integration test that spins up axum and makes a real request from an allowed / denied source if a reviewer wants belt-and-braces coverage.

## Docs

Separate PR in `freenet/web` adds `hugo-site/content/build/manual/remote-access.md` explaining the two supported ways to reach a node from off-LAN (SSH tunnel as the safest default; Tailscale with this new CIDR allowlist as the alternative). That PR links back here.

## Fixes

Addresses a Matrix question about Tailscale access; no existing issue.

[AI-assisted - Claude]