### PR TITLE
build(release): exclude Dependabot from in-progress CI gate

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -541,7 +541,14 @@ check_prerequisites() {
             # merge commit.
             local total_checks in_progress_count failed_count
             total_checks=$(echo "$check_runs_json" | jq '.total_count // 0')
-            in_progress_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status != "completed" and (.name | startswith("Build for") | not) and .name != "claude" and .name != "Large Scale Simulation" and .name != "Simulation Tests (Nightly)" and .name != "Notify Matrix on Failure")] | length')
+            # `Dependabot` runs on a cron and attaches to the HEAD commit
+            # of main, which made a still-running Dependabot job block
+            # the release pre-flight wait indefinitely even though
+            # `failed_count` already excluded it below. Align the two
+            # filters so a Dependabot run in either state never gates a
+            # release (release blocked by unrelated Dependabot cron,
+            # 2026-04-14 v0.2.45 release).
+            in_progress_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status != "completed" and .name != "Dependabot" and (.name | startswith("Build for") | not) and .name != "claude" and .name != "Large Scale Simulation" and .name != "Simulation Tests (Nightly)" and .name != "Notify Matrix on Failure")] | length')
             failed_count=$(echo "$check_runs_json" | jq '[.check_runs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .name != "Dependabot" and (.name | startswith("Build for") | not) and .name != "claude" and .name != "Large Scale Simulation" and .name != "Simulation Tests (Nightly)" and .name != "Notify Matrix on Failure")] | length')
 
             if [[ "$total_checks" == "0" ]]; then


### PR DESCRIPTION
## Problem

The release script's pre-flight CI wait in \`scripts/release.sh\` got stuck for 10 minutes during the 0.2.45 release because an unrelated Dependabot cron run on main was still \`in_progress\`. The wait timed out at \`ci_max_wait=600\` and the script exited with an error. Resuming the release required either waiting Dependabot out or manually cancelling the workflow run so the in-progress count dropped to zero.

The release script already has filters to ignore unrelated periodic workflows that attach check runs to the HEAD commit of main (Large Scale Simulation, Simulation Tests (Nightly), Notify Matrix on Failure, \`Build for *\` cross-compile jobs, \`claude\`). The \`failed_count\` filter at line 545 also excludes \`Dependabot\`. But the \`in_progress_count\` filter at line 544 does not — so a running Dependabot job blocks release, while a failed one is correctly ignored. This asymmetry is the bug.

## Solution

Add \`Dependabot\` to the \`in_progress_count\` exclusion list so both filters match. A Dependabot cron run on main does not gate the correctness of the commit under release and should never block a release in either state.

## Testing

\`bash -n scripts/release.sh\` passes. No behavioral tests for the release script exist in the repo; the bug reproduces in practice (0.2.45 release pre-flight, 2026-04-14). The fix is a one-expression filter change aligned with an already-working sibling filter on the adjacent line.

## Fixes

Follow-up from the 0.2.45 release pre-flight incident.

[AI-assisted - Claude]