### PR TITLE
fix(subscribe): restore upstream-peer interest registration in task-per-tx driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,16 @@ jobs:
           $(echo "$ADDED" | grep -n 'tokio::net::UdpSocket')"
           fi
 
-          # 4. Deleted test functions (removed #[test] or #[tokio::test] lines)
+          # 4. Deleted test functions (removed #[test], #[tokio::test],
+          # #[test_log::test], or #[freenet_test(...)] lines)
           # Check ALL Rust files for test additions/removals (not just crates/core/src/)
+          # TEST_ATTR_RE matches the set of attributes this repo uses to mark
+          # a function as a test:
+          #   #[test]                  — plain libtest
+          #   #[tokio::test]           — async tests
+          #   #[test_log::test]        — tracing-subscriber-enabled tests
+          #   #[freenet_test(...)]     — Freenet integration-test macro
+          TEST_ATTR_RE='#\[((tokio|test_log)::)?test\]|#\[freenet_test'
           ALL_ADDED=$(git diff "$BASE"..."$HEAD" -- '**/*.rs' \
             | grep '^+' | grep -v '^+++' || true)
           ALL_ADDED_STRIPPED=$(echo "$ALL_ADDED" | sed 's|//.*||' || true)
@@ -169,10 +177,10 @@ jobs:
           REMOVED=$(git diff "$BASE"..."$HEAD" -- 'crates/core/src/**/*.rs' 'crates/core/tests/**/*.rs' \
             | grep '^-' | grep -v '^---' || true)
           REMOVED_STRIPPED=$(echo "$REMOVED" | sed 's|//.*||' || true)
-          if echo "$REMOVED_STRIPPED" | grep -qE '#\[(tokio::)?test\]'; then
+          if echo "$REMOVED_STRIPPED" | grep -qE "$TEST_ATTR_RE"; then
             # Check it wasn't just moved (also present in added lines across all files)
