### PR TITLE
fix(server): redirect top-level HTML subpath loads to shell route

### DIFF
--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -268,16 +268,24 @@ async fn web_subpages(
     // response in the sandbox iframe. Otherwise `variable_content` serves
     // raw HTML with no `authToken` query parameter, breaking webapps that
     // read credentials from `location.search` (freenet/river#208 follow-up:
-    // Delta links hit "Connection failed" on the destination). Hash-routed
-    // webapps preserve their fragment across the redirect; path-based
-    // multi-page apps lose the sub-path but still get a working shell.
+    // Delta links hit "Connection failed" on the destination).
+    //
+    // The browser preserves any URL fragment across a 303 redirect, which
+    // is sufficient for hash-routed webapps (e.g. Delta). Path-based
+    // multi-page apps still lose the sub-path — this redirect restores
+    // the baseline guarantee that top-level contract loads get a working
+    // shell. A fuller fix for path-based deep linking (#3841) would
+    // thread the sub-path into shell generation.
+    //
+    // Clients without `Sec-Fetch-Dest` (curl, older browsers) intentionally
+    // fall through to `variable_content` — matches pre-PR behaviour and
+    // avoids redirect loops for non-browser clients.
     let fetch_dest = req_headers
         .get("sec-fetch-dest")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     if should_redirect_subpage_to_shell(is_sandbox, &last_path, fetch_dest) {
-        let shell_url = format!("/{}/contract/web/{key}/", api_version.prefix());
-        return Ok(axum::response::Redirect::to(&shell_url).into_response());
+        return redirect_to_shell_root(&key, api_version, query_string.as_deref());
     }
 
     let version_prefix = api_version.prefix();
@@ -290,6 +298,69 @@ async fn web_subpages(
             add_sandbox_cors_headers(&mut response);
             response
         })
+}
+
+/// Builds a 303 redirect to the contract's shell root, preserving
+/// inbound query parameters (minus sensitive ones that must never be
+/// attacker-controlled across the redirect).
+///
+/// Validates `key` as a `ContractInstanceId` before interpolating into
+/// the `Location` header. A crafted path containing e.g. percent-encoded
+/// CRLF would otherwise reach `HeaderValue::try_from` inside
+/// `Redirect::to`, which panics on invalid header values. Returning a
+/// structured `InvalidParam` error instead keeps the handler panic-free
+/// and lets axum serialise a normal 4xx response.
+///
+/// `__sandbox=1` is stripped so a crafted deep link cannot land the
+/// victim inside `web_home`'s sandbox branch and bypass shell
+/// generation entirely. `authToken` is stripped so a malicious
+/// cross-contract link cannot inject a token into the destination
+/// shell's `location.search`; the shell generates its own token via
+/// `AuthToken::generate()` and any forwarded value would only mislead
+/// webapps that read credentials from the URL.
+fn redirect_to_shell_root(
+    key: &str,
+    api_version: ApiVersion,
+    query_string: Option<&str>,
+) -> Result<axum::response::Response, WebSocketApiError> {
+    if key.is_empty() {
+        return Err(WebSocketApiError::InvalidParam {
+            error_cause: "empty contract key in redirect target".into(),
+        });
+    }
+    let _instance_id =
+        ContractInstanceId::from_bytes(key).map_err(|err| WebSocketApiError::InvalidParam {
+            error_cause: format!("invalid contract key in redirect target: {err}"),
+        })?;
+
+    let filtered_query = query_string
+        .map(|qs| {
+            qs.split('&')
+                .filter(|p| !p.is_empty())
+                .filter(|p| !is_sensitive_query_param(p))
+                .collect::<Vec<_>>()
+                .join("&")
+        })
+        .filter(|s| !s.is_empty());
+
+    let prefix = api_version.prefix();
+    let shell_url = match filtered_query {
+        Some(qs) => format!("/{prefix}/contract/web/{key}/?{qs}"),
+        None => format!("/{prefix}/contract/web/{key}/"),
+    };
+    Ok(axum::response::Redirect::to(&shell_url).into_response())
+}
+
+/// Query parameters that must be stripped before forwarding a user URL
+/// into the shell. `__sandbox` is a server-interpreted routing flag;
+/// `authToken` is the shell's auth credential and must only come from
+/// `AuthToken::generate()`, never from an attacker-controlled URL.
+fn is_sensitive_query_param(param: &str) -> bool {
+    // Prefix-match so variants like `__sandbox_debug` or `authTokenExtra`
+    // (from a future refactor or an adversarial URL) are also stripped.
+    // Matches the filter in `path_handlers::shell_page` that forwards
+    // query params into the iframe.
+    param.starts_with("__sandbox") || param.starts_with("authToken")
 }
 
 /// Returns true if a contract sub-path request is a top-level HTML
