### PR TITLE
docs: document the WallClockInstant alias exception in code-style rules

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -283,6 +283,34 @@ Need network socket in tests?
   → USE: Socket trait (crates/core/src/transport/)
 ```
 
+#### Exception: real wall-clock comparison against `boot_time::Instant`
+
+There is exactly **one** legitimate reason to reach for real wall-clock
+time in `crates/core/` rather than `TimeSource`: detecting OS
+suspend/resume by comparing `boot_time::Instant` (CLOCK_BOOTTIME, advances
+during suspend) against a monotonic wall clock that does not advance
+during suspend. `TimeSource` returns simulation time in test builds and
+would never reflect a real suspend, so it is the wrong abstraction for
+this specific use case.
+
+When you have this exact need:
+
+1. Alias the type at the `use` line so the rule-lint grep does not trip:
+   ```rust
+   use std::time::Instant as WallClockInstant;
+   ```
+2. Add a load-bearing comment on the `use` line explaining *why* the
+   exception is correct (cite the specific suspend-detection use case —
+   a generic "we need wall clock" justification is not sufficient).
+3. Use `WallClockInstant::now()` at the call sites.
+4. Keep the clock samples back-to-back with no intervening `.await`, so
+   the two clocks measure the same window.
+
+See `crates/core/src/ring.rs::connection_maintenance` for the canonical
+example (the `classify_suspend_jump` helper and its rustdoc). Do not
+add new call sites for any other purpose — every other "I need real
+time" urge in `crates/core/` should still go through `TimeSource`.
+
 ### WHEN writing documentation
 
 ```


### PR DESCRIPTION
## Problem

PR #3871 (merged as `ac761dab`) introduced a `use std::time::Instant as WallClockInstant;` alias exception in `crates/core/src/ring.rs::connection_maintenance` to satisfy the suspend/resume detector's need for a real wall clock (comparing `CLOCK_BOOTTIME` against `CLOCK_MONOTONIC`, which `TimeSource` cannot express in tests). The Claude Rule Review agent on that PR correctly flagged that the rule documentation in `.claude/rules/code-style.md` still reads "DO NOT use: `std::time::Instant::now()`" with no carve-outs — leaving a future reviewer with no rule to cite as justification for the existing `WallClockInstant::now()` call sites.

AGENTS.md rule says documentation updates must land in the same PR as the pattern they describe. The doc commit was ready on the `fix/nightly-sim-cm-race` branch locally, but by the time the rule-review agent flagged it, the merge queue had already frozen the branch (`GH006: Protected branch update failed ... A pull request for this branch has been added to a merge queue`), so it lands here as a fast-follow instead.

## Solution

Add a dedicated **"Exception: real wall-clock comparison against `boot_time::Instant`"** subsection under the existing `WHEN you need time/rng/sockets in crates/core/` rule. The exception:

- Names the one legitimate use case (OS suspend/resume detection).
- Explains why `TimeSource` is the wrong abstraction for this specific case (it returns simulation time in tests and can't reflect a real suspend).
- Documents the exact mechanics: alias at the `use` line with a load-bearing comment, call via `WallClockInstant::now()`, keep clock samples back-to-back with no intervening `.await`.
- Points at `crates/core/src/ring.rs::connection_maintenance` and `classify_suspend_jump` as the canonical example.
- Explicitly narrows the exception: do NOT add new call sites for any other purpose — every other "I need real time" urge in `crates/core/` should still go through `TimeSource`.

A future reviewer seeing `WallClockInstant::now()` now has a rule to cite; a future contributor tempted to reach for `std::time::Instant::now()` under a different justification will see the rule refuses it.

## Testing

Docs-only change. No code paths modified. `cargo fmt`/`clippy`/`test` not re-run since nothing Rust changed.

## Follow-up to

#3871 (merged as `ac761dab`).

[AI-assisted - Claude]