-            REMOVED_TESTS=$(echo "$REMOVED_STRIPPED" | grep -cE '#\[(tokio::)?test\]' || true)
-            ADDED_TESTS=$(echo "$ALL_ADDED_STRIPPED" | grep -cE '#\[(tokio::)?test\]' || true)
+            REMOVED_TESTS=$(echo "$REMOVED_STRIPPED" | grep -cE "$TEST_ATTR_RE" || true)
+            ADDED_TESTS=$(echo "$ALL_ADDED_STRIPPED" | grep -cE "$TEST_ATTR_RE" || true)
             if [ "$REMOVED_TESTS" -gt "$ADDED_TESTS" ]; then
               ERRORS="$ERRORS
           ERROR: Test function(s) removed — tests must not be deleted (use #[ignore] with a tracking issue if broken)
@@ -186,7 +194,7 @@ jobs:
           HAS_EXEMPT_LABEL=$(echo "${{ join(github.event.pull_request.labels.*.name, ',') }}" | grep -c 'test-exempt' || true)
 
           if [ "$IS_FIX" -gt 0 ] && [ "$HAS_EXEMPT_LABEL" -eq 0 ]; then
-            NEW_TESTS=$(echo "$ALL_ADDED_STRIPPED" | grep -cE '#\[(tokio::)?test\]' || true)
+            NEW_TESTS=$(echo "$ALL_ADDED_STRIPPED" | grep -cE "$TEST_ATTR_RE" || true)
             if [ "$NEW_TESTS" -eq 0 ]; then
               ERRORS="$ERRORS
           ERROR: fix: PR must include at least one new regression test

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -466,6 +466,20 @@ async fn drive_client_subscribe_inner(
                 // never learn about the subscription, breaking
                 // ChangeInterests-driven update propagation. Both calls are
                 // idempotent for repeat subscribes.
+                //
+                // Register the responding peer as our upstream. Without
+                // this, `send_unsubscribe_upstream` cannot locate the peer
+                // on client disconnect and no Unsubscribe is emitted (#3874).
+                if let Some(pkl) = op_manager
+                    .ring
+                    .connection_manager
+                    .get_peer_by_addr(current_target_addr)
+                {
+                    let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key.clone());
+                    op_manager
+                        .interest_manager
+                        .register_peer_interest(&key, peer_key, None, true);
+                }
                 op_manager.ring.subscribe(key);
                 op_manager.ring.complete_subscription_request(&key, true);
                 let became_interested = op_manager.interest_manager.add_local_client(&key);

--- a/crates/core/tests/operations.rs
+++ b/crates/core/tests/operations.rs
@@ -4178,12 +4178,6 @@ async fn test_delegate_contract_get(ctx: &mut TestContext) -> TestResult {
 /// the subscription works (update propagates), client B disconnects. The test
 /// asserts that node-b sent an UnsubscribeSent event and the upstream peer
 /// logged an UnsubscribeReceived event in the aggregated event logs.
-///
-/// Ignored: regression under #1454 Phase 3a PUT driver migration. Two bugs
-/// identified; Bug 1 (GC retry of completed PUTs) fixed; Bug 2 (fresh
-/// Subscribe::Request from node-b ~30-50s after Phase 2, origin not yet
-/// traced) still blocks the Unsubscribe emission. Tracked in #3874.
-#[ignore]
 #[freenet_test(
     nodes = ["gateway", "node-a", "node-b"],
     timeout_secs = 600,

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -2408,9 +2408,6 @@ fn test_subscribe_forwarding_ack_relay() {
 /// same code path. Marked `#[ignore]` until the missing registration
 /// is restored; the test is kept in-tree as executable documentation
 /// of the gap and as a regression guard for the fix.
-// Ignored: reproduces #3874 — task-per-tx subscribe driver misses
-// register_peer_interest(.., is_upstream=true). Un-ignore once fixed. #3874
-#[ignore]
 #[test_log::test]
 fn test_client_disconnect_emits_upstream_unsubscribe() {
     use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
@@ -2513,6 +2510,132 @@ fn test_client_disconnect_emits_upstream_unsubscribe() {
         received_count > 0,
         "Upstream node MUST log UnsubscribeReceived after client disconnect \
          (sent={sent_count}, received={received_count})"
+    );
+}
+
+/// Edge case: disconnect from a node that never subscribed. No Unsubscribe
+/// should be emitted and nothing should log "No upstream peer found".
+#[test_log::test]
+fn test_client_disconnect_without_subscriptions_is_noop() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
+
+    const SEED: u64 = 0x5CB6_F37C_0004;
+    const NETWORK_NAME: &str = "disconnect-no-subs";
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let (sim, logs_handle) = rt.block_on(async {
+        let sim = SimNetwork::new(NETWORK_NAME, 1, 4, 7, 3, 5, 2, SEED).await;
+        let logs_handle = sim.event_logs_handle();
+        (sim, logs_handle)
+    });
+
+    let operations = vec![ScheduledOperation::new(
+        NodeLabel::node(NETWORK_NAME, 1),
+        SimOperation::Disconnect,
+    )];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(60),
+        Duration::from_secs(30),
+    );
+
+    assert!(
+        result.turmoil_result.is_ok(),
+        "Simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let sent_count = rt.block_on(async {
+        let logs = logs_handle.lock().await;
+        logs.iter()
+            .filter(|log| log.kind.unsubscribe_sent_instance_id().is_some())
+            .count()
+    });
+
+    assert_eq!(
+        sent_count, 0,
+        "Disconnecting a client with no subscriptions must not emit any \
+         UnsubscribeSent events (got {sent_count})"
+    );
+}
+
+/// Edge case: subscribe twice from the same client, then disconnect.
+/// The upstream registration is idempotent, so only one Unsubscribe should
+/// be emitted per contract.
+#[test_log::test]
+fn test_repeat_subscribe_then_disconnect_emits_single_unsubscribe() {
+    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation};
+
+    const SEED: u64 = 0x5CB6_F37C_0005;
+    const NETWORK_NAME: &str = "repeat-subscribe-disconnect";
+
+    GlobalTestMetrics::reset();
+    setup_deterministic_state(SEED);
+    let rt = create_runtime();
+
+    let (sim, logs_handle) = rt.block_on(async {
+        let sim = SimNetwork::new(NETWORK_NAME, 1, 4, 7, 3, 5, 2, SEED).await;
+        let logs_handle = sim.event_logs_handle();
+        (sim, logs_handle)
+    });
+
+    let contract = SimOperation::create_test_contract(0xDD);
+    let contract_id = *contract.key().id();
+    let initial_state = SimOperation::create_test_state(1);
+
+    let operations = vec![
+        ScheduledOperation::new(
+            NodeLabel::gateway(NETWORK_NAME, 0),
+            SimOperation::Put {
+                contract: contract.clone(),
+                state: initial_state,
+                subscribe: false,
+            },
+        ),
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 1),
+            SimOperation::Subscribe { contract_id },
+        ),
+        ScheduledOperation::new(
+            NodeLabel::node(NETWORK_NAME, 1),
+            SimOperation::Subscribe { contract_id },
+        ),
+        ScheduledOperation::new(NodeLabel::node(NETWORK_NAME, 1), SimOperation::Disconnect),
+    ];
+
+    let result = sim.run_controlled_simulation(
+        SEED,
+        operations,
+        Duration::from_secs(120),
+        Duration::from_secs(30),
+    );
+
+    assert!(
+        result.turmoil_result.is_ok(),
+        "Simulation failed: {:?}",
+        result.turmoil_result.err()
+    );
+
+    let sent_count = rt.block_on(async {
+        let logs = logs_handle.lock().await;
+        logs.iter()
+            .filter(|log| {
+                log.kind
+                    .unsubscribe_sent_instance_id()
+                    .is_some_and(|id| *id == contract_id)
+            })
+            .count()
+    });
+
+    assert_eq!(
+        sent_count, 1,
+        "Repeat-subscribe + disconnect must emit exactly one UnsubscribeSent \
+         (got {sent_count})"
     );
 }
 


