### PR TITLE
test(sim): add SimOperation::Disconnect + client-disconnect coverage

### DIFF
--- a/crates/core/src/node/network_bridge/broadcast_queue.rs
+++ b/crates/core/src/node/network_bridge/broadcast_queue.rs
@@ -10,238 +10,262 @@
 //! via a semaphore, deduplicates entries per (contract, peer), and replaces
 //! older entries with newer state when a duplicate is enqueued.
 
-use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
 use freenet_stdlib::prelude::{ContractKey, WrappedState};
-use tokio::sync::{Mutex, Notify, Semaphore};
 
 use crate::node::OpManager;
 use crate::ring::PeerKeyLocation;
 
 use super::p2p_protoc::P2pBridge;
 
-/// Maximum concurrent outbound broadcast streams for small payloads (< 64KB).
-/// Small payloads (deltas, chat messages) can fan out aggressively without
-/// saturating the uplink since they finish quickly.
-const DEFAULT_SMALL_PAYLOAD_CONCURRENCY: usize = 12;
-
-/// Maximum concurrent outbound broadcast streams for large payloads (>= 64KB).
-/// Large payloads (full state) are rate-limited to avoid uplink saturation.
-const DEFAULT_LARGE_PAYLOAD_CONCURRENCY: usize = 2;
-
-/// Payload size threshold for choosing the small vs large concurrency pool.
-/// Matches the streaming threshold used elsewhere in the broadcast path.
-const PAYLOAD_SIZE_THRESHOLD: usize = 64 * 1024;
-
-/// Maximum entries in the queue before oldest are dropped.
-const DEFAULT_MAX_QUEUE_DEPTH: usize = 256;
-
 /// Timeout for awaiting stream completion signal before releasing the permit
 /// anyway. Prevents permanent permit leak if a stream task panics or hangs.
+/// Used by `broadcast_to_single_peer` under both `simulation_tests` and
+/// production, hence kept at module scope rather than inside the cfg-gated
+/// `queue` submodule.
 const STREAM_COMPLETION_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// Key for deduplicating broadcast entries: (contract, peer identity).