@@ -340,8 +411,7 @@ async fn serve_sandbox_response(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     if fetch_dest == "document" {
-        let shell_url = format!("/{}/contract/web/{key}/", api_version.prefix());
-        return Ok(axum::response::Redirect::to(&shell_url).into_response());
+        return redirect_to_shell_root(&key, api_version, None);
     }
 
     let contract_response =
@@ -608,6 +678,241 @@ mod tests {
         // redirecting would break multi-page navigation inside the sandbox.
         assert!(!should_redirect_subpage_to_shell(true, "page2", "iframe"));
         assert!(!should_redirect_subpage_to_shell(true, "page2", "document"));
+    }
+
+    /// A valid contract key used across redirect tests. Constructed from
+    /// 32 zero bytes so `ContractInstanceId::from_bytes` accepts it.
+    fn valid_contract_key_b58() -> String {
+        use freenet_stdlib::prelude::ContractInstanceId;
+        let bytes = [0u8; 32];
+        ContractInstanceId::new(bytes).to_string()
+    }
+
+    #[test]
+    fn redirect_to_shell_root_drops_sensitive_params_and_preserves_others() {
+        let key = valid_contract_key_b58();
+        // Mixed query with sensitive + harmless params.
+        let query = Some("authToken=attacker&invite=abc&__sandbox=1&room=42");
+        let resp = redirect_to_shell_root(&key, ApiVersion::V1, query)
+            .expect("valid key should not fail validation");
+        let loc = resp
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .expect("redirect must set Location")
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Pin the full shape: contract sub-path, preserved query (order
+        // preserved, sensitive params stripped).
+        assert_eq!(
+            loc,
+            format!("/v1/contract/web/{key}/?invite=abc&room=42"),
+            "sensitive params must be stripped, harmless ones preserved in order"
+        );
+
+        // Defensive: ensure attacker token never appears anywhere in the
+        // redirect URL. If a future refactor reintroduces it, this fails.
+        assert!(
+            !loc.contains("authToken"),
+            "authToken must never appear in redirect target"
+        );
+        assert!(
+            !loc.contains("__sandbox"),
+            "__sandbox must never appear in redirect target"
+        );
+    }
+
+    #[test]
+    fn redirect_to_shell_root_omits_query_when_empty() {
+        let key = valid_contract_key_b58();
+        let resp = redirect_to_shell_root(&key, ApiVersion::V1, None).unwrap();
+        let loc = resp
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(loc, format!("/v1/contract/web/{key}/"));
+        assert!(!loc.contains('?'));
+
+        // A query that is entirely sensitive params must also produce no
+        // trailing `?` — keeps the URL canonical so browsers don't show
+        // a bare `?` in the address bar.
+        let resp =
+            redirect_to_shell_root(&key, ApiVersion::V1, Some("authToken=x&__sandbox=1")).unwrap();
+        let loc = resp
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(loc, format!("/v1/contract/web/{key}/"));
+    }
+
+    #[test]
+    fn redirect_to_shell_root_uses_303_see_other_for_fragment_preservation() {
+        // A 303 See Other (axum's `Redirect::to` default) has RFC 7231
+        // SHOULD semantics for URL-fragment preservation across the
+        // redirect, and converts any method to GET. Pin so that a future
+        // refactor to `Redirect::temporary` (307) or `Redirect::permanent`
+        // (308) doesn't silently change fragment semantics for hash-routed
+        // webapps like Delta.
+        let key = valid_contract_key_b58();
+        let resp = redirect_to_shell_root(&key, ApiVersion::V1, None).unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::SEE_OTHER);
+    }
+
+    /// Regression test for the L3 panic surface raised during review:
+    /// without key validation, a crafted path containing percent-encoded
+    /// CRLF would reach `HeaderValue::try_from` inside `Redirect::to`,
+    /// which panics on invalid header values. Validating via
+    /// `ContractInstanceId::from_bytes` first converts this into a
+    /// structured 4xx response.
+    #[test]
+    fn redirect_to_shell_root_rejects_invalid_key_instead_of_panicking() {
+        // Obvious garbage.
+        assert!(matches!(
+            redirect_to_shell_root("not-a-real-contract-key", ApiVersion::V1, None),
+            Err(WebSocketApiError::InvalidParam { .. })
+        ));
+        // CRLF-bearing key: exactly the panic surface L3 flagged. Must
+        // return an error, not panic inside the handler.
+        assert!(matches!(
+            redirect_to_shell_root("AAAA\r\nInjected: x", ApiVersion::V1, None),
+            Err(WebSocketApiError::InvalidParam { .. })
+        ));
+        // Empty key.
+        assert!(matches!(
+            redirect_to_shell_root("", ApiVersion::V1, None),
+            Err(WebSocketApiError::InvalidParam { .. })
+        ));
+    }
+
+    /// End-to-end regression: call `web_subpages` with the exact input
+    /// shape the Delta cross-contract-link failure mode produces, and
+    /// assert the handler responds with the shell-root redirect, the
+    /// filtered query string, and the 303 status.
+    ///
+    /// Pins the wiring the predicate-only tests do not reach: the
+    /// `Sec-Fetch-Dest` header lookup, the interaction with the query
+    /// string from `RawQuery`, the redirect URL construction, and the
+    /// full status + `Location` response contract.
+    #[tokio::test]
+    async fn web_subpages_redirects_top_level_document_load_to_shell() {
+        let key = valid_contract_key_b58();
+
+        // Case 1: top-level HTML document load of an HTML sub-path
+        // (non-sandbox, matching a pasted cross-contract link). Must
+        // redirect to shell root, preserving `invite` and stripping
+        // the attacker-supplied `authToken`.
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("sec-fetch-dest", "document".parse().unwrap());
+        let resp = web_subpages(
+            key.clone(),
+            "page2".to_string(),
+            ApiVersion::V1,
+            Some("authToken=attacker&invite=abc".to_string()),
+            headers,
+        )
+        .await
+        .expect("redirect response must be Ok");
+        assert_eq!(resp.status(), axum::http::StatusCode::SEE_OTHER);
+        let loc = resp
+            .headers()
+            .get(axum::http::header::LOCATION)
+            .expect("Location header must be set on the redirect")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(loc, format!("/v1/contract/web/{key}/?invite=abc"));
+        assert!(
+            !loc.contains("authToken"),
+            "authToken must be stripped on the redirect hop"
+        );
+
+        // Case 1b: a sandbox sub-page request with `Sec-Fetch-Dest:
+        // document` must still redirect to the shell root (via the
+        // sandbox branch's existing top-level-load guard) rather than
+        // serving raw sandbox content in the top frame. Exercises the
+        // sandbox short-circuit that runs *before* the new redirect
+        // block, which is the path a pasted sandbox URL hits.
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("sec-fetch-dest", "document".parse().unwrap());
+        let resp = web_subpages(
+            key.clone(),
+            "page2".to_string(),
+            ApiVersion::V1,
+            Some("__sandbox=1".to_string()),
+            headers,
+        )
+        .await
+        .expect("sandbox document load must redirect, not error");
+        assert_eq!(resp.status(), axum::http::StatusCode::SEE_OTHER);
+
+        // Case 2: missing Sec-Fetch-Dest (curl, older browsers) falls
+        // through to variable_content — pre-PR behaviour preserved, no
+        // redirect loop for non-browser clients. Call returns an error
+        // (file does not exist in the test cache); we assert only that
+        // it is NOT a shell-root redirect.
+        let res = web_subpages(
+            key.clone(),
+            "page2".to_string(),
+            ApiVersion::V1,
+            None,
+            axum::http::HeaderMap::new(),
+        )
+        .await;
+        match res {
+            Ok(resp) => assert_ne!(resp.status(), axum::http::StatusCode::SEE_OTHER),
+            Err(_) => {
+                // variable_content returned an error for a missing
+                // cache file, which is fine — the point is that we did
+                // not take the redirect branch.
+            }
+        }
+    }
+
+    /// Regression test pinning the ordering inside `web_subpages`: a
+    /// sandbox iframe request for an HTML sub-path MUST hit the sandbox
+    /// branch (line ~261), not the new top-level-document redirect,
+    /// even if a future reorder moves the redirect block earlier.
+    ///
+    /// We cannot exercise the full sandbox pipeline in a unit test
+    /// (requires a real contract state in the cache), but we can
+    /// assert the predicate-level invariant — `should_redirect_subpage_to_shell`
+    /// returns false for any sandbox request — and check the source
+    /// ordering via byte-offset comparison so that a reorder is caught
+    /// mechanically.
+    #[test]
+    fn web_subpages_sandbox_branch_runs_before_redirect_branch() {
+        let src = include_str!("client_api.rs");
+        // The sandbox short-circuit must appear before the
+        // top-level-document redirect inside `web_subpages`. Both
+        // markers are unique to that function.
+        let sandbox_idx = src
+            .find("serve_sandbox_response(key, api_version, Some(&last_path)")
+            .expect("sandbox short-circuit marker present in web_subpages");
+        let redirect_idx = src
+            .find("should_redirect_subpage_to_shell(is_sandbox")
+            .expect("subpage redirect marker present in web_subpages");
+        assert!(
+            sandbox_idx < redirect_idx,
+            "sandbox branch must run before the top-level-document redirect: \
+             reordering would break sandbox iframe sub-page loads"
+        );
+
+        // Predicate-level invariant: sandbox requests are never
+        // redirected regardless of other inputs.
+        assert!(!should_redirect_subpage_to_shell(true, "page2", "document"));
+        assert!(!should_redirect_subpage_to_shell(true, "news/", "document"));
+        assert!(!should_redirect_subpage_to_shell(
+            true,
+            "index.html",
+            "iframe"
+        ));
     }
 
     #[test]

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -262,6 +262,31 @@ async fn web_subpages(
         return serve_sandbox_response(key, api_version, Some(&last_path), &req_headers).await;
     }
 
+    // Top-level document load for a contract sub-path HTML page (paste,
+    // bookmark, or cross-contract link click via window.location.assign).
+    // These requests would otherwise be served raw by `variable_content`
+    // without generating an auth token or wrapping in the shell iframe,
+    // leaving the page with no WebSocket credentials and breaking every
+    // webapp that reads `authToken` from `location.search` (freenet/river#208
+    // follow-up: Delta cross-contract links produced "Connection failed"
+    // on the destination site). Redirect to the shell root instead so the
+    // shell route (`web_home`) issues a fresh auth token. Any URL fragment
+    // is preserved client-side by the browser across the redirect, which
+    // is sufficient for hash-routed webapps (e.g. Delta). Path-based
+    // multi-page apps lose the sub-path component here — a fuller fix
+    // would thread the sub-path into shell generation so the initial
+    // iframe load targets the requested page, but the root redirect
+    // restores the baseline guarantee that every top-level contract
+    // load gets a working shell.
+    let fetch_dest = req_headers
+        .get("sec-fetch-dest")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if should_redirect_subpage_to_shell(is_sandbox, &last_path, fetch_dest) {
+        let shell_url = format!("/{}/contract/web/{key}/", api_version.prefix());
+        return Ok(axum::response::Redirect::to(&shell_url).into_response());
+    }
+
     let version_prefix = api_version.prefix();
     let full_path: String = format!("/{version_prefix}/contract/web/{key}/{last_path}");
     path_handlers::variable_content(key, full_path, api_version)
@@ -272,6 +297,23 @@ async fn web_subpages(
             add_sandbox_cors_headers(&mut response);
             response
         })