### PR DESCRIPTION
## Problem

Client-initiated SUBSCRIBE migrated to the task-per-tx driver in #1454 Phase 2b but dropped one side-effect from the legacy `SubscribeMsg::Response` handler: calling `interest_manager.register_peer_interest(key, peer, None, is_upstream=true)`. Without it, `send_unsubscribe_upstream` cannot find the upstream peer on client disconnect and bails with "No upstream peer found for unsubscribe", so no Unsubscribe is ever emitted.

This broke `test_client_disconnect_triggers_upstream_unsubscribe` and was exposed consistently by PR #3843's Phase 3a PUT driver migration (#3874).

Full diagnosis in `.claude/followup-3874-fix.md` (and comment thread on #3874).

## Solution

Add the missing `register_peer_interest` call in `operations/subscribe/op_ctx_task.rs`'s successful-subscribe path, using the same signature (`is_upstream=true`) as the legacy handler at `operations/subscribe.rs:1767`. The call is idempotent, so repeat subscribes don't duplicate entries.

```rust
if let Some(pkl) = op_manager
    .ring
    .connection_manager
    .get_peer_by_addr(current_target_addr)
{
    let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key.clone());
    op_manager
        .interest_manager
        .register_peer_interest(&key, peer_key, None, true);
}
```

## Testing

- [x] Un-ignored `test_client_disconnect_triggers_upstream_unsubscribe` (integration) — passes on Linux Docker; event log shows `UnsubscribeSent` followed immediately by `UnsubscribeReceived`.
- [x] Un-ignored `test_client_disconnect_emits_upstream_unsubscribe` (simulation, added in #3885) — passes.
- [x] Added `test_client_disconnect_without_subscriptions_is_noop` — disconnect with no prior subscriptions emits zero `UnsubscribeSent`.
- [x] Added `test_repeat_subscribe_then_disconnect_emits_single_unsubscribe` — verifies idempotent upstream registration.
- [x] `cargo test -p freenet --lib subscribe` — 114 passed.
- [x] Sibling simulation test `test_subscribe_forwarding_ack_relay` still green.
- [x] `cargo fmt --all -- --check` (toolchain 1.93.0) clean.
- [x] `cargo clippy -p freenet --tests -- -D warnings` clean.

## CI

Also extends the Rule Lint test-attribute regex to recognize `#[test_log::test]` and `#[freenet_test(...)]`, not just `#[test]` / `#[tokio::test]`. Without this, Rule Lint counted this PR's two new `#[test_log::test]` regression tests as zero and failed the "fix: PR must include at least one new regression test" check. The old regex recognized only 10 of 70 test attributes in `simulation_integration.rs`.

## Fixes

Closes #3874.
Refs #3843, #3885, #1454.