-type DedupeKey = (ContractKey, PeerKeyLocation);
+// The `BroadcastQueue` struct (constants, types, impl) is only used in the
+// production `p2p_protoc` path. Under `simulation_tests` the code routes
+// through `broadcast_to_single_peer` directly (see p2p_protoc.rs), so the
+// queue itself is dead code in that build. Gate it out to keep
+// `cargo clippy --features simulation_tests -- -D warnings` clean.
+#[cfg(not(feature = "simulation_tests"))]
+mod queue {
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Arc;
 
-/// A pending broadcast entry in the queue.
-struct BroadcastEntry {
-    key: ContractKey,
-    target: PeerKeyLocation,
-    new_state: WrappedState,
-    /// Payload size in bytes, used to select concurrency pool.
-    payload_size: usize,
-}
+    use freenet_stdlib::prelude::{ContractKey, WrappedState};
+    use tokio::sync::{Mutex, Notify, Semaphore};
 
-/// Internal queue state: FIFO ordering via VecDeque + HashMap for dedup lookup.
-struct QueueState {
-    /// FIFO order of dedup keys. Entries may be stale if replaced by dedup.
-    order: VecDeque<DedupeKey>,
-    /// Actual entries, keyed by (contract, peer). Dedup replaces the state in-place.
-    entries: HashMap<DedupeKey, BroadcastEntry>,
-}
+    use crate::node::OpManager;
+    use crate::ring::PeerKeyLocation;
 
-impl QueueState {
-    fn new() -> Self {
-        Self {
-            order: VecDeque::new(),
-            entries: HashMap::new(),
-        }
-    }
+    use super::super::p2p_protoc::P2pBridge;
+    use super::broadcast_to_single_peer;
 
-    fn len(&self) -> usize {
-        self.entries.len()
-    }
+    /// Maximum concurrent outbound broadcast streams for small payloads (< 64KB).
+    /// Small payloads (deltas, chat messages) can fan out aggressively without
+    /// saturating the uplink since they finish quickly.
+    const DEFAULT_SMALL_PAYLOAD_CONCURRENCY: usize = 12;
 
-    /// Pop the oldest entry. Skips stale keys (removed by eviction or dedup).
-    fn pop_front(&mut self) -> Option<BroadcastEntry> {
-        while let Some(key) = self.order.pop_front() {
-            if let Some(entry) = self.entries.remove(&key) {
-                return Some(entry);
-            }
-            // Stale key (was evicted or already popped), skip
-        }
-        None
-    }
-}
+    /// Maximum concurrent outbound broadcast streams for large payloads (>= 64KB).
+    /// Large payloads (full state) are rate-limited to avoid uplink saturation.
+    const DEFAULT_LARGE_PAYLOAD_CONCURRENCY: usize = 2;
 
-/// Global broadcast queue that serializes outbound broadcast streams
-/// with bounded concurrency and deduplication.
-///
-/// Uses dual concurrency pools: small payloads (< 64KB) get high concurrency
-/// (12 slots) for fast fan-out of deltas/chat messages, while large payloads
-/// (>= 64KB) get low concurrency (2 slots) to avoid saturating the uplink.
-#[derive(Clone)]
-pub(crate) struct BroadcastQueue {
-    queue: Arc<Mutex<QueueState>>,
-    notify: Arc<Notify>,
-    small_payload_concurrency: usize,
-    large_payload_concurrency: usize,
-    max_queue_depth: usize,
-}
+    /// Payload size threshold for choosing the small vs large concurrency pool.
+    /// Matches the streaming threshold used elsewhere in the broadcast path.
+    const PAYLOAD_SIZE_THRESHOLD: usize = 64 * 1024;
 
-impl BroadcastQueue {
-    pub(crate) fn new() -> Self {
-        Self {
-            queue: Arc::new(Mutex::new(QueueState::new())),
-            notify: Arc::new(Notify::new()),
-            small_payload_concurrency: DEFAULT_SMALL_PAYLOAD_CONCURRENCY,
-            large_payload_concurrency: DEFAULT_LARGE_PAYLOAD_CONCURRENCY,
-            max_queue_depth: DEFAULT_MAX_QUEUE_DEPTH,
-        }
-    }
+    /// Maximum entries in the queue before oldest are dropped.
+    const DEFAULT_MAX_QUEUE_DEPTH: usize = 256;
 
-    /// Enqueue a broadcast for a single (contract, peer) pair.
-    ///
-    /// If an entry for the same contract+peer already exists, it is replaced
-    /// with the newer state (the older state is stale and would be superseded
-    /// anyway). If the queue is at capacity, the oldest entry is evicted.
-    pub(crate) async fn enqueue(
-        &self,
+    /// Key for deduplicating broadcast entries: (contract, peer identity).
+    type DedupeKey = (ContractKey, PeerKeyLocation);
+
+    /// A pending broadcast entry in the queue.
+    struct BroadcastEntry {
         key: ContractKey,
         target: PeerKeyLocation,
         new_state: WrappedState,
-    ) {
-        let dedup_key = (key, target.clone());
-        let mut queue = self.queue.lock().await;
+        /// Payload size in bytes, used to select concurrency pool.
+        payload_size: usize,
+    }
 
-        // Replace-on-dedup: if same contract+peer exists, update state in-place
-        if let Some(existing) = queue.entries.get_mut(&dedup_key) {
-            existing.new_state = new_state;
-            tracing::trace!(
-                contract = %dedup_key.0,
-                peer = ?target.socket_addr(),
-                "Broadcast queue: replaced stale entry with newer state"
-            );
-        } else {
-            // Evict oldest if at capacity
-            while queue.len() >= self.max_queue_depth {
-                if let Some(entry) = queue.pop_front() {
-                    tracing::warn!(
-                        contract = %entry.key,
-                        peer = ?entry.target.socket_addr(),
-                        queue_depth = self.max_queue_depth,
-                        "Broadcast queue full, evicted oldest entry"
-                    );
-                } else {
-                    break;
-                }
+    /// Internal queue state: FIFO ordering via VecDeque + HashMap for dedup lookup.
+    struct QueueState {
+        /// FIFO order of dedup keys. Entries may be stale if replaced by dedup.
+        order: VecDeque<DedupeKey>,
+        /// Actual entries, keyed by (contract, peer). Dedup replaces the state in-place.
+        entries: HashMap<DedupeKey, BroadcastEntry>,
+    }
+
+    impl QueueState {
+        fn new() -> Self {
+            Self {
+                order: VecDeque::new(),
+                entries: HashMap::new(),
             }
-            let payload_size = new_state.size();
-            queue.entries.insert(
-                dedup_key.clone(),
-                BroadcastEntry {
-                    key,
-                    target,
-                    new_state,
-                    payload_size,
-                },
-            );
-            queue.order.push_back(dedup_key);
         }
 
-        drop(queue);
-        self.notify.notify_one();
-    }
+        fn len(&self) -> usize {
+            self.entries.len()
+        }
 
-    /// Start the background worker that drains the queue with bounded concurrency.
-    ///
-    /// The worker runs forever. It should be spawned as a background task.
-    pub(crate) fn start_worker(
-        &self,
-        bridge: P2pBridge,
-        op_manager: Arc<OpManager>,
-    ) -> tokio::task::JoinHandle<()> {
-        let queue = self.queue.clone();
-        let notify = self.notify.clone();
-        let small_semaphore = Arc::new(Semaphore::new(self.small_payload_concurrency));
-        let large_semaphore = Arc::new(Semaphore::new(self.large_payload_concurrency));
-
-        tokio::spawn(async move {
-            loop {
-                // Register the notified future BEFORE checking the queue to avoid
-                // a race where enqueue() calls notify_one() between our "queue empty"
-                // check and the notified().await call.
-                let notified = notify.notified();
-
-                // Drain all available entries
-                let mut drained_any = false;
-                loop {
-                    let entry = {
-                        let mut q = queue.lock().await;
-                        q.pop_front()
-                    };
-
-                    let Some(entry) = entry else {
-                        break; // Queue empty
-                    };
-                    drained_any = true;
-
-                    // Select concurrency pool based on payload size.
-                    // Small payloads (deltas, chat messages) get high concurrency for
-                    // fast fan-out. Large payloads get low concurrency to avoid saturation.
-                    let sem = if entry.payload_size < PAYLOAD_SIZE_THRESHOLD {
-                        small_semaphore.clone()
-                    } else {
-                        large_semaphore.clone()
-                    };
-
-                    // Acquire semaphore permit to limit concurrent streams.
-                    // This blocks until a slot is available.
-                    let permit = sem.acquire_owned().await;
-                    let Ok(permit) = permit else {
-                        tracing::error!("Broadcast queue semaphore closed unexpectedly");
-                        return;
-                    };
-
-                    let bridge = bridge.clone();
-                    let op_manager = op_manager.clone();
-
-                    tokio::spawn(async move {
-                        let _permit = permit; // Held until this task completes
-
-                        broadcast_to_single_peer(
-                            &bridge,
-                            &op_manager,
-                            entry.key,
-                            entry.new_state,
-                            entry.target,
-                        )
-                        .await;
-                    });
+        /// Pop the oldest entry. Skips stale keys (removed by eviction or dedup).
+        fn pop_front(&mut self) -> Option<BroadcastEntry> {
+            while let Some(key) = self.order.pop_front() {
+                if let Some(entry) = self.entries.remove(&key) {
+                    return Some(entry);
                 }
-
-                if !drained_any {
-                    // Queue was empty, wait for new entries
-                    notified.await;
-                }
-                // If we drained entries, loop immediately to check for more
-                // (the pre-registered notified future is dropped, which is fine)
+                // Stale key (was evicted or already popped), skip
             }
-        })
+            None
+        }
     }
-}
+
+    /// Global broadcast queue that serializes outbound broadcast streams
+    /// with bounded concurrency and deduplication.
+    ///
+    /// Uses dual concurrency pools: small payloads (< 64KB) get high concurrency
+    /// (12 slots) for fast fan-out of deltas/chat messages, while large payloads
+    /// (>= 64KB) get low concurrency (2 slots) to avoid saturating the uplink.
+    #[derive(Clone)]
+    pub(crate) struct BroadcastQueue {
+        queue: Arc<Mutex<QueueState>>,
+        notify: Arc<Notify>,
+        small_payload_concurrency: usize,
+        large_payload_concurrency: usize,
+        max_queue_depth: usize,
+    }
+
+    impl BroadcastQueue {
+        pub(crate) fn new() -> Self {
+            Self {
+                queue: Arc::new(Mutex::new(QueueState::new())),
+                notify: Arc::new(Notify::new()),
+                small_payload_concurrency: DEFAULT_SMALL_PAYLOAD_CONCURRENCY,
+                large_payload_concurrency: DEFAULT_LARGE_PAYLOAD_CONCURRENCY,
+                max_queue_depth: DEFAULT_MAX_QUEUE_DEPTH,
+            }
+        }
+
+        /// Enqueue a broadcast for a single (contract, peer) pair.
+        ///
+        /// If an entry for the same contract+peer already exists, it is replaced
+        /// with the newer state (the older state is stale and would be superseded
+        /// anyway). If the queue is at capacity, the oldest entry is evicted.
+        pub(crate) async fn enqueue(
+            &self,
+            key: ContractKey,
+            target: PeerKeyLocation,
+            new_state: WrappedState,
+        ) {
+            let dedup_key = (key, target.clone());
+            let mut queue = self.queue.lock().await;
+
+            // Replace-on-dedup: if same contract+peer exists, update state in-place
+            if let Some(existing) = queue.entries.get_mut(&dedup_key) {
+                existing.new_state = new_state;
+                tracing::trace!(
+                    contract = %dedup_key.0,
+                    peer = ?target.socket_addr(),
+                    "Broadcast queue: replaced stale entry with newer state"
+                );
+            } else {
+                // Evict oldest if at capacity
+                while queue.len() >= self.max_queue_depth {
+                    if let Some(entry) = queue.pop_front() {
+                        tracing::warn!(
+                            contract = %entry.key,
+                            peer = ?entry.target.socket_addr(),
+                            queue_depth = self.max_queue_depth,
+                            "Broadcast queue full, evicted oldest entry"
+                        );
+                    } else {
+                        break;
+                    }
+                }
+                let payload_size = new_state.size();
+                queue.entries.insert(
+                    dedup_key.clone(),
+                    BroadcastEntry {
+                        key,
+                        target,
+                        new_state,
+                        payload_size,
+                    },
+                );
+                queue.order.push_back(dedup_key);
+            }
+
+            drop(queue);
+            self.notify.notify_one();
+        }
+
+        /// Start the background worker that drains the queue with bounded concurrency.
+        ///
+        /// The worker runs forever. It should be spawned as a background task.
+        pub(crate) fn start_worker(
+            &self,
+            bridge: P2pBridge,
+            op_manager: Arc<OpManager>,
+        ) -> tokio::task::JoinHandle<()> {
+            let queue = self.queue.clone();
+            let notify = self.notify.clone();
+            let small_semaphore = Arc::new(Semaphore::new(self.small_payload_concurrency));
+            let large_semaphore = Arc::new(Semaphore::new(self.large_payload_concurrency));
+
+            tokio::spawn(async move {
+                loop {
+                    // Register the notified future BEFORE checking the queue to avoid
+                    // a race where enqueue() calls notify_one() between our "queue empty"
+                    // check and the notified().await call.
+                    let notified = notify.notified();
+
+                    // Drain all available entries
+                    let mut drained_any = false;
+                    loop {
+                        let entry = {
+                            let mut q = queue.lock().await;
+                            q.pop_front()
+                        };
+
+                        let Some(entry) = entry else {
+                            break; // Queue empty
+                        };
+                        drained_any = true;
+
+                        // Select concurrency pool based on payload size.
+                        // Small payloads (deltas, chat messages) get high concurrency for
+                        // fast fan-out. Large payloads get low concurrency to avoid saturation.
+                        let sem = if entry.payload_size < PAYLOAD_SIZE_THRESHOLD {
+                            small_semaphore.clone()
+                        } else {
+                            large_semaphore.clone()
+                        };
+
+                        // Acquire semaphore permit to limit concurrent streams.
+                        // This blocks until a slot is available.
+                        let permit = sem.acquire_owned().await;
+                        let Ok(permit) = permit else {
+                            tracing::error!("Broadcast queue semaphore closed unexpectedly");
+                            return;
+                        };
+
+                        let bridge = bridge.clone();
+                        let op_manager = op_manager.clone();
+
+                        tokio::spawn(async move {
+                            let _permit = permit; // Held until this task completes
+
+                            broadcast_to_single_peer(
+                                &bridge,
+                                &op_manager,
+                                entry.key,
+                                entry.new_state,
+                                entry.target,
+                            )
+                            .await;
+                        });
+                    }
+
+                    if !drained_any {
+                        // Queue was empty, wait for new entries
+                        notified.await;
+                    }
+                    // If we drained entries, loop immediately to check for more
+                    // (the pre-registered notified future is dropped, which is fine)
+                }
+            })
+        }
+    }
+} // end `mod queue` (cfg-gated)
+
+#[cfg(not(feature = "simulation_tests"))]
+pub(crate) use queue::BroadcastQueue;
 
 /// Send a state change broadcast to a single peer.
 ///

--- a/crates/core/src/node/testing_impl.rs
+++ b/crates/core/src/node/testing_impl.rs
@@ -177,6 +177,20 @@ pub enum SimOperation {
         /// Initial state bytes
         state: Vec<u8>,
     },
+    /// Simulate a client disconnecting from this node.
+    ///
+    /// Emits `ClientRequest::Disconnect` through the same
+    /// `MemoryEventsGen` → `client_event_handling` path the real
+    /// WebSocket client takes, so the node runs
+    /// `remove_client_from_all_subscriptions`,
+    /// `should_unsubscribe_upstream`, and `send_unsubscribe_upstream`
+    /// — producing `UnsubscribeSent` / `UnsubscribeReceived` telemetry
+    /// that can be asserted on.
+    ///
+    /// This targets `ClientId::FIRST`, which is the client id used by
+    /// every other `SimOperation` in the same node, so subscriptions
+    /// issued earlier by this operation's node are the ones cleaned up.
+    Disconnect,
 }
 
 impl SimOperation {
@@ -290,6 +304,7 @@ impl SimOperation {
                      by run_controlled_simulation before event dispatch"
                 )
             }
+            SimOperation::Disconnect => ClientRequest::Disconnect { cause: None },
         }
     }
 }
@@ -3423,7 +3438,8 @@ impl SimNetwork {
                 SimOperation::Put { .. }
                 | SimOperation::Get { .. }
                 | SimOperation::Subscribe { .. }
-                | SimOperation::Update { .. } => event_ops.push(scheduled_op),
+                | SimOperation::Update { .. }
+                | SimOperation::Disconnect => event_ops.push(scheduled_op),
             }
         }
 

