### PR TITLE
refactor(ops): decouple task-per-tx drivers from SubOperationTracker (#1454 phase 3c)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -110,7 +110,7 @@ WRONG:
 
 ## Sub-Operation Rules
 
-### WHEN spawning a sub-operation
+### WHEN spawning a sub-operation (legacy state-machine path)
 
 ```
 1. FIRST: Register with expect_and_register_sub_operation()
@@ -126,6 +126,21 @@ WRONG:
   let child_op = SubscribeOp::new(...);
   op_manager.push(child_tx, child_op).await?;  // Child might complete here!
   op_manager.expect_and_register_sub_operation(parent_tx, child_tx);  // Too late
+```
+
+### WHEN spawning a sub-operation (task-per-tx path)
+
+```
+Task-per-tx drivers (PUT, GET) do NOT register children with
+SubOperationTracker. They create children via Transaction::new_child_of
+and either await them inline (blocking) or fire-and-forget (async).
+
+The is_sub_operation guards at p2p_protoc.rs, node.rs, and subscribe.rs
+use the structural Transaction::is_sub_operation() check (parent field
+set by new_child_of), not the tracker DashMap. No registration needed.
+
+SubOperationTracker is only used by legacy relay paths that go through
+the finalized-parent-parking branch in operations.rs:182–208.
 ```
 
 ### WHEN a sub-operation fails

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -549,7 +549,7 @@ async fn report_result(
             if let Some(transaction) = tx {
                 // Sub-operations (e.g., Subscribe spawned by PUT) don't notify clients directly;
                 // the parent operation handles the client response.
-                if op_manager.is_sub_operation(transaction) {
+                if transaction.is_sub_operation() {
                     tracing::debug!(
                         tx = %transaction,
                         "Skipping client notification for sub-operation"
@@ -643,7 +643,7 @@ async fn report_result(
                 // Sub-operations (e.g., Subscribe spawned by PUT) have no client
                 // registered — sending errors for them would pollute the
                 // SessionActor's pending_results cache.
-                if !op_manager.is_sub_operation(tx) {
+                if !tx.is_sub_operation() {
                     let client_error = freenet_stdlib::client_api::ClientError::from(
                         freenet_stdlib::client_api::ErrorKind::OperationError {
                             cause: err.to_string().into(),

--- a/crates/core/src/node/network_bridge/p2p_protoc.rs
+++ b/crates/core/src/node/network_bridge/p2p_protoc.rs
@@ -2054,7 +2054,11 @@ impl P2pConnManager {
 
                                 // If this is a child operation (e.g., Subscribe spawned by PUT),
                                 // just mark it complete - parent operation handles client response.
-                                if op_manager.is_sub_operation(tx) {
+                                // Uses the structural Transaction::is_sub_operation() check
+                                // (parent field set at creation via new_child_of) rather than
+                                // the SubOperationTracker DashMap lookup — correct for both
+                                // legacy and task-per-tx children.
+                                if tx.is_sub_operation() {
                                     tracing::debug!(
                                         tx = %tx,
                                         contract = %key,

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -192,6 +192,10 @@ impl SubOperationTracker {
 
     /// Check if a transaction is a sub-operation (has a parent transaction).
     /// Sub-operations should not send responses directly to clients.
+    ///
+    /// Production guards now use `Transaction::is_sub_operation()` (structural
+    /// check) instead. This method remains for legacy relay paths and unit tests.
+    #[cfg(test)]
     fn is_sub_operation(&self, tx: Transaction) -> bool {
         self.parent_of.contains_key(&tx)
     }
@@ -1046,12 +1050,6 @@ impl OpManager {
             );
         }
         Ok(())
-    }
-
-    /// Check if a transaction is a sub-operation (has a parent transaction).
-    /// Sub-operations should not send responses directly to clients.
-    pub fn is_sub_operation(&self, tx: Transaction) -> bool {
-        self.sub_op_tracker.is_sub_operation(tx)
     }
 
     /// Exposes root operations awaiting sub-operation completion.

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -917,10 +917,10 @@ async fn maybe_subscribe_child(
 
     let child_tx = Transaction::new_child_of::<subscribe::SubscribeMsg>(&client_tx);
 
-    // Register the child so `LocalSubscribeComplete` hits the
-    // silent-absorb branch instead of trying to publish to a
-    // nonexistent waiter.
-    op_manager.expect_and_register_sub_operation(client_tx, child_tx);
+    // No SubOperationTracker registration needed: the silent-absorb
+    // guards at `p2p_protoc.rs`, `node.rs`, and `subscribe.rs` use the
+    // structural `Transaction::is_sub_operation()` check (parent field
+    // set by `new_child_of`), not the tracker DashMap.
 
     if blocking_subscribe {
         subscribe::run_client_subscribe(op_manager.clone(), *key.id(), child_tx).await;
@@ -1318,7 +1318,7 @@ mod tests {
     /// invoke `assemble_and_cache_stream` so that streamed GET
     /// responses actually write the contract state into the local
     /// executor. Without this call, a cold-cache client GET of a
-    /// >threshold contract succeeds on the wire but leaves the
+    /// \>threshold contract succeeds on the wire but leaves the
     /// originator's local store empty — the client gets
     /// `OperationError` via `build_host_response`'s re-query miss.
     ///
@@ -1427,18 +1427,7 @@ mod tests {
             .find("async fn maybe_subscribe_child(")
             .expect("maybe_subscribe_child must exist");
         let body = &SOURCE[fn_start..];
-        let early_return = body
-            .find("if !subscribe {")
+        body.find("if !subscribe {")
             .expect("maybe_subscribe_child must short-circuit on !subscribe");
-        let register_call = body
-            .find("expect_and_register_sub_operation")
-            .expect("maybe_subscribe_child must register sub-operation");
-        assert!(
-            early_return < register_call,
-            "The !subscribe short-circuit must come BEFORE the \
-             expect_and_register_sub_operation call — otherwise we'd \
-             register a spurious sub-op for a client who didn't ask for \
-             one. See PUT 3a commit 494a3c69 for the analogous bug class."
-        );
     }
 }

--- a/crates/core/src/operations/put/op_ctx_task.rs
+++ b/crates/core/src/operations/put/op_ctx_task.rs
@@ -450,10 +450,10 @@ async fn maybe_subscribe_child(
 
     let child_tx = Transaction::new_child_of::<subscribe::SubscribeMsg>(&client_tx);
 
-    // Register the child so `LocalSubscribeComplete` hits the
-    // silent-absorb branch at `p2p_protoc.rs:2057–2066` instead
-    // of trying to publish to a nonexistent waiter.
-    op_manager.expect_and_register_sub_operation(client_tx, child_tx);
+    // No SubOperationTracker registration needed: the silent-absorb
+    // guards at `p2p_protoc.rs`, `node.rs`, and `subscribe.rs` use the
+    // structural `Transaction::is_sub_operation()` check (parent field
+    // set by `new_child_of`), not the tracker DashMap.
 
     if blocking_subscribe {
         // Inline await — PUT response waits for subscribe completion.

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -929,7 +929,7 @@ impl SubscribeOp {
         let requester_pub_key = self.requester_pub_key;
         let is_renewal = self.is_renewal;
         let stats = self.stats;
-        let is_sub_op = op_manager.is_sub_operation(tx_id);
+        let is_sub_op = tx_id.is_sub_operation();
 
         tracing::debug!(
             tx = %tx_id,


### PR DESCRIPTION
## Problem

After Phases 3a (#3843) and 3b (#3884) migrated client-initiated PUT and GET to task-per-tx drivers, both drivers still registered subscribe children with `SubOperationTracker` via `expect_and_register_sub_operation`. This was only needed so `op_manager.is_sub_operation(tx)` (a DashMap lookup) returned true at 4 guard sites that prevent spurious client notifications. The task-per-tx drivers never used the tracker's parking-lot mechanism — they await or fire-and-forget children directly.

Additionally, async non-blocking subscribe children (`track_parent=false`) were never registered in the tracker, so `op_manager.is_sub_operation()` returned `false` for them — they'd incorrectly try to notify a nonexistent client waiter at `LocalSubscribeComplete`.

## Solution

Switch all 4 `is_sub_operation` guard sites from `op_manager.is_sub_operation(tx)` (DashMap lookup on `SubOperationTracker.parent_of`) to `tx.is_sub_operation()` (structural check: `Transaction.parent.is_some()`, set at creation by `new_child_of`). This is a superset — correct for both legacy and task-per-tx children, and fixes the latent bug for async non-blocking children.

Then remove `expect_and_register_sub_operation` calls from PUT and GET task-per-tx drivers, making them fully independent of `SubOperationTracker`.

`SubOperationTracker` itself stays alive — legacy PUT/GET relay paths still use the parking-lot mechanism. Full deletion deferred until relay migration (#3883) completes.

### Guard sites changed

| File | Context |
|------|---------|
| `p2p_protoc.rs:2061` | `LocalSubscribeComplete` silent-absorb |
| `node.rs:552` | Subscribe completion — skip client notify for children |
| `node.rs:646` | Error path — skip client error for children |
| `subscribe.rs:932` | `handle_abort` — sub-op vs standalone abort routing |

## Testing

- `cargo clippy -- -D warnings` — clean
- `cargo test -p freenet` — 2380 tests pass (4 pre-existing macOS connectivity failures unrelated)
- Source-scrape test updated to reflect removed tracker registration

## Fixes

Partial progress on #1454 (Phase 3c)