### PR TITLE
feat: consolidate dashboard links into single Freenet Links section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,8 +294,11 @@ jobs:
     steps:
       - name: Detect release merge queue
         id: release_check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_COMMIT_MSG: ${{ github.event.merge_group.head_commit.message }}
         run: |
-          if [[ "${{ github.event_name }}" == "merge_group" && "${{ github.event.merge_group.head_commit.message }}" == build:\ release* ]]; then
+          if [[ "$EVENT_NAME" == "merge_group" && "$MERGE_COMMIT_MSG" == build:\ release* ]]; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"
             echo "Skipping tests — release PRs only bump versions (main CI already validated)"
           else
@@ -406,8 +409,11 @@ jobs:
     steps:
       - name: Detect release merge queue
         id: release_check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_COMMIT_MSG: ${{ github.event.merge_group.head_commit.message }}
         run: |
-          if [[ "${{ github.event_name }}" == "merge_group" && "${{ github.event.merge_group.head_commit.message }}" == build:\ release* ]]; then
+          if [[ "$EVENT_NAME" == "merge_group" && "$MERGE_COMMIT_MSG" == build:\ release* ]]; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"
             echo "Skipping tests — release PRs only bump versions (main CI already validated)"
           else
@@ -599,8 +605,11 @@ jobs:
     steps:
       - name: Detect release merge queue
         id: release_check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_COMMIT_MSG: ${{ github.event.merge_group.head_commit.message }}
         run: |
-          if [[ "${{ github.event_name }}" == "merge_group" && "${{ github.event.merge_group.head_commit.message }}" == build:\ release* ]]; then
+          if [[ "$EVENT_NAME" == "merge_group" && "$MERGE_COMMIT_MSG" == build:\ release* ]]; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"
             echo "Skipping tests — release PRs only bump versions (main CI already validated)"
           else

--- a/crates/core/src/server/home_page.rs
+++ b/crates/core/src/server/home_page.rs
@@ -71,7 +71,7 @@ fn homepage_html() -> String {
         {ops_card}
 
         <div class="card">
-            <h2>Freenet Apps</h2>
+            <h2>Freenet Links</h2>
             <ul class="app-list">
                 <li>
                     <a href="/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/">River Chat</a>
@@ -81,15 +81,14 @@ fn homepage_html() -> String {
                     <a href="/v1/contract/web/EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr/">Delta</a>
                     <p class="note">A website builder for Freenet.</p>
                 </li>
-            </ul>
-        </div>
-
-        <div class="card card-muted">
-            <h2>Links</h2>
-            <ul class="link-list">
-                <li><a href="https://freenet.org" target="_blank" rel="noopener noreferrer">freenet.org</a></li>
-                <li><a href="https://matrix.to/#/#freenet-locutus:matrix.org" target="_blank" rel="noopener noreferrer">Freenet Matrix channel</a></li>
-                <li><a href="https://github.com/freenet/freenet-core" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+                <li>
+                    <a href="/v1/contract/web/DLog47hEsrtuGT4N5XCeMBG45m4n1aWM89tBZXue2E1N/">Ghostkey Identity Vault</a>
+                    <p class="note">Manage Ghostkey identities on Freenet.</p>
+                </li>
+                <li>
+                    <a href="/v1/contract/web/E4m5WbaC4cdbpDjL82WfYUnrM9iMnfaaN8Tsn7UHPMjZ/">freenet.org</a>
+                    <p class="note">The freenet.org website, mirrored on Freenet.</p>
+                </li>
             </ul>
         </div>
     </main>


### PR DESCRIPTION
## Problem

The local peer dashboard had two separate link cards:

- **Freenet Apps** — River Chat, Delta
- **Links** — external freenet.org, Matrix channel, GitHub

The split was arbitrary. Calling a mirrored website an "app" was a stretch, and mixing on-Freenet and off-Freenet destinations made the dashboard feel like a generic bookmarks pane rather than a pointer to things you can only reach through your local node.

## Solution

Consolidate everything into a single **Freenet Links** card that lists only resources hosted on Freenet:

- River Chat
- Delta
- Ghostkey Identity Vault (new)
- freenet.org mirror (new)

Drop the off-Freenet links (external freenet.org, Matrix, GitHub) — users can reach those from anywhere. Keep the River invite link as the one documented exception, since bootstrapping into the "Freenet Official" room genuinely requires an off-network URL.

## Testing

- `cargo check -p freenet` passes.
- Manual change in an HTML string; no behavior paths affected.

[AI-assisted - Claude]