--- a/crates/core/src/wasm_runtime/delegate.rs
+++ b/crates/core/src/wasm_runtime/delegate.rs
@@ -3938,11 +3938,17 @@ mod test {
 
         assert_eq!(outbound.len(), 1, "Expected exactly one outbound message");
 
+        // Wildcard satisfies #[non_exhaustive] on OutboundDelegateMsg so
+        // future stdlib variants don't break this test at compile time.
+        #[allow(clippy::wildcard_enum_match_arm)]
         let app_msg = match &outbound[0] {
             OutboundDelegateMsg::ApplicationMessage(m) => m,
             other => panic!("Expected ApplicationMessage, got {other:?}"),
         };
         let response: OutboundAppMessage = bincode::deserialize(&app_msg.payload)?;
+        // Wildcard satisfies #[non_exhaustive] on OutboundAppMessage so
+        // future stdlib variants don't break this test at compile time.
+        #[allow(clippy::wildcard_enum_match_arm)]
         match response {
             OutboundAppMessage::DelegateMessageReceived {
                 origin_delegate_key_bytes,

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -2474,6 +2474,9 @@ async fn test_attested_contract_passed_to_delegate(ctx: &mut TestContext) -> Tes
                 OutboundAppMessage::Attested(Some(bytes)) => {
                     let origin: MessageOrigin = bincode::deserialize(&bytes)
                         .expect("Failed to deserialize MessageOrigin from delegate response");
+                    // Wildcard satisfies #[non_exhaustive] on MessageOrigin so
+                    // future stdlib variants don't break this test at compile time.
+                    #[allow(clippy::wildcard_enum_match_arm)]
                     match origin {
                         MessageOrigin::WebApp(contract_id) => {
                             assert_eq!(

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2373,6 +2373,149 @@ fn test_subscribe_forwarding_ack_relay() {
 /// relays fall through to the legacy handler and hit the bug. This is why
 /// the *primary* regression test for the bug is the in-process hosting
 /// manager unit test rather than this simulation test.
+///
+/// Simulation-side regression coverage for the bug tracked in #3874: when a
+/// subscribed client disconnects, the node MUST emit an upstream Unsubscribe
+/// so the hoster can drop the downstream subscriber registration.
+///
+/// This test exercises the same code path the failing integration test
+/// `test_client_disconnect_triggers_upstream_unsubscribe` exercises — the
+/// `ClientRequest::Disconnect` arm in `client_events::process_open_request`,
+/// which calls `remove_client_from_all_subscriptions` /
+/// `should_unsubscribe_upstream` / `send_unsubscribe_upstream` — but through
+/// the simulation harness where the bug's preconditions (completed PUT
+/// replay from GC, subscription resurrection, etc.) can be controlled and
+/// reproduced deterministically.
+///
+/// Before this test existed, `SimOperation` had no client-disconnect variant
+/// and simulation had NO coverage of the disconnect → unsubscribe chain —
+/// see #3874 for the full gap analysis. The integration-test regression
+/// that came out of PR #3843 was therefore invisible to the simulation
+/// suite.
+///
+/// This test currently FAILS and reproduces a concrete regression that
+/// was invisible to the simulation suite before: the task-per-tx
+/// subscribe driver in `operations/subscribe/op_ctx_task.rs` does NOT
+/// call `interest_manager.register_peer_interest(..., is_upstream=true)`
+/// on subscribe completion, so `send_unsubscribe_upstream` logs
+/// `"No upstream peer found for unsubscribe"` and no Unsubscribe is
+/// ever emitted. The legacy `operations/subscribe.rs::SubscribeMsg::Response`
+/// arm DOES register the upstream peer (see subscribe.rs:1767), so the
+/// behaviour regressed when client-initiated SUBSCRIBE migrated to the
+/// task-per-tx driver in Phase 2b.
+///
+/// This is either the #3874 root cause or a closely-related bug on the
+/// same code path. Marked `#[ignore]` until the missing registration
+/// is restored; the test is kept in-tree as executable documentation
+/// of the gap and as a regression guard for the fix.
+// Ignored: reproduces #3874 — task-per-tx subscribe driver misses
+// register_peer_interest(.., is_upstream=true). Un-ignore once fixed. #3874
+#[ignore]
+#[test_log::test]
+fn test_client_disconnect_emits_upstream_unsubscribe() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
+
+    const SEED: u64 = 0x5CB6_F37C_0003;
+    const NETWORK_NAME: &str = "client-disconnect-unsub";
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let (sim, logs_handle) = rt.block_on(async {
+        let sim = SimNetwork::new(
+            NETWORK_NAME,
+            1, // 1 gateway
+            4, // 4 regular nodes (matching subscribe_forwarding_ack_relay)
+            7, // ring_max_htl
+            3, // rnd_if_htl_above
+            5, // max_connections
+            2, // min_connections
+            SEED,
+        )
+        .await;
+        let logs_handle = sim.event_logs_handle();
+        (sim, logs_handle)
+    });
+
+    let contract = SimOperation::create_test_contract(0xDC);
+    let contract_id = *contract.key().id();
+    let initial_state = SimOperation::create_test_state(1);
+
+    // Gateway PUTs → node-1 subscribes → node-1 disconnects.
+    // Node-1 is a pure downstream subscriber with no further downstream
+    // of its own, so `should_unsubscribe_upstream` must return true
+    // on disconnect and an Unsubscribe must be emitted to its upstream.
+    let operations = vec![
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: initial_state,
+                subscribe: false,
+            },
+        ),
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 1),
+            SimOperation::Subscribe { contract_id },
+        ),
+        ScheduledOperation::new(NodeLabel::node(NETWORK_NAME, 1), SimOperation::Disconnect),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(120),
+        Duration::from_secs(30),
+    );
+
+    assert!(
+        result.turmoil_result.is_ok(),
+        "Simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let (sent_count, received_count) = rt.block_on(async {
+        let logs = logs_handle.lock().await;
+        let mut sent = 0usize;
+        let mut received = 0usize;
+        for log in logs.iter() {
+            if log
+                .kind
+                .unsubscribe_sent_instance_id()
+                .is_some_and(|id| *id == contract_id)
+            {
+                sent += 1;
+            }
+            if log
+                .kind
+                .unsubscribe_received_instance_id()
+                .is_some_and(|id| *id == contract_id)
+            {
+                received += 1;
+            }
+        }
+        (sent, received)
+    });
+
+    tracing::info!(
+        sent_count,
+        received_count,
+        "Unsubscribe telemetry after client disconnect"
+    );
+
+    assert!(
+        sent_count > 0,
+        "Disconnecting node MUST emit at least one UnsubscribeSent for the \
+         contract it was subscribed to (sent={sent_count}, received={received_count})"
+    );
+    assert!(
+        received_count > 0,
+        "Upstream node MUST log UnsubscribeReceived after client disconnect \
+         (sent={sent_count}, received={received_count})"
+    );
+}
+
 #[test_log::test]
 fn test_relay_does_not_pollute_active_subscriptions() {
     use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};


### PR DESCRIPTION
## Problem

While investigating #3874 (regression of `test_client_disconnect_triggers_upstream_unsubscribe` after PR #3843's Phase 3a PUT driver migration), we discovered the simulation suite had **zero coverage** of the client-disconnect → upstream-Unsubscribe chain. `SimOperation` had no client-disconnect variant, so any regression on that path (on-node disconnect handler, interest manager state, upstream-peer tracking) was invisible to simulation — only the integration test could catch it.

## Solution

### Close the on-node half of the gap (this PR)

- **`SimOperation::Disconnect`** — new variant that dispatches `ClientRequest::Disconnect` through `MemoryEventsGen` → `client_event_handling::process_open_request` → the real disconnect arm. Exercises `remove_client_from_all_subscriptions`, `should_unsubscribe_upstream`, and `send_unsubscribe_upstream` identically to a real WebSocket client.

- **`test_client_disconnect_emits_upstream_unsubscribe`** — new simulation test that sequences `Put → Subscribe → Disconnect` and asserts `UnsubscribeSent` / `UnsubscribeReceived` telemetry.

### Concrete root-cause candidate for #3874 found via the new test

Un-ignoring the new test reproduces the failure deterministically:

```
subscribe (task-per-tx): outcome="subscribed"
Received disconnect request from client, triggering subscription cleanup
Cleaned up client subscriptions and interest tracking  subscriptions_cleaned=1
No upstream peer found for unsubscribe  contract=...
Disconnecting node MUST emit at least one UnsubscribeSent (sent=0, received=0)
```

The task-per-tx subscribe driver in `operations/subscribe/op_ctx_task.rs:460-475` does **NOT** call `interest_manager.register_peer_interest(..., is_upstream=true)` on subscribe completion. The legacy `operations/subscribe.rs::Response` arm (subscribe.rs:1767) **DOES**. Behaviour regressed when client-initiated SUBSCRIBE migrated to the task-per-tx driver in Phase 2b.

The new test is `#[ignore]`d until the missing registration is restored, kept in-tree as executable documentation of the failure mode and as a regression guard for the eventual fix.

### Clippy baseline cleanup

`cargo clippy --features simulation_tests,testing --tests -- -D warnings` was pre-existing-failing on `main` with 12 errors unrelated to this change (verified with `git stash`). Fixed so the pre-commit hook runs clean:

- **`broadcast_queue.rs`** — queue-internals moved into a `#[cfg(not(feature = "simulation_tests"))] mod queue` with a `pub(crate) use queue::BroadcastQueue` re-export. `STREAM_COMPLETION_TIMEOUT` stays at outer scope (used by the free `broadcast_to_single_peer` fn under both cfgs).
- **`wasm_runtime/delegate.rs` (tests), `tests/operations.rs`** — `#[allow(clippy::wildcard_enum_match_arm)]` with WHY comments on three tests matching `#[non_exhaustive]` stdlib enums, per the documented pattern in `.claude/rules/git-workflow.md`.

## Testing

Verification strategy — since the new regression test is `#[ignore]`d and won't run in CI, here's what validates the dispatch plumbing:

- **Manually un-ignored and ran locally**: the test reaches the disconnect arm and logs the exact failure sequence shown above. The plumbing from `SimOperation::Disconnect` → `MemoryEventsGen::generate_events` → `process_open_request`'s `ClientRequest::Disconnect { .. }` arm is working; what fails is the pre-existing bug the test exposes (missing `register_peer_interest`).
- **`test_subscribe_forwarding_ack_relay`** still passes (closest sibling test — same `run_controlled_simulation` dispatch path, same `SimOperation` enum). Verifies the enum addition did not break the other variants.
- **`cargo clippy -p freenet --tests -- -D warnings`**: clean (production feature set).
- **`cargo clippy -p freenet --features simulation_tests,testing --tests -- -D warnings`**: clean (simulation feature set).
- **`cargo fmt --all -- --check`**: clean.
- **CI**: all checks green (Unit & Integration, Simulation, Windows Check, NAT Validation, Fmt, Clippy, Rule Lint).

Behavioural coverage (client disconnect → upstream Unsubscribe telemetry) will only become active on `main` once the missing `register_peer_interest` call is restored in `subscribe/op_ctx_task.rs` and the test is un-ignored.

## Follow-ups

- **#3882** — extend the simulation harness to exercise the full `SessionActor` / `result_router` / WebSocket client event path (the other half of the simulation gap, not addressed here).
- **#3874** — still open; un-ignore the new test + the original integration test once the `register_peer_interest` call is restored in `subscribe/op_ctx_task.rs`.

## Fixes

Progresses #3874 (diagnosis + regression guard; actual fix separate).
Refs #3843, #1454.