+}
+
+/// Decides whether a sub-path HTTP request should be redirected to the
+/// contract's shell root.
+///
+/// A top-level document load (`Sec-Fetch-Dest: document`) for a contract
+/// HTML sub-path would otherwise be served raw by `variable_content` with
+/// no auth token and no shell iframe, breaking any webapp that reads its
+/// credentials from `location.search`. Redirecting to the shell root
+/// route (`web_home`) forces a fresh auth token + shell wrapper. The
+/// browser preserves any URL fragment client-side across the redirect,
+/// which is sufficient for hash-routed webapps (e.g. Delta).
+///
+/// Sandbox iframe requests (`__sandbox=1`) are not redirected — those go
+/// through the sandbox pipeline.
+fn should_redirect_subpage_to_shell(is_sandbox: bool, last_path: &str, fetch_dest: &str) -> bool {
+    !is_sandbox && is_html_page(last_path) && fetch_dest == "document"
 }
 
 /// Returns true if the path looks like an HTML page request.
@@ -529,6 +571,65 @@ mod tests {
         // workflows (e.g. spawning Web Workers from a Blob URL).
         assert!(connect_src.contains("blob:"));
         assert!(connect_src.contains("data:"));
+    }
+
+    /// Regression test for cross-contract link handling (Delta report,
+    /// freenet/river#208 follow-up).
+    ///
+    /// A top-level document load of a contract HTML sub-path (e.g. a
+    /// cross-contract link click via `window.location.assign`, a pasted
+    /// bookmark, or a shared deep link) must be redirected to the shell
+    /// root so `web_home` can issue a fresh auth token and wrap the
+    /// content in the sandboxed iframe. Before this fix, such loads hit
+    /// `variable_content` directly and served raw HTML with no shell,
+    /// leaving webapps (Delta in particular) with no `authToken` query
+    /// parameter and "Connection failed" WebSocket state.
+    #[test]
+    fn subpage_redirects_top_level_html_document_load_to_shell() {
+        // Top-level document load of an HTML sub-path → redirect.
+        assert!(should_redirect_subpage_to_shell(false, "page2", "document"));
+        assert!(should_redirect_subpage_to_shell(
+            false,
+            "about/team",
+            "document"
+        ));
+        assert!(should_redirect_subpage_to_shell(false, "news/", "document"));
+        assert!(should_redirect_subpage_to_shell(
+            false,
+            "index.html",
+            "document"
+        ));
+    }
+
+    #[test]
+    fn subpage_does_not_redirect_sub_resource_fetches() {
+        // Non-HTML assets (JS, CSS, WASM, images) must be served, not
+        // redirected, or the page would never load its resources.
+        for path in ["app.js", "style.css", "app.wasm", "logo.png"] {
+            assert!(
+                !should_redirect_subpage_to_shell(false, path, "document"),
+                "{path} must not be redirected"
+            );
+        }
+        // iframe / xhr / fetch destinations must never be redirected,
+        // even for HTML paths — only top-level document loads are
+        // ambiguous with pasted URLs and cross-contract clicks.
+        for dest in ["iframe", "empty", "script", "style", "image", ""] {
+            assert!(
+                !should_redirect_subpage_to_shell(false, "page2", dest),
+                "Sec-Fetch-Dest={dest} must not be redirected"
+            );
+        }
+    }
+
+    #[test]
+    fn subpage_does_not_redirect_sandbox_requests() {
+        // Sandbox iframe requests already carry the correct path and
+        // must flow through the sandbox content pipeline, not be
+        // redirected to the shell root (which would defeat multi-page
+        // navigation inside the sandbox).
+        assert!(!should_redirect_subpage_to_shell(true, "page2", "iframe"));
+        assert!(!should_redirect_subpage_to_shell(true, "page2", "document"));
     }
 
     #[test]

--- a/crates/core/src/server/client_api.rs
+++ b/crates/core/src/server/client_api.rs
@@ -262,22 +262,15 @@ async fn web_subpages(
         return serve_sandbox_response(key, api_version, Some(&last_path), &req_headers).await;
     }
 
-    // Top-level document load for a contract sub-path HTML page (paste,
-    // bookmark, or cross-contract link click via window.location.assign).
-    // These requests would otherwise be served raw by `variable_content`
-    // without generating an auth token or wrapping in the shell iframe,
-    // leaving the page with no WebSocket credentials and breaking every
-    // webapp that reads `authToken` from `location.search` (freenet/river#208
-    // follow-up: Delta cross-contract links produced "Connection failed"
-    // on the destination site). Redirect to the shell root instead so the
-    // shell route (`web_home`) issues a fresh auth token. Any URL fragment
-    // is preserved client-side by the browser across the redirect, which
-    // is sufficient for hash-routed webapps (e.g. Delta). Path-based
-    // multi-page apps lose the sub-path component here — a fuller fix
-    // would thread the sub-path into shell generation so the initial
-    // iframe load targets the requested page, but the root redirect
-    // restores the baseline guarantee that every top-level contract
-    // load gets a working shell.
+    // Top-level document loads of contract HTML sub-paths (pasted URLs,
+    // bookmarks, cross-contract link clicks) must be redirected to the
+    // shell root so `web_home` issues a fresh auth token and wraps the
+    // response in the sandbox iframe. Otherwise `variable_content` serves
+    // raw HTML with no `authToken` query parameter, breaking webapps that
+    // read credentials from `location.search` (freenet/river#208 follow-up:
+    // Delta links hit "Connection failed" on the destination). Hash-routed
+    // webapps preserve their fragment across the redirect; path-based
+    // multi-page apps lose the sub-path but still get a working shell.
     let fetch_dest = req_headers
         .get("sec-fetch-dest")
         .and_then(|v| v.to_str().ok())
@@ -299,19 +292,16 @@ async fn web_subpages(
         })
 }
 
-/// Decides whether a sub-path HTTP request should be redirected to the
-/// contract's shell root.
+/// Returns true if a contract sub-path request is a top-level HTML
+/// document load that must be redirected to the shell root.
 ///
-/// A top-level document load (`Sec-Fetch-Dest: document`) for a contract
-/// HTML sub-path would otherwise be served raw by `variable_content` with
-/// no auth token and no shell iframe, breaking any webapp that reads its
-/// credentials from `location.search`. Redirecting to the shell root
-/// route (`web_home`) forces a fresh auth token + shell wrapper. The
-/// browser preserves any URL fragment client-side across the redirect,
-/// which is sufficient for hash-routed webapps (e.g. Delta).
-///
-/// Sandbox iframe requests (`__sandbox=1`) are not redirected — those go
-/// through the sandbox pipeline.
+/// Only top-level document loads (`Sec-Fetch-Dest: document`) of HTML
+/// sub-paths are ambiguous with pasted URLs and cross-contract link
+/// clicks; redirecting them to `web_home` guarantees a fresh auth token
+/// and sandbox wrapper. The browser preserves any URL fragment across
+/// the redirect, which is sufficient for hash-routed webapps (e.g. Delta).
+/// Sandbox iframe requests (`__sandbox=1`) already flow through the
+/// sandbox pipeline and are never redirected here.
 fn should_redirect_subpage_to_shell(is_sandbox: bool, last_path: &str, fetch_dest: &str) -> bool {
     !is_sandbox && is_html_page(last_path) && fetch_dest == "document"
 }
@@ -574,19 +564,11 @@ mod tests {
     }
 
     /// Regression test for cross-contract link handling (Delta report,
-    /// freenet/river#208 follow-up).
-    ///
-    /// A top-level document load of a contract HTML sub-path (e.g. a
-    /// cross-contract link click via `window.location.assign`, a pasted
-    /// bookmark, or a shared deep link) must be redirected to the shell
-    /// root so `web_home` can issue a fresh auth token and wrap the
-    /// content in the sandboxed iframe. Before this fix, such loads hit
-    /// `variable_content` directly and served raw HTML with no shell,
-    /// leaving webapps (Delta in particular) with no `authToken` query
-    /// parameter and "Connection failed" WebSocket state.
+    /// freenet/river#208 follow-up). Top-level HTML sub-path loads must
+    /// redirect to the shell root so `web_home` issues a fresh auth token;
+    /// before the fix these loads served raw HTML with no `authToken`.
     #[test]
     fn subpage_redirects_top_level_html_document_load_to_shell() {
-        // Top-level document load of an HTML sub-path → redirect.
         assert!(should_redirect_subpage_to_shell(false, "page2", "document"));
         assert!(should_redirect_subpage_to_shell(
             false,
@@ -603,17 +585,15 @@ mod tests {
 
     #[test]
     fn subpage_does_not_redirect_sub_resource_fetches() {
-        // Non-HTML assets (JS, CSS, WASM, images) must be served, not
-        // redirected, or the page would never load its resources.
+        // Non-HTML assets must be served so the page can load resources.
         for path in ["app.js", "style.css", "app.wasm", "logo.png"] {
             assert!(
                 !should_redirect_subpage_to_shell(false, path, "document"),
                 "{path} must not be redirected"
             );
         }
-        // iframe / xhr / fetch destinations must never be redirected,
-        // even for HTML paths — only top-level document loads are
-        // ambiguous with pasted URLs and cross-contract clicks.
+        // Only top-level document loads are ambiguous with pasted URLs and
+        // cross-contract clicks; iframe/xhr/fetch must never be redirected.
         for dest in ["iframe", "empty", "script", "style", "image", ""] {
             assert!(
                 !should_redirect_subpage_to_shell(false, "page2", dest),
@@ -624,10 +604,8 @@ mod tests {
 
     #[test]
     fn subpage_does_not_redirect_sandbox_requests() {
-        // Sandbox iframe requests already carry the correct path and
-        // must flow through the sandbox content pipeline, not be
-        // redirected to the shell root (which would defeat multi-page
-        // navigation inside the sandbox).
+        // Sandbox iframe requests flow through the sandbox content pipeline;
+        // redirecting would break multi-page navigation inside the sandbox.
         assert!(!should_redirect_subpage_to_shell(true, "page2", "iframe"));
         assert!(!should_redirect_subpage_to_shell(true, "page2", "document"));
     }

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -310,14 +310,30 @@ fn shell_page(
     let version_prefix = api_version.prefix();
     let base_path = format!("/{version_prefix}/contract/web/{contract_key}/");
 
-    // Build the iframe src URL: same path with __sandbox=1 plus any original query params
+    // Build the iframe src URL: same path with __sandbox=1 plus any
+    // original query params (e.g., ?invitation=...). `__sandbox` is the
+    // server-interpreted routing flag and must come only from the line
+    // we prepend here. `authToken` is the shell's credential — the
+    // freshly-generated one is passed to `freenetBridge(authToken)`
+    // below; a value forwarded from `query_string` would only arrive
+    // via an attacker-controlled URL (pasted deep link or cross-contract
+    // navigate-handler hop that preserved `resolved.search`), so strip
+    // it to keep the iframe's `location.search` free of injected
+    // credentials that a webapp reading `location.search` might pick up.
     let mut iframe_params = vec!["__sandbox=1".to_string()];
     if let Some(qs) = &query_string {
-        // Forward the original query params (e.g., ?invitation=...) to the iframe
         for param in qs.split('&') {
-            if !param.is_empty() && !param.starts_with("__sandbox") {
-                iframe_params.push(param.to_string());
+            if param.is_empty() {
+                continue;
             }
+            // Strip any `__sandbox*` param (server-interpreted routing
+            // flag) and the auth credential `authToken`. Both are
+            // prefix-checked since a future refactor might add
+            // variants like `__sandbox_debug` or `authToken2`.
+            if param.starts_with("__sandbox") || param.starts_with("authToken") {
+                continue;
+            }
+            iframe_params.push(param.to_string());
         }
     }
     let iframe_src_raw = format!("{}?{}", base_path, iframe_params.join("&"));
@@ -682,12 +698,16 @@ function freenetBridge(authToken) {
             // cross-contract restoration — no popstate handling needed.
             //
             // Include `resolved.search` so any query parameters the link
-            // carries (e.g. app-level routing args) survive the hop; the
-            // destination shell strips `__sandbox=1` before forwarding.
-            // The gateway redirects non-root HTML subpath loads to the
-            // shell route (see web_subpages `Sec-Fetch-Dest` handling)
-            // so `/v1/contract/web/{key}/page2` still lands on a shell
-            // that issues an auth token.
+            // carries (e.g. app-level routing args) survive the hop. The
+            // destination shell page strips the sensitive routing params
+            // (`__sandbox`, `authToken`) before forwarding the rest into
+            // the iframe's `location.search`. The gateway's subpage
+            // handler redirects non-root HTML loads to the shell route
+            // (see `web_subpages` `Sec-Fetch-Dest` handling), which
+            // preserves the filtered query string all the way through,
+            // so `/v1/contract/web/{key}/page2?invite=…` still lands on
+            // a shell that issues an auth token and forwards `invite`
+            // into the iframe.
             try {
               window.location.assign(cleanPath + resolved.search + cappedHash);
             } catch(e) {}
@@ -1887,6 +1907,42 @@ mod tests {
         assert!(
             html.contains("invitation=abc"),
             "normal param should be forwarded"
+        );
+    }
+
+    /// Regression test for the cross-contract `authToken` injection
+    /// surface raised in review. A crafted cross-contract link with
+    /// `?authToken=attacker_value` reaches `shell_page` via the
+    /// `resolved.search` passthrough in the navigate bridge (or via a
+    /// pasted deep link that the subpage redirect forwards). The
+    /// iframe URL must never carry an attacker-supplied `authToken`
+    /// because any webapp that reads credentials from
+    /// `location.search` (Delta, River) would pick it up and use it
+    /// as its WebSocket credential.
+    #[tokio::test]
+    async fn shell_page_strips_auth_token_from_forwarded_query() {
+        let token = AuthToken::generate();
+        let qs = Some("authToken=attacker_value&invite=abc&authTokenExtra=x".to_string());
+        let html =
+            response_body(shell_page(&token, "testkey123", ApiVersion::V1, qs).unwrap()).await;
+        assert!(
+            !html.contains("attacker_value"),
+            "attacker-supplied authToken value must not reach iframe src"
+        );
+        assert!(
+            !html.contains("authTokenExtra"),
+            "authToken-prefixed params must also be stripped"
+        );
+        assert!(
+            html.contains("invite=abc"),
+            "harmless params must still be forwarded"
+        );
+        // The only authToken in the resulting HTML is the
+        // freshly-generated one passed to `freenetBridge(authToken)`,
+        // not a query-string value in the iframe src.
+        assert!(
+            html.contains(&format!("freenetBridge(\"{}\"", token.as_str())),
+            "shell must still bind the freshly-generated auth token"
         );
     }
 

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -681,14 +681,13 @@ function freenetBridge(authToken) {
             // The browser's normal back/forward history takes care of
             // cross-contract restoration — no popstate handling needed.
             //
-            // Preserve `resolved.search` so any query parameters the link
-            // carries (e.g. app-level routing args) survive the hop. The
-            // destination shell strips `__sandbox=1` before forwarding to
-            // its own iframe, so passing through the full query is safe.
-            // The gateway handler redirects non-root HTML subpath loads
-            // to the shell route (see web_subpages Sec-Fetch-Dest
-            // handling) so paths like `/v1/contract/web/{key}/page2`
-            // still end up on the shell that issues the auth token.
+            // Include `resolved.search` so any query parameters the link
+            // carries (e.g. app-level routing args) survive the hop; the
+            // destination shell strips `__sandbox=1` before forwarding.
+            // The gateway redirects non-root HTML subpath loads to the
+            // shell route (see web_subpages `Sec-Fetch-Dest` handling)
+            // so `/v1/contract/web/{key}/page2` still lands on a shell
+            // that issues an auth token.
             try {
               window.location.assign(cleanPath + resolved.search + cappedHash);
             } catch(e) {}

--- a/crates/core/src/server/path_handlers.rs
+++ b/crates/core/src/server/path_handlers.rs
@@ -680,8 +680,17 @@ function freenetBridge(authToken) {
             // token + origin attribution for the destination contract.
             // The browser's normal back/forward history takes care of
             // cross-contract restoration — no popstate handling needed.
+            //
+            // Preserve `resolved.search` so any query parameters the link
+            // carries (e.g. app-level routing args) survive the hop. The
+            // destination shell strips `__sandbox=1` before forwarding to
+            // its own iframe, so passing through the full query is safe.
+            // The gateway handler redirects non-root HTML subpath loads
+            // to the shell route (see web_subpages Sec-Fetch-Dest
+            // handling) so paths like `/v1/contract/web/{key}/page2`
+            // still end up on the shell that issues the auth token.
             try {
-              window.location.assign(cleanPath + cappedHash);
+              window.location.assign(cleanPath + resolved.search + cappedHash);
             } catch(e) {}
           }
         } catch(e) {}
@@ -2099,6 +2108,15 @@ mod tests {
             SHELL_BRIDGE_JS.contains("window.location.assign"),
             "cross-contract branch must use top-level navigation so the gateway \
              regenerates a fresh shell + auth token for the new contract"
+        );
+        // Cross-contract branch must preserve the query string so any
+        // app-level routing arguments on the link survive the hop. Dropping
+        // `resolved.search` previously stripped query parameters that the
+        // destination webapp depended on.
+        assert!(
+            SHELL_BRIDGE_JS
+                .contains("window.location.assign(cleanPath + resolved.search + cappedHash)"),
+            "cross-contract branch must preserve the query string via resolved.search"
         );
         // Navigate handler must validate same-origin
         assert!(


### PR DESCRIPTION
## Problem

Users reported (via Matrix) that clicking a link from one Freenet site to another flipped the destination webapp into an Error state until the page was refreshed. Ivvor saw Delta's "Connected" badge turn red after following a Delta-to-Delta link; Lukas confirmed that pasting the same URL directly worked but clicking the link produced console errors.

Root cause: the gateway's routing splits on URL shape.

- \`/v1/contract/web/{key}/\` → \`web_home\` → issues a fresh auth token, wraps the content in the sandboxed iframe shell
- \`/v1/contract/web/{key}/{*path}\` → \`web_subpages\` → for a non-sandbox HTML request, calls \`variable_content\` and serves the raw HTML file with **no shell, no auth token, no cookie**

Every webapp that uses \`freenetBridge\` (Delta, River, etc.) reads \`authToken\` from \`location.search\` to build its WebSocket URL. A top-level document load of any contract sub-path — pasted deep link, bookmark, or a cross-contract link click that goes through \`window.location.assign\` (added in #3858) — lands on \`web_subpages\` with no auth token in the query string, and the WebSocket handshake fails immediately.

Directly pasting \`/v1/contract/web/KEY/\` (the canonical share URL shape) happens to hit the root route and works — which is why Lukas saw paste succeed but click fail.

A secondary bug: the cross-contract navigate handler in \`SHELL_BRIDGE_JS\` passed only \`cleanPath + cappedHash\` to \`window.location.assign\`, silently dropping \`resolved.search\`. Any query parameters a link carried (app-level routing args, invitation tokens) were lost across the hop.

## Solution

Two changes, both in \`crates/core/src/server/\`:

1. **\`web_subpages\` redirect** — when the request is a top-level document load (\`Sec-Fetch-Dest: document\`) for a contract HTML sub-path that is not itself a sandbox request, redirect to the shell root \`/v{N}/contract/web/{key}/\`. The shell route generates a fresh auth token, wraps the contract in the sandboxed iframe, and the webapp loads with working credentials. The browser preserves any URL fragment client-side across the redirect, which is sufficient for hash-routed apps (Delta). Sub-resource fetches (\`Sec-Fetch-Dest: iframe/empty/script/...\`) and non-HTML assets are unaffected.

2. **Cross-contract navigate handler** — preserve \`resolved.search\` in the \`window.location.assign\` call so query parameters on the link survive the hop.

Key insight: the redirect is driven by \`Sec-Fetch-Dest\`, which the browser sets automatically and scripts cannot spoof. This matches the existing \`serve_sandbox_response\` guard that redirects top-level loads of sandbox URLs to the shell. Same security boundary, symmetric behaviour.

A fuller fix would thread the sub-path into shell generation so the iframe loads the requested page instead of the contract root. Out of scope for this PR — the root redirect restores the baseline guarantee that every top-level contract load gets a working shell, which is what was actually broken for users. Path-based multi-page apps that depend on deep-link entry can be addressed in a follow-up.

## Testing

New unit tests in \`crates/core/src/server/client_api.rs\`:

- \`subpage_redirects_top_level_html_document_load_to_shell\` — pins the redirect path for HTML pages (including extensionless, directory-style, and \`.html\` suffixes) when \`Sec-Fetch-Dest: document\`.
- \`subpage_does_not_redirect_sub_resource_fetches\` — pins that non-HTML assets (JS, CSS, WASM, images) and non-document destinations (\`iframe\`, \`empty\`, \`script\`, ...) are **not** redirected, so pages can still load their sub-resources.
- \`subpage_does_not_redirect_sandbox_requests\` — pins that sandbox iframe requests flow through the existing sandbox pipeline instead of being redirected to the shell root (which would defeat in-contract multi-page navigation).

The redirect decision is extracted into \`should_redirect_subpage_to_shell\` so the test matrix covers the pure logic without needing to spin up the axum router.

New SHELL_BRIDGE_JS assertion:

- Pins that the cross-contract \`window.location.assign\` expression includes \`resolved.search\`, so the query-preservation contract is part of the JS regression net.

Existing \`navigate_*\` tests (11 of them) and the sandbox/shell CSP tests continue to pass.

## Fixes

Follow-up to #3858 (\`allow cross-contract links from sandboxed webapps\`). Addresses the Delta cross-contract link reports surfaced by Ivvor and Lukas on Matrix.

[AI-assisted - Claude]