### PR TITLE
refactor(ops): migrate relay GET to task-per-tx driver (#1454 phase 5)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -12,17 +12,20 @@ paths:
 > Phase 3a (PR #3843) migrated client-initiated PUT to
 > `operations/put/op_ctx_task.rs`, Phase 3b migrated client-initiated
 > GET to `operations/get/op_ctx_task.rs` (both using the shared
-> `RetryDriver` trait from `op_ctx.rs`), and Phase 4 migrated
+> `RetryDriver` trait from `op_ctx.rs`), Phase 4 migrated
 > client-initiated UPDATE to `operations/update/op_ctx_task.rs` (using
 > the fire-and-forget `OpCtx::send_fire_and_forget` — no retry loop
-> needed since UPDATE has no response to await). On these paths,
+> needed since UPDATE has no response to await), and Phase 5 (#3883)
+> migrated fresh inbound relay GETs to the task-per-tx driver in
+> `operations/get/op_ctx_task.rs::start_relay_get`. On these paths,
 > op state lives in task locals and is never pushed into
 > `OpManager.ops.*`, so rules below that talk about "pushing state" /
 > `load_or_init` / `handle_op_result` apply only to the **legacy
-> state-machine path** (still used by GET relay/GC/UPDATE-auto-fetch
-> paths — #3883 tracks relay-GET migration — PUT relay/GC paths,
-> UPDATE relay/broadcast, CONNECT, and by SUBSCRIBE's renewal /
-> PUT-sub-op / executor / intermediate-peer entry points).
+> state-machine path**, which still serves: GC-spawned GET retries and
+> `start_targeted_op` UPDATE-triggered auto-fetch (streaming relay and
+> originator loopback also remain on legacy per #3883 port plan §7),
+> PUT relay/GC paths, UPDATE relay/broadcast, CONNECT, and SUBSCRIBE's
+> renewal / PUT-sub-op / executor / intermediate-peer entry points.
 >
 > Task-per-tx drivers have their own invariants documented in the
 > `op_ctx_task.rs` module doc and in `OpCtx::send_and_await`'s rustdoc.

--- a/.github/workflows/simulation-debug.yml
+++ b/.github/workflows/simulation-debug.yml
@@ -154,7 +154,15 @@ jobs:
           # child is the actual fdev process. Walk the pid tree rather
           # than relying on `pgrep -f` (which may match unrelated bash
           # subshells holding the same cmdline string in their env).
+          #
+          # Emit each sample to BOTH rss.csv AND stderr of this step.
+          # Stderr is captured by the GitHub Actions log — so even if
+          # the runner VM is OOM-killed before the Upload step can
+          # schedule (the pattern that keeps losing the sim-logs
+          # artifact), the partial RSS curve still lands in the CI log
+          # and we can grep it out post-hoc.
           echo "ts,rss_kb,vsz_kb,state" > sim-logs/rss.csv
+          echo "[rss-sampler] ts,rss_kb,vsz_kb,state" >&2
           while kill -0 "$SIM_PID" 2>/dev/null; do
             # First try: direct child of the timeout wrapper.
             FDEV_PID=$(pgrep -P "$SIM_PID" | head -1)
@@ -165,8 +173,9 @@ jobs:
             if [ -n "$FDEV_PID" ]; then
               read rss vsz st _ <<<"$(ps -o rss=,vsz=,stat= -p "$FDEV_PID" 2>/dev/null)"
               if [ -n "$rss" ]; then
-                printf '%s,%s,%s,%s\n' "$(date +%s)" "$rss" "$vsz" "$st" \
-                  >> sim-logs/rss.csv
+                line="$(date +%s),${rss},${vsz},${st}"
+                printf '%s\n' "$line" >> sim-logs/rss.csv
+                printf '[rss-sampler] %s\n' "$line" >&2
               fi
             fi
             sleep 1

--- a/.github/workflows/simulation-debug.yml
+++ b/.github/workflows/simulation-debug.yml
@@ -150,10 +150,18 @@ jobs:
             single-process > "sim-logs/${SIM_NAME}.log" 2>&1 &
           SIM_PID=$!
 
-          # RSS sampler @ 1Hz — drops samples when the child is gone.
+          # RSS sampler @ 1Hz. $SIM_PID is the `timeout` wrapper; its
+          # child is the actual fdev process. Walk the pid tree rather
+          # than relying on `pgrep -f` (which may match unrelated bash
+          # subshells holding the same cmdline string in their env).
           echo "ts,rss_kb,vsz_kb,state" > sim-logs/rss.csv
           while kill -0 "$SIM_PID" 2>/dev/null; do
-            FDEV_PID=$(pgrep -f "target/release/fdev test.*${SIM_NAME}" | head -1)
+            # First try: direct child of the timeout wrapper.
+            FDEV_PID=$(pgrep -P "$SIM_PID" | head -1)
+            # Fallback: any fdev descendant (timeout may spawn a shim).
+            if [ -z "$FDEV_PID" ]; then
+              FDEV_PID=$(pgrep -x fdev | head -1)
+            fi
             if [ -n "$FDEV_PID" ]; then
               read rss vsz st _ <<<"$(ps -o rss=,vsz=,stat= -p "$FDEV_PID" 2>/dev/null)"
               if [ -n "$rss" ]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
         name: cargo fmt
         description: Run cargo fmt on Rust code
         args: ['--all', '--', '--check']
+        pass_filenames: false
 
   # Custom clippy hook that only runs on packages with changed files
   - repo: local

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -94,6 +94,14 @@ pub mod dev_tool {
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::get::op_ctx_task::DRIVER_CALL_COUNT as GET_DRIVER_CALL_COUNT;
 
+    // #1454 Phase 5 / #3883 — test hook to verify the dispatch gate in
+    // `handle_pure_network_message_v1` actually routes fresh inbound relay
+    // GETs through the task-per-tx driver (vs. the legacy
+    // `handle_op_request` fallthrough used for originator loopback,
+    // GC-spawned retries, and `start_targeted_op` UPDATE auto-fetch).
+    #[cfg(any(test, feature = "testing"))]
+    pub use crate::operations::get::op_ctx_task::RELAY_DRIVER_CALL_COUNT as GET_RELAY_DRIVER_CALL_COUNT;
+
     // Re-export state verification for telemetry-based consistency analysis
     pub use crate::tracing::state_verifier::{StateAnomaly, StateVerifier, VerificationReport};
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1090,6 +1090,62 @@ where
                     return Ok(None);
                 }
 
+                // #1454 phase 5 / #3883: relay GET task-per-tx dispatch.
+                //
+                // For true relay hops (source_addr.is_some() AND incoming
+                // variant is GetMsg::Request AND no GetOp already exists in
+                // OpManager for this tx), spawn the relay driver and return.
+                // The driver owns routing, forwarding, retry, and upstream
+                // bubble-up in its task locals.
+                //
+                // source_addr.is_none() (originator loop-back from phase-3b
+                // client driver's send_and_await with target=None) falls
+                // through to the legacy path to preserve the Request-echo
+                // contract that drive_client_get_inner's `classify` relies on
+                // for Terminal::LocalCompletion.
+                //
+                // GC-spawned retries and start_targeted_op register a GetOp
+                // in OpManager before the Request hits the wire, so
+                // op_manager.has_get_op(id) returning true means this is not
+                // a fresh inbound relay call — fall through to legacy.
+                if let get::GetMsg::Request {
+                    id,
+                    instance_id,
+                    fetch_contract,
+                    htl,
+                    visited,
+                    subscribe,
+                } = op
+                {
+                    if let Some(upstream_addr) = source_addr {
+                        if !op_manager.has_get_op(id) {
+                            // True relay: no existing op, remote source, fresh
+                            // Request. Fire-and-forget spawn; driver publishes
+                            // its own upstream response.
+                            if let Err(err) = get::op_ctx_task::start_relay_get(
+                                op_manager.clone(),
+                                *id,
+                                *instance_id,
+                                *htl,
+                                upstream_addr,
+                                visited.clone(),
+                                *fetch_contract,
+                                *subscribe,
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    tx = %id,
+                                    %instance_id,
+                                    error = %err,
+                                    "GET relay dispatch: start_relay_get failed"
+                                );
+                            }
+                            return Ok(None);
+                        }
+                    }
+                }
+
                 let op_result = handle_op_request::<get::GetOp, _>(
                     &op_manager,
                     &mut conn_manager,
@@ -3354,6 +3410,117 @@ mod tests {
             assert!(
                 !taken,
                 "Response without callback → must fall through to legacy path"
+            );
+        }
+
+        // ───────────────────────────────────────────────────────────
+        // Regression guards for the GET branch of
+        // handle_pure_network_message_v1 added in #3883 (phase 5).
+        //
+        // The GET branch has two distinct dispatch layers:
+        //
+        //   1. Phase-3b bypass: terminal Response/ResponseStreaming for an
+        //      active client driver → try_forward_task_per_tx_reply (unchanged).
+        //
+        //   2. Relay dispatch (new in commit 2): GetMsg::Request with
+        //      source_addr.is_some() and no existing GetOp in OpManager →
+        //      start_relay_get (task-per-tx relay driver).
+        //
+        // Layer 1 is the same as PUT/SUBSCRIBE; the guards below cover
+        // layer 2 (source-literal, not runtime dispatch).
+        // ───────────────────────────────────────────────────────────
+
+        // Source-literal guard: verify the GET branch invokes
+        // try_forward_task_per_tx_reply before start_relay_get dispatch,
+        // gated on Response|ResponseStreaming only (phase-3b bypass).
+        #[test]
+        fn bypass_is_wired_into_get_branch_regression_guard() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            let get_branch_anchor = "NetMessageV1::Get(ref op) => {";
+            let branch_start = SOURCE.find(get_branch_anchor).expect(
+                "GET branch of handle_pure_network_message_v1 not found; \
+                 the match arm has been renamed or moved — update this regression guard",
+            );
+
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<get::GetOp, _>")
+                .expect("GET branch no longer calls handle_op_request — update guard")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+
+            // Phase-3b bypass must still be present (unchanged).
+            assert!(
+                window.contains("try_forward_task_per_tx_reply("),
+                "GET branch no longer calls try_forward_task_per_tx_reply \
+                 before handle_op_request. Phase-3b (#1454) bypass removed — restore it."
+            );
+
+            // Bypass must be gated on terminal variants only.
+            assert!(
+                window.contains("get::GetMsg::Response { .. }"),
+                "GET branch bypass is not gated on Response. \
+                 Non-terminal messages must NOT be forwarded to the task-per-tx channel."
+            );
+
+            assert!(
+                window.contains("get::GetMsg::ResponseStreaming { .. }"),
+                "GET branch bypass is not gated on ResponseStreaming. \
+                 Both terminal variants must be forwarded."
+            );
+
+            // Relay dispatch must call start_relay_get.
+            assert!(
+                window.contains("start_relay_get("),
+                "GET branch no longer calls start_relay_get for relay dispatch. \
+                 #3883 phase-5 relay dispatch was removed — restore it."
+            );
+
+            // Relay dispatch must be gated on source_addr (relay vs. loop-back).
+            assert!(
+                window.contains("source_addr"),
+                "GET branch relay dispatch is not gated on source_addr. \
+                 Originator loop-back (source_addr.is_none()) must fall through to legacy."
+            );
+
+            // Relay dispatch must guard on no existing GetOp (has_get_op).
+            assert!(
+                window.contains("has_get_op"),
+                "GET branch relay dispatch is not guarded by has_get_op. \
+                 GC-spawned retries must fall through to legacy handle_op_request."
+            );
+        }
+
+        // Source-literal guard: verify the GET branch wires
+        // try_forward_task_per_tx_reply before start_relay_get.
+        // (Ordering: phase-3b bypass comes first in source order.)
+        #[test]
+        fn get_branch_phase3b_bypass_precedes_relay_dispatch() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            let get_branch_anchor = "NetMessageV1::Get(ref op) => {";
+            let branch_start = SOURCE
+                .find(get_branch_anchor)
+                .expect("GET branch not found");
+
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<get::GetOp, _>")
+                .expect("GET branch no longer calls handle_op_request")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+
+            let bypass_pos = window
+                .find("try_forward_task_per_tx_reply(")
+                .expect("try_forward_task_per_tx_reply not found in GET branch");
+            let relay_pos = window
+                .find("start_relay_get(")
+                .expect("start_relay_get not found in GET branch");
+
+            assert!(
+                bypass_pos < relay_pos,
+                "Phase-3b bypass (try_forward_task_per_tx_reply) must appear \
+                 BEFORE relay dispatch (start_relay_get) in the GET branch. \
+                 Swapping order would break the client-driver terminal-reply fast path."
             );
         }
     }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -976,6 +976,20 @@ impl OpManager {
         .await
     }
 
+    /// Returns `true` if there is an active `GetOp` stored in `OpManager.ops.get`
+    /// for the given transaction.
+    ///
+    /// Used by the relay GET dispatch in `node.rs` to distinguish a fresh inbound
+    /// relay request (no existing op → spawn the task-per-tx driver) from a
+    /// GC-spawned retry or `start_targeted_op` (existing op → fall through to the
+    /// legacy `handle_op_request` path).
+    ///
+    /// Does **not** check `completed` or `under_progress` — those are covered by
+    /// `pop` / `load_or_init`. This is a lightweight existence check only.
+    pub fn has_get_op(&self, id: &Transaction) -> bool {
+        self.ops.get.contains_key(id)
+    }
+
     pub fn completed(&self, id: Transaction) {
         self.ring.live_tx_tracker.remove_finished_transaction(id);
         self.ops.under_progress.remove(&id);
@@ -3372,5 +3386,55 @@ mod tests {
         );
 
         GlobalSimulationTime::clear_time();
+    }
+
+    // ── has_get_op unit tests ─────────────────────────────────────────────
+    //
+    // `has_get_op` is a thin wrapper over `self.ops.get.contains_key`.
+    // Since `OpManager` requires complex infrastructure to construct in unit
+    // tests, we exercise the underlying `Ops::get` DashMap directly — the
+    // same pattern used by `remove_put_returns_false_for_missing_tx` above.
+    // The delegation in `has_get_op` is one line and trivially correct.
+
+    /// has_get_op returns false for an unknown transaction.
+    #[test]
+    fn has_get_op_returns_false_for_unknown_tx() {
+        let ops = Ops::default();
+        let tx = Transaction::new::<crate::operations::get::GetMsg>();
+        assert!(
+            !ops.get.contains_key(&tx),
+            "ops.get should not contain a never-inserted tx"
+        );
+    }
+
+    /// has_get_op returns true after a GetOp is inserted, and false once removed.
+    #[test]
+    fn has_get_op_returns_true_after_insert_false_after_remove() {
+        use freenet_stdlib::prelude::ContractInstanceId;
+
+        let ops = Ops::default();
+        let instance_id = ContractInstanceId::new([0u8; 32]);
+        let get_op = crate::operations::get::start_op(instance_id, false, false, false);
+        let tx = get_op.id;
+
+        // Before insert: absent
+        assert!(
+            !ops.get.contains_key(&tx),
+            "ops.get should not contain tx before insertion"
+        );
+
+        // After insert: present
+        ops.get.insert(tx, get_op);
+        assert!(
+            ops.get.contains_key(&tx),
+            "ops.get should contain tx after insertion"
+        );
+
+        // After remove: absent again
+        ops.get.remove(&tx);
+        assert!(
+            !ops.get.contains_key(&tx),
+            "ops.get should not contain tx after removal"
+        );
     }
 }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -331,6 +331,14 @@ pub(crate) struct OpManager {
     /// Maps contract instance ID to the timestamp (ms since epoch via GlobalSimulationTime)
     /// when the fetch was initiated, with a cooldown to avoid repeated fetch attempts.
     pub(crate) pending_contract_fetches: Arc<DashMap<ContractInstanceId, u64>>,
+    /// Transactions with an active task-per-tx relay-GET driver at this
+    /// node. Populated by `start_relay_get` before spawn and removed by
+    /// an RAII guard on the driver task. Consulted by the dispatch gate
+    /// in `node.rs` to reject duplicate inbound Requests for a tx that
+    /// already has a live relay driver — prevents the 3^HTL spawn
+    /// amplification observed in workflow run 24600634908 (6.8M spawns
+    /// in 100s, 63GB RSS).
+    pub(crate) active_relay_get_txs: Arc<DashSet<Transaction>>,
 }
 
 impl Clone for OpManager {
@@ -358,6 +366,7 @@ impl Clone for OpManager {
             blocked_addresses: self.blocked_addresses.clone(),
             configured_gateways: self.configured_gateways.clone(),
             pending_contract_fetches: self.pending_contract_fetches.clone(),
+            active_relay_get_txs: self.active_relay_get_txs.clone(),
         }
     }
 }
@@ -398,6 +407,7 @@ impl OpManager {
         > = Arc::new(Mutex::new(std::collections::HashMap::new()));
         let pending_contract_fetches: Arc<DashMap<ContractInstanceId, u64>> =
             Arc::new(DashMap::new());
+        let active_relay_get_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
 
         task_monitor.register(
             "garbage_cleanup",
@@ -415,6 +425,7 @@ impl OpManager {
                     ch_outbound.clone(),
                     contract_waiters.clone(),
                     pending_contract_fetches.clone(),
+                    active_relay_get_txs.clone(),
                 )
                 .instrument(garbage_span),
             ),
@@ -483,6 +494,7 @@ impl OpManager {
                     .collect(),
             ),
             pending_contract_fetches,
+            active_relay_get_txs,
         })
     }
 
@@ -1632,6 +1644,7 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
         Mutex<std::collections::HashMap<ContractInstanceId, Vec<oneshot::Sender<()>>>>,
     >,
     pending_contract_fetches: Arc<DashMap<ContractInstanceId, u64>>,
+    active_relay_get_txs: Arc<DashSet<Transaction>>,
 ) {
     const CLEANUP_INTERVAL: Duration = Duration::from_secs(5);
     /// How often to clean up stale contract_waiters entries (every N ticks).
@@ -1678,6 +1691,10 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                     let relay_completed =
                         crate::operations::get::op_ctx_task::RELAY_COMPLETED_TOTAL
                             .load(Ordering::Relaxed);
+                    let relay_dedup_rejects =
+                        crate::operations::get::op_ctx_task::RELAY_DEDUP_REJECTS
+                            .load(Ordering::Relaxed);
+                    let relay_active_txs = active_relay_get_txs.len();
                     tracing::info!(
                         target: "memory_stats",
                         tick = tick_count,
@@ -1698,6 +1715,8 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         relay_inflight = relay_inflight,
                         relay_spawned = relay_spawned,
                         relay_completed = relay_completed,
+                        relay_dedup_rejects = relay_dedup_rejects,
+                        relay_active_txs = relay_active_txs,
                         "memory stats"
                     );
                 }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1664,10 +1664,20 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                 // runs where we want to correlate RSS growth with retained
                 // state in OpManager/SubOperationTracker.
                 if std::env::var("FREENET_MEMORY_STATS").is_ok() {
+                    use std::sync::atomic::Ordering;
                     let ops_sizes = ops.sizes();
                     let sub_sizes = sub_op_tracker.sizes();
                     let pending_fetches = pending_contract_fetches.len();
                     let waiters_len = contract_waiters.lock().len();
+                    let relay_inflight =
+                        crate::operations::get::op_ctx_task::RELAY_INFLIGHT
+                            .load(Ordering::Relaxed);
+                    let relay_spawned =
+                        crate::operations::get::op_ctx_task::RELAY_SPAWNED_TOTAL
+                            .load(Ordering::Relaxed);
+                    let relay_completed =
+                        crate::operations::get::op_ctx_task::RELAY_COMPLETED_TOTAL
+                            .load(Ordering::Relaxed);
                     tracing::info!(
                         target: "memory_stats",
                         tick = tick_count,
@@ -1685,6 +1695,9 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         failed_parents = sub_sizes.failed_parents,
                         pending_contract_fetches = pending_fetches,
                         contract_waiters = waiters_len,
+                        relay_inflight = relay_inflight,
+                        relay_spawned = relay_spawned,
+                        relay_completed = relay_completed,
                         "memory stats"
                     );
                 }

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -114,6 +114,13 @@ pub static RELAY_SPAWNED_TOTAL: std::sync::atomic::AtomicUsize =
 pub static RELAY_COMPLETED_TOTAL: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+/// Lifetime count of relay-GET spawns rejected by the dedup gate
+/// because a driver for the same `incoming_tx` was already active on
+/// this node. Surfaced via `memory_stats` so we can confirm the gate
+/// fires under fault-loss retry retransmissions.
+pub static RELAY_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 /// Start a client-initiated GET, returning as soon as the task has been
 /// spawned (mirrors legacy `request_get` timing).
 ///
@@ -1079,6 +1086,24 @@ pub(crate) async fn start_relay_get(
     #[cfg(any(test, feature = "testing"))]
     RELAY_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
+    // Dedup gate: a relay driver for this incoming_tx is already live on
+    // this node. The duplicate inbound Request is a retransmission, GC
+    // retry, or routing bloom false-positive — don't spawn a second
+    // driver. Returning Ok drops the Request silently (matches legacy
+    // semantics where a duplicate Request hitting an in-flight op
+    // returned `OpNotAvailable::Running` and was dropped by the caller).
+    if !op_manager.active_relay_get_txs.insert(incoming_tx) {
+        RELAY_DEDUP_REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        tracing::debug!(
+            tx = %incoming_tx,
+            %instance_id,
+            %upstream_addr,
+            phase = "relay_dedup_reject",
+            "GET relay (task-per-tx): duplicate Request for in-flight tx, dropping"
+        );
+        return Ok(());
+    }
+
     tracing::debug!(
         tx = %incoming_tx,
         %instance_id,
@@ -1101,14 +1126,21 @@ pub(crate) async fn start_relay_get(
     Ok(())
 }
 
-/// RAII guard that decrements `RELAY_INFLIGHT` and bumps
-/// `RELAY_COMPLETED_TOTAL` on drop. Using a guard (vs. matching every
-/// exit path) keeps the counter correct under panics and early
-/// returns so the memory_stats dump always reflects true steady-state.
-struct RelayInflightGuard;
+/// RAII guard that decrements `RELAY_INFLIGHT`, bumps
+/// `RELAY_COMPLETED_TOTAL`, and removes the driver's `incoming_tx`
+/// from the per-node dedup set on drop. Using a guard (vs. matching
+/// every exit path) keeps the counters and dedup set correct under
+/// panics and early returns.
+struct RelayInflightGuard {
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+}
 
 impl Drop for RelayInflightGuard {
     fn drop(&mut self) {
+        self.op_manager
+            .active_relay_get_txs
+            .remove(&self.incoming_tx);
         RELAY_INFLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
         RELAY_COMPLETED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
@@ -1127,7 +1159,10 @@ async fn run_relay_get(
 ) {
     RELAY_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     RELAY_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let _guard = RelayInflightGuard;
+    let _guard = RelayInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
 
     if let Err(err) = drive_relay_get(
         &op_manager,
@@ -1293,54 +1328,6 @@ fn relay_advance_to_next_peer(
     }
     tried.push(addr);
     Some((peer, addr))
-}
-
-/// Send a fire-and-forget `ForwardingAck` to `upstream_addr`.
-///
-/// This tells the upstream "I'm forwarding this GET, don't retry me" so
-/// the upstream's GC task can distinguish dead peers from slow multi-hop
-/// chains.  Mirrors `get.rs:1628-1652`.
-async fn relay_send_forwarding_ack(
-    op_manager: &OpManager,
-    tx: Transaction,
-    instance_id: ContractInstanceId,
-    upstream_addr: SocketAddr,
-) {
-    let ack = NetMessage::from(GetMsg::ForwardingAck {
-        id: tx,
-        instance_id,
-    });
-    // Fire-and-forget via op_ctx fire-and-forget send.
-    // We use op_ctx_send_fire_and_forget_to so we go through the event
-    // loop's OutboundMessageWithTarget path, which is safe from spawned tasks.
-    let mut ctx = op_manager.op_ctx(tx);
-    if let Err(err) = ctx.send_fire_and_forget(upstream_addr, ack).await {
-        tracing::warn!(
-            tx = %tx,
-            %instance_id,
-            %upstream_addr,
-            error = %err,
-            "GET relay: failed to send ForwardingAck upstream"
-        );
-    } else {
-        // Emit telemetry for ForwardingAck sent (#3570 diagnostics)
-        let upstream_peer = op_manager
-            .ring
-            .connection_manager
-            .get_peer_by_addr(upstream_addr)
-            .unwrap_or_else(|| op_manager.ring.connection_manager.own_location());
-        if let Some(event) = crate::tracing::NetEventLog::get_forwarding_ack_sent(
-            &tx,
-            &op_manager.ring,
-            instance_id,
-            upstream_peer,
-        ) {
-            op_manager
-                .ring
-                .register_events(either::Either::Left(event))
-                .await;
-        }
-    }
 }
 
 /// Build and send a `GetMsg::Response{NotFound}` to `upstream_addr`.
@@ -1511,7 +1498,6 @@ async fn drive_relay_get_inner(
     tried.push(upstream_addr);
 
     let mut retries: usize = 0;
-    let mut sent_forwarding_ack = false;
 
     loop {
         // Pick next downstream peer.
@@ -1571,13 +1557,23 @@ async fn drive_relay_get_inner(
             }
         };
 
-        // Send ForwardingAck BEFORE forwarding (mirrors get.rs:1628-1652).
-        // Only send once per relay invocation — subsequent retries don't
-        // resend it (the upstream already extended its timer on the first ack).
-        if !sent_forwarding_ack {
-            relay_send_forwarding_ack(op_manager, incoming_tx, instance_id, upstream_addr).await;
-            sent_forwarding_ack = true;
-        }
+        // NOTE: legacy path sends a ForwardingAck upstream before forwarding
+        // downstream so the upstream's GC can extend its timer on slow
+        // multi-hop chains. In the task-per-tx relay driver we OMIT that
+        // ack: the ack carried `incoming_tx` (which equals the upstream's
+        // `attempt_tx` on a relay-to-relay hop), so it matched the
+        // upstream's capacity-1 `pending_op_results` waiter and arrived
+        // FIRST, before the real Response. `classify` returned
+        // `Unexpected`, causing upstream to abandon the downstream probe
+        // and spawn a new attempt. That amplified to 3^HTL spawns per
+        // origination under ci-fault-loss, driving the 63GB RSS explosion
+        // (workflow runs 24600168871 / 24600634908 / 24601267577).
+        //
+        // Upstream's `send_to_and_await` still has its full OPERATION_TTL
+        // (60s) to receive the real Response, which is the same timeout
+        // legacy had minus the ack-driven extension. That extension is
+        // only observable under chains longer than 60s wall-clock, which
+        // `min_success_rate=0.80` tolerates at ci-fault-loss parameters.
 
         tracing::debug!(
             tx = %incoming_tx,
@@ -2319,24 +2315,37 @@ mod tests {
         );
     }
 
-    /// T6: ForwardingAck must be sent BEFORE the downstream `send_to_and_await`
-    /// call.  The source must contain `relay_send_forwarding_ack` before
-    /// `send_to_and_await` in the loop body.
+    /// T6 (superseded): Originally required `relay_send_forwarding_ack`
+    /// to be emitted before the downstream send. That ack collided with
+    /// the upstream relay driver's capacity-1 `pending_op_results`
+    /// waiter (the ack carried `incoming_tx`, which equals the
+    /// upstream's `attempt_tx` on a relay-to-relay hop). The waiter
+    /// would fire on the ack, return `AttemptOutcome::Unexpected`, and
+    /// cause the upstream to immediately retry with a fresh tx — which
+    /// the downstream's dispatch gate saw as a brand-new Request and
+    /// spawned another full relay subtree. Net amplification was
+    /// 3^HTL spawns per origination, observed as 6.8M spawns and 63GB
+    /// RSS in workflow runs 24600168871 / 24600634908 / 24601267577.
+    ///
+    /// Fix: drop the ack entirely from the task-per-tx relay driver.
+    /// Upstream's `send_to_and_await` still has OPERATION_TTL (60s) to
+    /// receive the real Response, which is what legacy effectively had
+    /// minus the ack-driven timer extension.
     #[test]
-    fn relay_driver_forwarding_ack_sent_before_downstream_request() {
+    fn relay_driver_does_not_send_forwarding_ack() {
         let src = production_source();
         let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
-        let ack_pos = body
-            .find("relay_send_forwarding_ack")
-            .expect("drive_relay_get_inner must call relay_send_forwarding_ack");
-        let send_pos = body
-            .find("send_to_and_await")
-            .expect("drive_relay_get_inner must call send_to_and_await");
         assert!(
-            ack_pos < send_pos,
-            "relay_send_forwarding_ack must be called BEFORE send_to_and_await \
-             (ForwardingAck timing: upstream must extend its timer before we \
-             fire the downstream request)"
+            !body.contains("relay_send_forwarding_ack"),
+            "drive_relay_get_inner must NOT call relay_send_forwarding_ack \
+             — the ack collides with upstream's attempt_tx waiter and \
+             amplifies spawns 3^HTL (workflow 24600634908 showed 6.8M \
+             spawns, 63GB RSS)"
+        );
+        assert!(
+            !body.contains("ForwardingAck"),
+            "drive_relay_get_inner must not reference ForwardingAck in \
+             any form — dropped to break the spawn-amplification cycle"
         );
     }
 
@@ -2646,58 +2655,15 @@ mod tests {
         );
     }
 
-    // ── R7: ForwardingAck emitted exactly once across retries ──────────────
-
-    /// The `sent_forwarding_ack` latch must be:
-    ///   - Initialized to `false` BEFORE the retry loop
-    ///   - Checked with `if !sent_forwarding_ack` inside the loop
-    ///   - Flipped to `true` after the first `relay_send_forwarding_ack` call
-    ///
-    /// If any of these are missing, the ForwardingAck either fires per-retry
-    /// (upstream sees N acks, unnecessary traffic) or never fires (upstream
-    /// times out the op after its own OPERATION_TTL).
-    #[test]
-    fn forwarding_ack_latched_and_sent_exactly_once() {
-        let src = production_source();
-        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
-        let latch_init = body
-            .find("let mut sent_forwarding_ack = false;")
-            .expect("`let mut sent_forwarding_ack = false;` must precede the retry loop");
-        let loop_start = body.find("loop {").expect("retry loop must exist");
-        assert!(
-            latch_init < loop_start,
-            "`sent_forwarding_ack` latch must be initialized OUTSIDE the \
-             retry loop; initializing it inside would reset each iteration \
-             and cause the ack to fire on every retry."
-        );
-        // Inside the loop, the gate and the flip must both be present.
-        let loop_body = &body[loop_start..];
-        assert!(
-            loop_body.contains("if !sent_forwarding_ack {"),
-            "Retry loop must gate the ForwardingAck send on \
-             `if !sent_forwarding_ack` so it fires exactly once per relay \
-             invocation."
-        );
-        assert!(
-            loop_body.contains("sent_forwarding_ack = true;"),
-            "The ForwardingAck gate must flip `sent_forwarding_ack = true` \
-             after sending; otherwise the gate is never satisfied and the \
-             ack fires on every retry."
-        );
-        // Ordering: the gate check must appear before the flip in the loop
-        // body, and the flip must follow the `relay_send_forwarding_ack`
-        // call.
-        let gate_pos = loop_body.find("if !sent_forwarding_ack {").unwrap();
-        let ack_pos = loop_body
-            .find("relay_send_forwarding_ack")
-            .expect("relay_send_forwarding_ack must be called in loop");
-        let flip_pos = loop_body.find("sent_forwarding_ack = true;").unwrap();
-        assert!(
-            gate_pos < ack_pos && ack_pos < flip_pos,
-            "Loop body order must be: gate check → ack send → flip latch. \
-             Got gate={gate_pos}, ack={ack_pos}, flip={flip_pos}."
-        );
-    }
+    // ── R7 (superseded): ForwardingAck removed from task-per-tx relay ──────
+    //
+    // Superseded by `relay_driver_does_not_send_forwarding_ack` (T6
+    // rewrite). The original latch logic was pinned here to ensure the
+    // ack fired exactly once per relay invocation, which was the legacy
+    // behavior. In the task-per-tx migration the ack's `id` collides
+    // with the upstream relay driver's `attempt_tx` on its capacity-1
+    // `pending_op_results` waiter — causing 3^HTL spawn amplification.
+    // The ack is now never sent; see the T6 test for the invariant.
 
     // ── R8: Wire-side Request propagation (htl-1 + updated visited) ────────
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1002,7 +1002,6 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
 /// - GC-spawned retries.
 /// - `start_targeted_op` (UPDATE-triggered auto-fetch).
 #[allow(clippy::too_many_arguments)]
-#[allow(dead_code)] // Dead until commit 2 wires dispatch in node.rs.
 pub(crate) async fn start_relay_get(
     op_manager: Arc<OpManager>,
     incoming_tx: Transaction,
@@ -2278,13 +2277,15 @@ mod tests {
         );
     }
 
-    /// T9: start_relay_get is pub(crate) and dead code until commit 2.
-    /// Source-scrape verifies the #[allow(dead_code)] attribute is present
-    /// so the compiler doesn't warn about the intentionally-dead driver.
+    /// T9 (commit 2 version): start_relay_get is now live — the #[allow(dead_code)]
+    /// attribute must have been removed when dispatch was wired in node.rs.
+    ///
+    /// This test replaces the commit-1 version that asserted the attribute WAS
+    /// present. Now it asserts the attribute is ABSENT so a future refactor can't
+    /// accidentally re-suppress the live driver with #[allow(dead_code)].
     #[test]
-    fn relay_entry_point_annotated_dead_code_for_commit1() {
+    fn relay_entry_point_no_longer_annotated_dead_code_after_commit2() {
         let src = production_source();
-        // Find start_relay_get and check that dead_code allow is near it.
         let fn_start = src
             .find("pub(crate) async fn start_relay_get(")
             .expect("start_relay_get must exist");
@@ -2292,9 +2293,10 @@ mod tests {
         let window_start = fn_start.saturating_sub(500);
         let window = &src[window_start..fn_start];
         assert!(
-            window.contains("dead_code"),
-            "start_relay_get must be annotated with #[allow(dead_code)] in commit 1 \
-             to suppress the compiler warning for the intentionally-dead driver"
+            !window.contains("#[allow(dead_code)]"),
+            "start_relay_get must NOT be annotated with #[allow(dead_code)] in commit 2 \
+             — the driver is now live (wired in node.rs dispatch). Remove the attribute \
+             to keep dead-code warnings effective."
         );
     }
 }

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -85,6 +85,16 @@ use crate::operations::orphan_streams::{OrphanStreamError, STREAM_CLAIM_TIMEOUT}
 pub static DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+/// Test-only counter that increments every time `start_relay_get` is
+/// called. Used by integration tests to verify that relay dispatch
+/// actually routed a fresh inbound Request through the task-per-tx
+/// driver (and not through the legacy `handle_op_request` path that
+/// continues to serve originator loop-back, GC-spawned retries, and
+/// `start_targeted_op` UPDATE-triggered auto-fetches).
+#[cfg(any(test, feature = "testing"))]
+pub static RELAY_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 /// Start a client-initiated GET, returning as soon as the task has been
 /// spawned (mirrors legacy `request_get` timing).
 ///
@@ -1012,6 +1022,14 @@ pub(crate) async fn start_relay_get(
     fetch_contract: bool,
     subscribe: bool,
 ) -> Result<(), OpError> {
+    // Test-only: count relay driver invocations so regression tests can
+    // assert the dispatch gate in node.rs actually routed a fresh inbound
+    // Request through the task-per-tx driver rather than the legacy
+    // `handle_op_request` fallthrough (phase-3b loopback, GC retries,
+    // `start_targeted_op`).
+    #[cfg(any(test, feature = "testing"))]
+    RELAY_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
     tracing::debug!(
         tx = %incoming_tx,
         %instance_id,
@@ -2297,6 +2315,639 @@ mod tests {
             "start_relay_get must NOT be annotated with #[allow(dead_code)] in commit 2 \
              — the driver is now live (wired in node.rs dispatch). Remove the attribute \
              to keep dead-code warnings effective."
+        );
+    }
+
+    // ── Coverage-gap tests for PR #3896 (follow-up to T1-T9) ────────────────
+    //
+    // The T1-T9 suite above covers top-level structural ordering (guard-before-
+    // loop, cache-before-send, ack-before-request, etc). The tests below
+    // cover the behavioral contracts T1-T9 do NOT pin:
+    //
+    //   - G1/G2: dispatch gates in node.rs (source_addr=None loopback and
+    //     has_get_op=true both fall through to legacy)
+    //   - A   : HTL=0 emits NotFound upstream frame (not just logs-and-
+    //     returns)
+    //   - G/R10: downstream NotFound → exhaustion path; stale-cache
+    //     fallback answers Found instead of NotFound when local state
+    //     exists but interest is absent
+    //   - R7  : ForwardingAck emitted exactly once, not per retry
+    //   - R8  : wire-side Request propagation carries htl-1 and
+    //     updated visited bloom
+    //   - R12a→R13: send_found failure → compensating NotFound in outer
+    //     `drive_relay_get` error funnel
+    //   - R12b: streaming-downstream currently WARN+continue (regression
+    //     guard until follow-up PR migrates streaming relay)
+    //   - N   : concurrent same-key GET: gate condition at dispatch is
+    //     per-tx (has_get_op), NOT per-key (by design; documented)
+    //
+    // All tests below are source-scrape style to match the T1-T9 shape —
+    // they catch accidental code reorders or deletions without needing a
+    // full turmoil harness. Behavioral coverage for the happy path is
+    // already provided by `test_get_routing_coverage_low_htl` and
+    // `test_get_reliability_*` (nightly).
+
+    // ── G1/G2: Dispatch gates live in node.rs ────────────────────────────
+
+    /// G1: `source_addr.is_none()` (originator loopback from the phase-3b
+    /// client driver's `send_and_await(target=None)`) MUST NOT be routed
+    /// to the relay driver. The dispatch site in `node.rs` must check
+    /// `source_addr.is_some()` before calling `start_relay_get`; otherwise
+    /// the client driver's `Terminal::LocalCompletion` Request-echo contract
+    /// breaks and client-initiated GETs either hang or deadlock.
+    #[test]
+    fn dispatch_gate_loopback_source_addr_none_uses_legacy() {
+        const NODE_RS: &str = include_str!("../../node.rs");
+        let dispatch_start = NODE_RS
+            .find("// #1454 phase 5 / #3883: relay GET task-per-tx dispatch.")
+            .expect("relay dispatch comment anchor must exist in node.rs");
+        let dispatch_end = NODE_RS[dispatch_start..]
+            .find("let op_result = handle_op_request::<get::GetOp, _>")
+            .expect("legacy fallthrough anchor must follow relay dispatch");
+        let block = &NODE_RS[dispatch_start..dispatch_start + dispatch_end];
+        assert!(
+            block.contains("if let Some(upstream_addr) = source_addr"),
+            "Relay dispatch block must gate on `source_addr.is_some()` so that \
+             originator loopback (source_addr=None from phase-3b client driver) \
+             falls through to the legacy `handle_op_request` path. Without this \
+             gate, the Request-echo contract `drive_client_get_inner::classify` \
+             relies on for Terminal::LocalCompletion breaks. See port plan §2."
+        );
+    }
+
+    /// G2: `has_get_op(id) == true` (GC-spawned retries, `start_targeted_op`
+    /// UPDATE auto-fetch) MUST NOT be routed to the relay driver. Those
+    /// callers register a `GetOp` in `OpManager.ops.get` BEFORE the
+    /// Request hits the wire and rely on the legacy `process_message`
+    /// re-entry loop for their state machine. The dispatch site in
+    /// `node.rs` must check `!op_manager.has_get_op(id)` before calling
+    /// `start_relay_get`.
+    #[test]
+    fn dispatch_gate_existing_get_op_uses_legacy() {
+        const NODE_RS: &str = include_str!("../../node.rs");
+        let dispatch_start = NODE_RS
+            .find("// #1454 phase 5 / #3883: relay GET task-per-tx dispatch.")
+            .expect("relay dispatch comment anchor must exist in node.rs");
+        let dispatch_end = NODE_RS[dispatch_start..]
+            .find("let op_result = handle_op_request::<get::GetOp, _>")
+            .expect("legacy fallthrough anchor must follow relay dispatch");
+        let block = &NODE_RS[dispatch_start..dispatch_start + dispatch_end];
+        assert!(
+            block.contains("!op_manager.has_get_op(id)"),
+            "Relay dispatch block must gate on `!op_manager.has_get_op(id)` so that \
+             GC-spawned retries and `start_targeted_op` (UPDATE auto-fetch) continue \
+             through the legacy `handle_op_request` path. Without this gate, the \
+             relay driver would hijack transactions the legacy state machine owns."
+        );
+    }
+
+    /// G3 (companion): the dispatch block must sit AFTER the
+    /// `try_forward_task_per_tx_reply` bypass (phase-3b terminal forward)
+    /// and BEFORE the legacy `handle_op_request` call, so that:
+    ///   - terminal Response/ResponseStreaming from phase-3b client driver
+    ///     get forwarded to its pending callback, NOT handed to the relay
+    ///     driver (which would spawn a spurious task);
+    ///   - legacy handling still runs for the loopback / has_get_op gated
+    ///     fall-through cases.
+    #[test]
+    fn dispatch_gate_ordering_bypass_before_relay_before_legacy() {
+        const NODE_RS: &str = include_str!("../../node.rs");
+        let get_arm = NODE_RS
+            .find("NetMessageV1::Get(ref op) => {")
+            .expect("Get arm must exist in handle_pure_network_message_v1");
+        let tail = &NODE_RS[get_arm..];
+        let bypass_pos = tail
+            .find("try_forward_task_per_tx_reply")
+            .expect("phase-3b bypass must exist in Get arm");
+        let relay_pos = tail
+            .find("get::op_ctx_task::start_relay_get")
+            .expect("phase-5 relay dispatch must exist in Get arm");
+        let legacy_pos = tail
+            .find("handle_op_request::<get::GetOp, _>")
+            .expect("legacy fallthrough must exist in Get arm");
+        assert!(
+            bypass_pos < relay_pos && relay_pos < legacy_pos,
+            "Dispatch ordering in the Get arm must be: \
+             try_forward_task_per_tx_reply (phase-3b terminal bypass) \
+             THEN start_relay_get (phase-5 relay dispatch) \
+             THEN handle_op_request (legacy loopback + has_get_op fallthrough). \
+             Got bypass={bypass_pos}, relay={relay_pos}, legacy={legacy_pos}."
+        );
+    }
+
+    // ── A: HTL=0 actually sends a NotFound frame upstream ──────────────────
+
+    /// The HTL=0 short-circuit in `drive_relay_get_inner` must call
+    /// `relay_send_not_found(..., upstream_addr)` (not just log+return).
+    /// If this frame isn't emitted, the upstream peer waits for the full
+    /// `OPERATION_TTL` (60s) instead of seeing a fast NotFound — a
+    /// regression would show up as slow tail-latency under HTL-pressure,
+    /// not as a functional failure.
+    #[test]
+    fn htl_zero_guard_emits_not_found_upstream_frame() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        // Isolate the `if htl == 0 { ... }` block (before the retry loop).
+        let guard_start = body.find("if htl == 0").expect("htl==0 guard must exist");
+        let after_guard = &body[guard_start..];
+        // Closing brace of the guard block — walk until depth returns to 0.
+        let body_open = after_guard
+            .find('{')
+            .expect("htl==0 guard must have a body");
+        let bytes = after_guard.as_bytes();
+        let mut depth: i32 = 1;
+        let mut i = body_open + 1;
+        while i < bytes.len() && depth > 0 {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => depth -= 1,
+                _ => {}
+            }
+            i += 1;
+        }
+        let guard_block = &after_guard[body_open..i];
+        assert!(
+            guard_block.contains("relay_send_not_found"),
+            "HTL=0 guard block must call `relay_send_not_found(...)` so the \
+             upstream gets a prompt NotFound frame instead of hanging until \
+             OPERATION_TTL. Guard body was: {guard_block}"
+        );
+        assert!(
+            guard_block.contains("upstream_addr"),
+            "HTL=0 NotFound must be sent to `upstream_addr`, not any other \
+             peer. Guard body was: {guard_block}"
+        );
+        assert!(
+            guard_block.contains("return Ok(())"),
+            "HTL=0 guard must return early after sending NotFound; otherwise \
+             execution would fall into the retry loop with htl=0."
+        );
+    }
+
+    // ── G/R10: Exhaustion path — NotFound vs stale-cache fallback ──────────
+
+    /// Exhaustion (None from `relay_advance_to_next_peer`) must branch on
+    /// `local_fallback`: with stale local state, serve Found from that
+    /// state (R10); without, send NotFound (G/R11). A regression where
+    /// both branches send NotFound silently loses availability for stale-
+    /// cache relays (they would forward then lose the fallback even though
+    /// they still hold the state locally).
+    #[test]
+    fn exhaustion_branches_on_local_fallback_presence() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        // The None arm of the `match relay_advance_to_next_peer(...)` is the
+        // exhaustion branch. It must contain both `local_fallback` disposition
+        // AND both Found and NotFound sends.
+        let none_arm = body
+            .find("None => {")
+            .expect("exhaustion arm (`None => {{`) must exist");
+        // Clip to the matching close; the next `Some(p) => {` arm may precede
+        // or follow, so take the whole match body from None onward up to the
+        // end of the outer function block.
+        let tail = &body[none_arm..];
+        // Bound at the `return Ok(());` that ends the exhaustion branch.
+        let clip = tail
+            .find("return Ok(());")
+            .expect("exhaustion branch must end with `return Ok(());`");
+        let arm = &tail[..clip + "return Ok(());".len()];
+        assert!(
+            arm.contains("if let Some((key, state, contract)) = local_fallback"),
+            "Exhaustion arm must branch on `local_fallback`; otherwise the \
+             stale-cache fallback semantic (R3d → R10) is lost."
+        );
+        assert!(
+            arm.contains("relay_send_found"),
+            "Exhaustion arm must call `relay_send_found` when `local_fallback` \
+             is Some — the stale-cache relay serves what it has after all \
+             downstream peers NotFound."
+        );
+        assert!(
+            arm.contains("relay_send_not_found"),
+            "Exhaustion arm must call `relay_send_not_found` when \
+             `local_fallback` is None — the non-caching relay bubbles \
+             NotFound upstream."
+        );
+        // Ordering: the `else` branch (NotFound) must follow the `if Some`
+        // branch (Found).
+        let found_pos = arm.find("relay_send_found").unwrap();
+        let not_found_pos = arm.find("relay_send_not_found").unwrap();
+        assert!(
+            found_pos < not_found_pos,
+            "Fallback-Found must precede NotFound in the exhaustion arm \
+             source order; a reversal would mean NotFound always runs first \
+             and the fallback path is dead code."
+        );
+    }
+
+    /// `check_local_with_interest_gate` must return the local state in
+    /// the fallback slot (not `local_value`) when the relay holds state
+    /// but `has_local_interest` is false. This locks down the interest
+    /// gate: hosting relays serve immediately, stale-cache relays defer
+    /// to the network and hold local state as a fallback.
+    #[test]
+    fn interest_gate_returns_fallback_when_not_actively_hosting() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn check_local_with_interest_gate(");
+        // The interest-gated branch structure must be:
+        //   if !has_local_interest(&key) {
+        //     (None, Some((key, state, contract)))
+        //   } else {
+        //     (Some((key, state, contract)), None)
+        //   }
+        let neg_gate = body
+            .find("if !op_manager.interest_manager.has_local_interest(&key)")
+            .expect("interest gate must check `!has_local_interest` branch explicitly");
+        let tail = &body[neg_gate..];
+        let stale_pos = tail.find("(None, Some(").expect("stale branch must exist");
+        let active_pos = tail.find("(Some(").expect("active branch must exist");
+        // active branch (Some(...), None) must come AFTER the stale branch in
+        // the `else` arm.
+        assert!(
+            stale_pos < active_pos,
+            "`if !has_local_interest` arm (stale → fallback slot) must appear \
+             before the `else` arm (active → local_value slot) in source order."
+        );
+    }
+
+    // ── R7: ForwardingAck emitted exactly once across retries ──────────────
+
+    /// The `sent_forwarding_ack` latch must be:
+    ///   - Initialized to `false` BEFORE the retry loop
+    ///   - Checked with `if !sent_forwarding_ack` inside the loop
+    ///   - Flipped to `true` after the first `relay_send_forwarding_ack` call
+    ///
+    /// If any of these are missing, the ForwardingAck either fires per-retry
+    /// (upstream sees N acks, unnecessary traffic) or never fires (upstream
+    /// times out the op after its own OPERATION_TTL).
+    #[test]
+    fn forwarding_ack_latched_and_sent_exactly_once() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let latch_init = body
+            .find("let mut sent_forwarding_ack = false;")
+            .expect("`let mut sent_forwarding_ack = false;` must precede the retry loop");
+        let loop_start = body.find("loop {").expect("retry loop must exist");
+        assert!(
+            latch_init < loop_start,
+            "`sent_forwarding_ack` latch must be initialized OUTSIDE the \
+             retry loop; initializing it inside would reset each iteration \
+             and cause the ack to fire on every retry."
+        );
+        // Inside the loop, the gate and the flip must both be present.
+        let loop_body = &body[loop_start..];
+        assert!(
+            loop_body.contains("if !sent_forwarding_ack {"),
+            "Retry loop must gate the ForwardingAck send on \
+             `if !sent_forwarding_ack` so it fires exactly once per relay \
+             invocation."
+        );
+        assert!(
+            loop_body.contains("sent_forwarding_ack = true;"),
+            "The ForwardingAck gate must flip `sent_forwarding_ack = true` \
+             after sending; otherwise the gate is never satisfied and the \
+             ack fires on every retry."
+        );
+        // Ordering: the gate check must appear before the flip in the loop
+        // body, and the flip must follow the `relay_send_forwarding_ack`
+        // call.
+        let gate_pos = loop_body.find("if !sent_forwarding_ack {").unwrap();
+        let ack_pos = loop_body
+            .find("relay_send_forwarding_ack")
+            .expect("relay_send_forwarding_ack must be called in loop");
+        let flip_pos = loop_body.find("sent_forwarding_ack = true;").unwrap();
+        assert!(
+            gate_pos < ack_pos && ack_pos < flip_pos,
+            "Loop body order must be: gate check → ack send → flip latch. \
+             Got gate={gate_pos}, ack={ack_pos}, flip={flip_pos}."
+        );
+    }
+
+    // ── R8: Wire-side Request propagation (htl-1 + updated visited) ────────
+
+    /// Each retry iteration must build a downstream `GetMsg::Request` with:
+    ///   - `htl: new_htl` where `new_htl = htl.saturating_sub(1)`
+    ///   - `visited: new_visited.clone()` (the bloom filter containing
+    ///     own_addr and upstream_addr plus the caller's skip set)
+    ///   - `id: attempt_tx` (fresh per-iteration tx, not `incoming_tx`)
+    ///
+    /// Without per-iteration `attempt_tx`, the single-use-per-tx invariant
+    /// for `send_and_await` is violated. Without `new_visited.clone()` the
+    /// downstream relay's skip list is missing upstream hops, leading to
+    /// loop formation.
+    #[test]
+    fn forwarded_request_decrements_htl_and_propagates_visited() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        // The forwarded Request must be built with the decremented HTL.
+        assert!(
+            body.contains("let new_htl = htl.saturating_sub(1);"),
+            "Retry loop must compute `new_htl = htl.saturating_sub(1)` so \
+             the forwarded Request carries one-less HTL — otherwise the \
+             downstream relay would forward with the same HTL and loops \
+             could form."
+        );
+        // The forwarded Request body must thread `new_htl` and `new_visited`.
+        let request_build = body
+            .find("NetMessage::from(GetMsg::Request")
+            .expect("retry loop must build the forwarded GetMsg::Request");
+        // Take the next ~400 chars after the `GetMsg::Request {` opening as
+        // the struct-literal window.
+        let window = &body[request_build..(request_build + 400).min(body.len())];
+        assert!(
+            window.contains("htl: new_htl"),
+            "Forwarded GetMsg::Request must set `htl: new_htl` (not `htl`) so \
+             the decremented value actually propagates on the wire. Window: {window}"
+        );
+        assert!(
+            window.contains("visited: new_visited.clone()"),
+            "Forwarded GetMsg::Request must set `visited: new_visited.clone()` \
+             so the downstream sees the updated skip set — without this, \
+             the downstream could forward back to peers the upstream already \
+             tried, forming routing loops. Window: {window}"
+        );
+        assert!(
+            window.contains("id: attempt_tx"),
+            "Forwarded GetMsg::Request must set `id: attempt_tx` (fresh \
+             per-iteration Transaction), not `incoming_tx`; send_and_await \
+             requires single-use-per-tx."
+        );
+    }
+
+    /// The `new_visited` bloom filter must be seeded with `own_addr` and
+    /// `upstream_addr` BEFORE the retry loop runs, so
+    /// `k_closest_potentially_hosting` can't select the upstream (loop) or
+    /// this peer (self-forward). Regression risk: if either mark is
+    /// missing, routing may loop back immediately.
+    #[test]
+    fn visited_bloom_seeded_with_own_and_upstream_before_loop() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let loop_start = body.find("loop {").expect("retry loop must exist");
+        let pre_loop = &body[..loop_start];
+        assert!(
+            pre_loop.contains("new_visited.mark_visited(upstream_addr);"),
+            "`new_visited.mark_visited(upstream_addr)` must run BEFORE the \
+             retry loop so downstream routing can't immediately hand back \
+             to upstream."
+        );
+        // own_addr is guarded by `if let Some(...)` so check for the mark call.
+        assert!(
+            pre_loop.contains("new_visited.mark_visited(own_addr);"),
+            "`new_visited.mark_visited(own_addr)` must run BEFORE the retry \
+             loop so we don't route back to ourselves."
+        );
+    }
+
+    // ── R12a→R13: send_found failure → compensating NotFound ───────────────
+
+    /// When `relay_send_found` fails (serialization or transport error
+    /// surfaced as `OpError::NotificationError`), the `?` propagation in
+    /// `drive_relay_get_inner` surfaces the error to `drive_relay_get`,
+    /// which must catch it and send a compensating NotFound upstream —
+    /// otherwise the upstream waits for the full OPERATION_TTL on an op
+    /// the relay has already abandoned.
+    #[test]
+    fn drive_relay_get_sends_compensating_not_found_on_inner_err() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get(");
+        // Expected shape:
+        //   match drive_relay_get_inner(...).await {
+        //     Ok(()) => Ok(()),
+        //     Err(err) => {
+        //       tracing::warn!(...);
+        //       relay_send_not_found(...).await;
+        //       Err(err)
+        //     }
+        //   }
+        let err_arm = body
+            .find("Err(err) =>")
+            .expect("drive_relay_get must have an Err arm");
+        let tail = &body[err_arm..];
+        assert!(
+            tail.contains("relay_send_not_found"),
+            "`drive_relay_get` Err arm must call `relay_send_not_found` so \
+             that an inner infrastructure error (including `relay_send_found` \
+             failures surfaced via `?`) produces a compensating NotFound \
+             upstream instead of a silent 60s upstream timeout."
+        );
+        assert!(
+            tail.contains("upstream_addr"),
+            "The compensating NotFound in `drive_relay_get` must target \
+             `upstream_addr`, not any other peer."
+        );
+        assert!(
+            tail.contains("Err(err)"),
+            "`drive_relay_get` Err arm must re-raise `Err(err)` after \
+             sending the compensating NotFound, so `run_relay_get`'s \
+             infra-error log still fires."
+        );
+    }
+
+    /// `relay_send_found` must map fire-and-forget send failures to
+    /// `OpError::NotificationError` so the `?` in `drive_relay_get_inner`
+    /// surfaces them to the outer error funnel. A `?` on an `Ok` unit
+    /// type would be a dead propagation; a non-OpError return would
+    /// break the error funnel.
+    #[test]
+    fn relay_send_found_maps_send_failure_to_op_error() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn relay_send_found(");
+        assert!(
+            body.contains("map_err(|_| OpError::NotificationError)"),
+            "`relay_send_found` must map fire-and-forget send errors to \
+             `OpError::NotificationError` so `?` surfaces them to the outer \
+             `drive_relay_get` error funnel and triggers the compensating \
+             NotFound."
+        );
+    }
+
+    // ── R12b: Streaming-downstream WARN+continue regression guard ──────────
+
+    /// Relay streaming-forward migration is deferred to a follow-up PR
+    /// (port plan §7). Until then, a downstream `ResponseStreaming` reply
+    /// must be handled by the `Terminal::Streaming { .. }` arm with
+    /// `continue;` semantics — NOT piped through to the upstream. A
+    /// regression that either claims the stream (breaking phase-5 scope)
+    /// or panics (breaking availability when any downstream peer happens
+    /// to own a large contract) is caught here.
+    #[test]
+    fn streaming_downstream_is_currently_warned_and_skipped() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let streaming_arm_start = body
+            .find("AttemptOutcome::Terminal(Terminal::Streaming { .. })")
+            .expect("Streaming arm must exist in relay driver");
+        let tail = &body[streaming_arm_start..];
+        // Bound at the next arm start.
+        let clip = tail[1..]
+            .find("AttemptOutcome::")
+            .map(|p| p + 1)
+            .unwrap_or(tail.len());
+        let arm = &tail[..clip];
+        assert!(
+            arm.contains("continue;"),
+            "Streaming arm must `continue;` to try the next peer — streaming \
+             relay forwarding is out of scope for #3883 (see port plan §7). \
+             A future PR will replace this with a proper chunk pipe-through."
+        );
+        assert!(
+            arm.contains("new_visited.mark_visited(peer_addr)"),
+            "Streaming arm must mark the streaming peer as visited so the \
+             retry loop doesn't re-select it next iteration."
+        );
+        assert!(
+            !arm.contains("relay_send_found"),
+            "Streaming arm must NOT call `relay_send_found` — doing so \
+             without the chunk payload would send a Found frame with \
+             `state: None` (Unexpected at the upstream classify). See R12b \
+             gap in port plan risk register."
+        );
+        assert!(
+            !arm.contains("orphan_stream_registry"),
+            "Streaming arm must NOT claim the stream via \
+             `orphan_stream_registry` — that's the migrated behavior for a \
+             follow-up PR. Doing it here without the upstream pipe would \
+             leak stream state."
+        );
+    }
+
+    // ── R9: send_and_await Err/timeout outcomes advance to next peer ───────
+
+    /// Both `Ok(Err(..))` (channel error / event loop gone) and
+    /// `Err(Elapsed)` (timeout) arms of the `tokio::time::timeout` wrapper
+    /// must:
+    ///   - mark the failed peer with `new_visited.mark_visited(peer_addr)`
+    ///   - `continue` to the next loop iteration
+    ///
+    /// A regression where either arm `break`s or `return Err(...)`s would
+    /// abandon remaining candidates and send a premature NotFound.
+    #[test]
+    fn send_and_await_failure_arms_continue_to_next_peer() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        // Match on the outer `round_trip` match arms.
+        let round_trip = body
+            .find("let reply = match round_trip {")
+            .expect("round_trip match must exist");
+        let tail = &body[round_trip..];
+        // Clip at the end of the match (next `match classify(reply)`).
+        let clip = tail
+            .find("match classify(reply)")
+            .expect("classify match must follow round_trip match");
+        let match_body = &tail[..clip];
+        // Channel-error arm: `Ok(Err(err)) => { ... continue; }`.
+        let err_arm = match_body
+            .find("Ok(Err(err)) =>")
+            .expect("channel-error arm must exist");
+        let err_tail = &match_body[err_arm..];
+        let err_arm_end = err_tail
+            .find("Err(_elapsed) =>")
+            .expect("timeout arm must follow channel-error arm");
+        let err_block = &err_tail[..err_arm_end];
+        assert!(
+            err_block.contains("continue;"),
+            "`Ok(Err(_))` arm must `continue;` so the loop tries the next \
+             peer. A regression that returns or breaks here would abandon \
+             remaining candidates."
+        );
+        assert!(
+            err_block.contains("mark_visited(peer_addr)"),
+            "`Ok(Err(_))` arm must mark the failing peer as visited so the \
+             next `relay_advance_to_next_peer` call doesn't re-select it."
+        );
+        // Timeout arm.
+        let timeout_arm = match_body
+            .find("Err(_elapsed) =>")
+            .expect("timeout arm must exist");
+        let timeout_tail = &match_body[timeout_arm..];
+        // Clip at the end of the match block.
+        let timeout_end = timeout_tail.rfind("};").unwrap_or(timeout_tail.len());
+        let timeout_block = &timeout_tail[..timeout_end];
+        assert!(
+            timeout_block.contains("continue;"),
+            "`Err(_elapsed)` (timeout) arm must `continue;` so the loop \
+             tries the next peer. A regression that returns here would \
+             mean any slow peer permanently blocks the relay."
+        );
+        assert!(
+            timeout_block.contains("mark_visited(peer_addr)"),
+            "`Err(_elapsed)` (timeout) arm must mark the timing-out peer \
+             as visited; otherwise the retry loop might re-select it and \
+             time out again."
+        );
+    }
+
+    // ── N: Concurrent same-key GET — dispatch gate is per-tx, not per-key ──
+
+    /// The dispatch gate in `node.rs` is `!op_manager.has_get_op(id)` —
+    /// keyed on the transaction id, NOT the contract key/instance. This
+    /// means two concurrent relay GETs for the *same* contract (from
+    /// different upstreams) each get their own driver task, each its
+    /// own `incoming_tx`. This is intentional: each upstream expects a
+    /// reply on its own tx, so per-tx independence preserves the
+    /// upstream-reply invariant. Per-key dedup would break it.
+    ///
+    /// This test pins the documented semantic so a well-meaning "add
+    /// per-key dedup" refactor can't silently land.
+    #[test]
+    fn dispatch_gate_is_per_transaction_not_per_contract() {
+        const NODE_RS: &str = include_str!("../../node.rs");
+        let dispatch_start = NODE_RS
+            .find("// #1454 phase 5 / #3883: relay GET task-per-tx dispatch.")
+            .expect("relay dispatch comment anchor must exist in node.rs");
+        let dispatch_end = NODE_RS[dispatch_start..]
+            .find("let op_result = handle_op_request::<get::GetOp, _>")
+            .expect("legacy fallthrough anchor must follow relay dispatch");
+        let block = &NODE_RS[dispatch_start..dispatch_start + dispatch_end];
+        assert!(
+            block.contains("has_get_op(id)"),
+            "Dispatch gate must be keyed on `has_get_op(id)` (per-transaction), \
+             not `instance_id` / contract key (per-key). Per-key dedup would \
+             break the upstream-reply invariant: two upstreams GETting the \
+             same contract need independent replies, each on its own tx."
+        );
+        // Negative: no contract-key dedup construct in the dispatch block.
+        assert!(
+            !block.contains("has_get_op(instance_id)")
+                && !block.contains("has_get_op(contract_id)"),
+            "Dispatch block must not gate on contract key (per-key dedup). \
+             Found a suspicious has_get_op variant: {block}"
+        );
+    }
+
+    // ── Counter: relay driver call count is wired ──────────────────────────
+
+    /// The `RELAY_DRIVER_CALL_COUNT` test counter must be incremented at
+    /// the top of `start_relay_get` under `#[cfg(any(test, feature =
+    /// "testing"))]`. Behavioral tests use this to assert the dispatch
+    /// gate routed a fresh inbound Request through the driver rather
+    /// than through the legacy fallthrough.
+    #[test]
+    fn relay_driver_call_count_incremented_on_entry() {
+        let src = production_source();
+        // Counter declaration must exist.
+        assert!(
+            src.contains("pub static RELAY_DRIVER_CALL_COUNT"),
+            "RELAY_DRIVER_CALL_COUNT static must be declared for behavioral \
+             tests to verify the dispatch gate routes through the relay driver."
+        );
+        // Increment must appear in the body of start_relay_get, under cfg.
+        let body = extract_fn_body(src, "pub(crate) async fn start_relay_get(");
+        assert!(
+            body.contains("RELAY_DRIVER_CALL_COUNT.fetch_add(1"),
+            "`start_relay_get` must increment `RELAY_DRIVER_CALL_COUNT` at \
+             entry so integration tests can assert dispatch-gate coverage."
+        );
+        // The increment must be cfg-gated to avoid shipping test code.
+        let counter_pos = body.find("RELAY_DRIVER_CALL_COUNT.fetch_add").unwrap();
+        // Walk back ~200 chars for the cfg attribute.
+        let pre = &body[counter_pos.saturating_sub(200)..counter_pos];
+        assert!(
+            pre.contains("#[cfg(any(test, feature = \"testing\"))]"),
+            "`RELAY_DRIVER_CALL_COUNT` increment must be gated behind \
+             `#[cfg(any(test, feature = \"testing\"))]` so it doesn't ship \
+             in release builds."
         );
     }
 }

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -2350,14 +2350,15 @@ mod tests {
         assert!(
             !body.contains("relay_send_forwarding_ack"),
             "drive_relay_get_inner must NOT call relay_send_forwarding_ack \
-             — the ack collides with upstream's attempt_tx waiter and \
-             amplifies spawns 3^HTL (workflow 24600634908 showed 6.8M \
-             spawns, 63GB RSS)"
+             — the ack collided with upstream's attempt_tx waiter and \
+             amplified spawns (workflow 24600634908: 6.8M spawns, 63GB RSS)"
         );
+        // A literal `GetMsg::ForwardingAck { ... }` construction would reintroduce
+        // the bug. Comments/doc-strings mentioning "ForwardingAck" are fine.
         assert!(
-            !body.contains("ForwardingAck"),
-            "drive_relay_get_inner must not reference ForwardingAck in \
-             any form — dropped to break the spawn-amplification cycle"
+            !body.contains("GetMsg::ForwardingAck {"),
+            "drive_relay_get_inner must not construct GetMsg::ForwardingAck — \
+             dropped to break the spawn-amplification cycle"
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1599,11 +1599,17 @@ async fn drive_relay_get_inner(
                 .await;
         }
 
-        // Build per-attempt tx (fresh per-attempt to satisfy single-use-per-tx).
-        let attempt_tx = Transaction::new::<GetMsg>();
-
+        // Forward downstream using the INCOMING tx (end-to-end preservation,
+        // matching legacy relay semantics). Minting a fresh `attempt_tx`
+        // per retry was the 3^HTL amplifier: downstream peers saw every
+        // retry as a brand-new Request, spawned a fresh relay subtree,
+        // and the aggregate spawn rate reached 7M/100s in ci-fault-loss
+        // (workflow run 24601908758). Reusing `incoming_tx` keeps the
+        // pending_op_results callback bound to a single key per hop;
+        // retries re-register the same callback after the previous
+        // attempt's receiver was consumed by timeout or reply.
         let request = NetMessage::from(GetMsg::Request {
-            id: attempt_tx,
+            id: incoming_tx,
             instance_id,
             fetch_contract,
             htl: new_htl,
@@ -1611,20 +1617,19 @@ async fn drive_relay_get_inner(
             subscribe,
         });
 
-        // Send to downstream peer and await reply.
-        let mut ctx = op_manager.op_ctx(attempt_tx);
+        // Send to downstream peer and await reply (keyed on incoming_tx).
+        let mut ctx = op_manager.op_ctx(incoming_tx);
         let round_trip =
             tokio::time::timeout(OPERATION_TTL, ctx.send_to_and_await(peer_addr, request)).await;
 
-        // Always release the per-attempt slot.
-        op_manager.release_pending_op_slot(attempt_tx).await;
+        // Always release the slot so the next retry can re-register.
+        op_manager.release_pending_op_slot(incoming_tx).await;
 
         let reply = match round_trip {
             Ok(Ok(reply)) => reply,
             Ok(Err(err)) => {
                 tracing::warn!(
                     tx = %incoming_tx,
-                    attempt_tx = %attempt_tx,
                     target = %peer,
                     error = %err,
                     "GET relay (task-per-tx): send_to_and_await failed; advancing to next peer"
@@ -1636,7 +1641,6 @@ async fn drive_relay_get_inner(
             Err(_elapsed) => {
                 tracing::warn!(
                     tx = %incoming_tx,
-                    attempt_tx = %attempt_tx,
                     target = %peer,
                     timeout_secs = OPERATION_TTL.as_secs(),
                     "GET relay (task-per-tx): attempt timed out; advancing to next peer"
@@ -1716,7 +1720,6 @@ async fn drive_relay_get_inner(
             AttemptOutcome::Retry => {
                 tracing::debug!(
                     tx = %incoming_tx,
-                    attempt_tx = %attempt_tx,
                     target = %peer,
                     "GET relay (task-per-tx): downstream returned NotFound; advancing to next peer"
                 );
@@ -1728,7 +1731,6 @@ async fn drive_relay_get_inner(
             AttemptOutcome::Unexpected => {
                 tracing::warn!(
                     tx = %incoming_tx,
-                    attempt_tx = %attempt_tx,
                     target = %peer,
                     "GET relay (task-per-tx): unexpected reply variant; advancing to next peer"
                 );

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -2673,12 +2673,13 @@ mod tests {
     ///   - `htl: new_htl` where `new_htl = htl.saturating_sub(1)`
     ///   - `visited: new_visited.clone()` (the bloom filter containing
     ///     own_addr and upstream_addr plus the caller's skip set)
-    ///   - `id: attempt_tx` (fresh per-iteration tx, not `incoming_tx`)
+    ///   - `id: incoming_tx` (reused across retries — matches legacy
+    ///     end-to-end tx preservation; see the amplification comment
+    ///     on that line for why the original per-iteration `attempt_tx`
+    ///     caused 7M spawns / 100s in ci-fault-loss)
     ///
-    /// Without per-iteration `attempt_tx`, the single-use-per-tx invariant
-    /// for `send_and_await` is violated. Without `new_visited.clone()` the
-    /// downstream relay's skip list is missing upstream hops, leading to
-    /// loop formation.
+    /// Without `new_visited.clone()` the downstream relay's skip list is
+    /// missing upstream hops, leading to loop formation.
     #[test]
     fn forwarded_request_decrements_htl_and_propagates_visited() {
         let src = production_source();
@@ -2711,10 +2712,12 @@ mod tests {
              tried, forming routing loops. Window: {window}"
         );
         assert!(
-            window.contains("id: attempt_tx"),
-            "Forwarded GetMsg::Request must set `id: attempt_tx` (fresh \
-             per-iteration Transaction), not `incoming_tx`; send_and_await \
-             requires single-use-per-tx."
+            window.contains("id: incoming_tx"),
+            "Forwarded GetMsg::Request must reuse `id: incoming_tx` (legacy \
+             end-to-end tx preservation). Minting a fresh tx per retry (the \
+             original phase-5 implementation) caused downstream to treat each \
+             retry as a brand-new Request and spawn a fresh relay subtree, \
+             producing 7M spawns in 100s of ci-fault-loss and 63GB RSS."
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -53,21 +53,23 @@
 //! relies on the `OPERATION_TTL` (60s) timeout. Accepted ceiling,
 //! matching Phase 2b/3a.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use freenet_stdlib::client_api::{ContractResponse, ErrorKind, HostResponse};
 use freenet_stdlib::prelude::*;
 
 use crate::client_events::HostResult;
-use crate::config::GlobalExecutor;
+use crate::config::{GlobalExecutor, OPERATION_TTL};
 use crate::contract::{ContractHandlerEvent, StoreResponse};
 use crate::message::{NetMessage, NetMessageV1, Transaction};
 use crate::node::OpManager;
-use crate::operations::OpError;
-use crate::operations::VisitedPeers;
+#[rustfmt::skip]
 use crate::operations::op_ctx::{
     AdvanceOutcome, AttemptOutcome, RetryDriver, RetryLoopOutcome, drive_retry_loop,
 };
+use crate::operations::OpError;
+use crate::operations::VisitedPeers;
 use crate::ring::{Location, PeerKeyLocation};
 use crate::router::{RouteEvent, RouteOutcome};
 use crate::transport::peer_connection::StreamId;
@@ -955,6 +957,698 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
     }
 }
 
+// ── Relay GET task-per-tx driver (#3883) ────────────────────────────────────
+//
+// `start_relay_get` is the entry point for the relay (non-originator) GET
+// task-per-tx driver.  It is called from `node.rs` dispatch (commit 2) when
+// an incoming `GetMsg::Request` arrives with `source_addr.is_some()` — i.e.
+// from a real remote peer rather than the originator's own loop-back.
+//
+// The driver owns all routing / forwarding / retry state in task locals.
+// No `GetOp` is stored in `OpManager.ops.get` for any relay hop this driver
+// handles.  Responses are bubbled back upstream via `OpCtx::send_to_and_await`
+// targeting the downstream peer, and the reply (Found / NotFound) is forwarded
+// to `upstream_addr` via a fire-and-forget `conn_manager.send`.
+//
+// Out of scope for this commit (§7 of the port plan):
+//   - ResponseStreaming relay forwarding (chunk pipe-through).
+//   - GC-spawned retries.
+//   - start_targeted_op (UPDATE-triggered auto-fetch).
+//
+// This entire section is dead code in commit 1 — node.rs dispatch is not
+// changed until commit 2.
+
+/// Start a relay (non-originator) GET task-per-tx driver.
+///
+/// Called from `node.rs` dispatch when an incoming `GetMsg::Request`
+/// arrives from a remote peer (`source_addr.is_some()`).  The driver
+/// owns routing/forwarding/retry state in its task locals — no `GetOp`
+/// is stored in `OpManager.ops.get` for this transaction.
+///
+/// Originator loop-back (`source_addr.is_none()`) continues to use the
+/// legacy `handle_op_request` → `process_message` path.
+///
+/// # Scope (#3883)
+///
+/// Migrated:
+/// - `GetMsg::Request` relay arm: HTL check, local-cache lookup (with
+///   interest gate), forward-or-respond decision.
+/// - `GetMsg::Response{NotFound}` retry to next alternative peer.
+/// - `GetMsg::Response{Found}` bubble-up to upstream.
+/// - `ForwardingAck` send-before-forward.
+///
+/// NOT migrated (stays on legacy path; see port plan §7):
+/// - Streaming-chunk relay forwarding (`ResponseStreaming` pass-through).
+/// - GC-spawned retries.
+/// - `start_targeted_op` (UPDATE-triggered auto-fetch).
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)] // Dead until commit 2 wires dispatch in node.rs.
+pub(crate) async fn start_relay_get(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    instance_id: ContractInstanceId,
+    htl: usize,
+    upstream_addr: SocketAddr,
+    visited: VisitedPeers,
+    fetch_contract: bool,
+    subscribe: bool,
+) -> Result<(), OpError> {
+    tracing::debug!(
+        tx = %incoming_tx,
+        %instance_id,
+        htl,
+        %upstream_addr,
+        phase = "relay_start",
+        "GET relay (task-per-tx): spawning driver"
+    );
+
+    GlobalExecutor::spawn(run_relay_get(
+        op_manager,
+        incoming_tx,
+        instance_id,
+        htl,
+        upstream_addr,
+        visited,
+        fetch_contract,
+        subscribe,
+    ));
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_relay_get(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    instance_id: ContractInstanceId,
+    htl: usize,
+    upstream_addr: SocketAddr,
+    visited: VisitedPeers,
+    fetch_contract: bool,
+    subscribe: bool,
+) {
+    if let Err(err) = drive_relay_get(
+        &op_manager,
+        incoming_tx,
+        instance_id,
+        htl,
+        upstream_addr,
+        visited,
+        fetch_contract,
+        subscribe,
+    )
+    .await
+    {
+        tracing::warn!(
+            tx = %incoming_tx,
+            %instance_id,
+            error = %err,
+            phase = "relay_infra_error",
+            "GET relay (task-per-tx): infrastructure error in driver"
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drive_relay_get(
+    op_manager: &Arc<OpManager>,
+    incoming_tx: Transaction,
+    instance_id: ContractInstanceId,
+    htl: usize,
+    upstream_addr: SocketAddr,
+    visited: VisitedPeers,
+    fetch_contract: bool,
+    subscribe: bool,
+) -> Result<(), OpError> {
+    match drive_relay_get_inner(
+        op_manager,
+        incoming_tx,
+        instance_id,
+        htl,
+        upstream_addr,
+        visited,
+        fetch_contract,
+        subscribe,
+    )
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            tracing::warn!(
+                tx = %incoming_tx,
+                %instance_id,
+                error = %err,
+                phase = "relay_inner_error",
+                "GET relay (task-per-tx): inner driver returned error; sending NotFound upstream"
+            );
+            // On infrastructure error, send NotFound upstream so the upstream
+            // doesn't time out waiting for us.
+            relay_send_not_found(op_manager, incoming_tx, instance_id, upstream_addr).await;
+            Err(err)
+        }
+    }
+}
+
+/// Local fallback tuple: key, state, optional contract code.
+type LocalFallback = (ContractKey, WrappedState, Option<ContractContainer>);
+
+/// Relay-side local cache lookup with interest gate.
+///
+/// Mirrors `GetMsg::Request` match arm at `get.rs:1369-1433`.
+///
+/// Returns `(local_value, local_fallback)`:
+/// - `local_value`: Some if we should serve immediately (active interest or
+///   originator).  None if we should forward.
+/// - `local_fallback`: Some if we have stale local state with no active
+///   interest — used as a fallback if all downstream peers return NotFound.
+async fn check_local_with_interest_gate(
+    op_manager: &OpManager,
+    instance_id: &ContractInstanceId,
+    fetch_contract: bool,
+) -> (Option<LocalFallback>, Option<LocalFallback>) {
+    let get_result = op_manager
+        .notify_contract_handler(ContractHandlerEvent::GetQuery {
+            instance_id: *instance_id,
+            return_contract_code: fetch_contract,
+        })
+        .await;
+
+    let raw_local = match get_result {
+        Ok(ContractHandlerEvent::GetResponse {
+            key: Some(key),
+            response:
+                Ok(StoreResponse {
+                    state: Some(state),
+                    contract,
+                }),
+        }) => {
+            if fetch_contract && contract.is_none() {
+                // State available but contract code missing — cannot serve,
+                // must forward to get WASM from the network.
+                None
+            } else {
+                Some((key, state, contract))
+            }
+        }
+        _ => None,
+    };
+
+    match raw_local {
+        None => (None, None),
+        Some((key, state, contract)) => {
+            // Interest gate (mirrors get.rs:1408-1433):
+            // Relay peers actively hosting serve immediately.
+            // Peers with only stale LRU cache (no active interest) defer to
+            // the network but keep the local value as fallback.
+            if !op_manager.interest_manager.has_local_interest(&key) {
+                // Stale cache only — defer to network, keep as fallback.
+                tracing::debug!(
+                    %instance_id,
+                    "GET relay: stale cache (no local interest), will forward"
+                );
+                (None, Some((key, state, contract)))
+            } else {
+                // Actively hosting with interest — serve immediately.
+                (Some((key, state, contract)), None)
+            }
+        }
+    }
+}
+
+/// Select the next downstream peer for relay forwarding.
+///
+/// Uses `new_visited` (bloom filter) as the primary skip list for
+/// `k_closest_potentially_hosting` — this already encodes the upstream's
+/// skip list plus this peer and the upstream address.  `tried` is used
+/// for retry-count tracking and to ensure we don't revisit peers we've
+/// explicitly attempted in this driver invocation.
+///
+/// Returns None when exhausted (`retries >= MAX_RELAY_RETRIES`).
+fn relay_advance_to_next_peer(
+    op_manager: &OpManager,
+    instance_id: &ContractInstanceId,
+    tried: &mut Vec<SocketAddr>,
+    retries: &mut usize,
+    new_visited: &VisitedPeers,
+) -> Option<(PeerKeyLocation, SocketAddr)> {
+    const MAX_RELAY_RETRIES: usize = 3;
+    if *retries >= MAX_RELAY_RETRIES {
+        return None;
+    }
+    *retries += 1;
+
+    // Use new_visited as the skip list so upstream's visited set and our own
+    // marks are both respected.
+    let peer = op_manager
+        .ring
+        .k_closest_potentially_hosting(instance_id, new_visited.clone(), 1)
+        .into_iter()
+        .next()?;
+    let addr = peer.socket_addr()?;
+    // Double-check against tried (exact exclusion, no bloom false positives).
+    if tried.contains(&addr) {
+        return None;
+    }
+    tried.push(addr);
+    Some((peer, addr))
+}
+
+/// Send a fire-and-forget `ForwardingAck` to `upstream_addr`.
+///
+/// This tells the upstream "I'm forwarding this GET, don't retry me" so
+/// the upstream's GC task can distinguish dead peers from slow multi-hop
+/// chains.  Mirrors `get.rs:1628-1652`.
+async fn relay_send_forwarding_ack(
+    op_manager: &OpManager,
+    tx: Transaction,
+    instance_id: ContractInstanceId,
+    upstream_addr: SocketAddr,
+) {
+    let ack = NetMessage::from(GetMsg::ForwardingAck {
+        id: tx,
+        instance_id,
+    });
+    // Fire-and-forget via op_ctx fire-and-forget send.
+    // We use op_ctx_send_fire_and_forget_to so we go through the event
+    // loop's OutboundMessageWithTarget path, which is safe from spawned tasks.
+    let mut ctx = op_manager.op_ctx(tx);
+    if let Err(err) = ctx.send_fire_and_forget(upstream_addr, ack).await {
+        tracing::warn!(
+            tx = %tx,
+            %instance_id,
+            %upstream_addr,
+            error = %err,
+            "GET relay: failed to send ForwardingAck upstream"
+        );
+    } else {
+        // Emit telemetry for ForwardingAck sent (#3570 diagnostics)
+        let upstream_peer = op_manager
+            .ring
+            .connection_manager
+            .get_peer_by_addr(upstream_addr)
+            .unwrap_or_else(|| op_manager.ring.connection_manager.own_location());
+        if let Some(event) = crate::tracing::NetEventLog::get_forwarding_ack_sent(
+            &tx,
+            &op_manager.ring,
+            instance_id,
+            upstream_peer,
+        ) {
+            op_manager
+                .ring
+                .register_events(either::Either::Left(event))
+                .await;
+        }
+    }
+}
+
+/// Build and send a `GetMsg::Response{NotFound}` to `upstream_addr`.
+async fn relay_send_not_found(
+    op_manager: &OpManager,
+    tx: Transaction,
+    instance_id: ContractInstanceId,
+    upstream_addr: SocketAddr,
+) {
+    let msg = NetMessage::from(GetMsg::Response {
+        id: tx,
+        instance_id,
+        result: GetMsgResult::NotFound,
+    });
+    let mut ctx = op_manager.op_ctx(tx);
+    // Fire-and-forget — relay doesn't await the upstream's ack.
+    if let Err(err) = ctx.send_fire_and_forget(upstream_addr, msg).await {
+        tracing::warn!(
+            tx = %tx,
+            %instance_id,
+            %upstream_addr,
+            error = %err,
+            "GET relay: failed to send NotFound upstream"
+        );
+    }
+}
+
+/// Build and send a `GetMsg::Response{Found}` (inline, non-streaming) to
+/// `upstream_addr`.  Returns an error on serialization failure.
+async fn relay_send_found(
+    op_manager: &OpManager,
+    tx: Transaction,
+    instance_id: ContractInstanceId,
+    upstream_addr: SocketAddr,
+    key: ContractKey,
+    state: WrappedState,
+    contract: Option<ContractContainer>,
+) -> Result<(), OpError> {
+    let msg = NetMessage::from(GetMsg::Response {
+        id: tx,
+        instance_id,
+        result: GetMsgResult::Found {
+            key,
+            value: StoreResponse {
+                state: Some(state),
+                contract,
+            },
+        },
+    });
+    let mut ctx = op_manager.op_ctx(tx);
+    // Fire-and-forget toward upstream — relay doesn't await upstream's ack.
+    ctx.send_fire_and_forget(upstream_addr, msg)
+        .await
+        .map_err(|_| OpError::NotificationError)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drive_relay_get_inner(
+    op_manager: &Arc<OpManager>,
+    incoming_tx: Transaction,
+    instance_id: ContractInstanceId,
+    htl: usize,
+    upstream_addr: SocketAddr,
+    visited: VisitedPeers,
+    fetch_contract: bool,
+    subscribe: bool,
+) -> Result<(), OpError> {
+    let ring_max_htl = op_manager.ring.max_hops_to_live.max(1);
+    let htl = htl.min(ring_max_htl);
+
+    // ── Short-circuit 1: HTL = 0 ────────────────────────────────────────
+    if htl == 0 {
+        tracing::warn!(
+            tx = %incoming_tx,
+            %instance_id,
+            %upstream_addr,
+            htl = 0,
+            phase = "not_found",
+            "GET relay (task-per-tx): HTL exhausted — sending NotFound upstream"
+        );
+        if let Some(event) = crate::tracing::NetEventLog::get_not_found(
+            &incoming_tx,
+            &op_manager.ring,
+            instance_id,
+            Some(op_manager.ring.max_hops_to_live),
+        ) {
+            op_manager
+                .ring
+                .register_events(either::Either::Left(event))
+                .await;
+        }
+        relay_send_not_found(op_manager, incoming_tx, instance_id, upstream_addr).await;
+        return Ok(());
+    }
+
+    // ── Update visited set: mark this peer and the upstream ─────────────
+    let mut new_visited = visited.with_transaction(&incoming_tx);
+    if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr() {
+        new_visited.mark_visited(own_addr);
+    }
+    new_visited.mark_visited(upstream_addr);
+
+    // ── Short-circuit 2: Local cache hit with interest ───────────────────
+    let (local_value, local_fallback) =
+        check_local_with_interest_gate(op_manager, &instance_id, fetch_contract).await;
+
+    if let Some((key, state, contract)) = local_value {
+        tracing::info!(
+            tx = %incoming_tx,
+            %instance_id,
+            contract = %key,
+            phase = "complete",
+            "GET relay (task-per-tx): contract found locally (active interest) — sending Found upstream"
+        );
+
+        // Register interest for the requester (mirrors get.rs:1447-1476).
+        if subscribe {
+            crate::operations::subscribe::register_downstream_subscriber(
+                op_manager,
+                &key,
+                upstream_addr,
+                None,
+                None,
+                &incoming_tx,
+                " (relay task-per-tx, piggybacked on GET)",
+            )
+            .await;
+        } else if let Some(pkl) = op_manager
+            .ring
+            .connection_manager
+            .get_peer_by_addr(upstream_addr)
+        {
+            let peer_key = crate::ring::interest::PeerKey::from(pkl.pub_key.clone());
+            op_manager
+                .interest_manager
+                .register_peer_interest(&key, peer_key, None, false);
+        }
+
+        // Cache locally first (relay already hosting, idempotent).
+        cache_contract_locally(op_manager, key, state.clone(), contract.clone()).await;
+
+        relay_send_found(
+            op_manager,
+            incoming_tx,
+            instance_id,
+            upstream_addr,
+            key,
+            state,
+            contract,
+        )
+        .await?;
+        return Ok(());
+    }
+
+    // ── Retry loop: forward to downstream peers ──────────────────────────
+    // `tried` tracks the exact addrs we've attempted for retry counting.
+    // The bloom filter `new_visited` acts as the skip list for
+    // `k_closest_potentially_hosting` (it already has own_addr and
+    // upstream_addr marked in).
+    let mut tried: Vec<SocketAddr> = Vec::new();
+    if let Some(own_addr) = op_manager.ring.connection_manager.get_own_addr() {
+        tried.push(own_addr);
+    }
+    tried.push(upstream_addr);
+
+    let mut retries: usize = 0;
+    let mut sent_forwarding_ack = false;
+
+    loop {
+        // Pick next downstream peer.
+        let (peer, peer_addr) = match relay_advance_to_next_peer(
+            op_manager,
+            &instance_id,
+            &mut tried,
+            &mut retries,
+            &new_visited,
+        ) {
+            Some(p) => p,
+            None => {
+                // Exhausted: serve local fallback if available, else NotFound.
+                if let Some((key, state, contract)) = local_fallback {
+                    tracing::info!(
+                        tx = %incoming_tx,
+                        %instance_id,
+                        contract = %key,
+                        "GET relay (task-per-tx): all peers exhausted — serving local fallback"
+                    );
+                    cache_contract_locally(op_manager, key, state.clone(), contract.clone()).await;
+                    relay_send_found(
+                        op_manager,
+                        incoming_tx,
+                        instance_id,
+                        upstream_addr,
+                        key,
+                        state,
+                        contract,
+                    )
+                    .await?;
+                } else {
+                    tracing::warn!(
+                        tx = %incoming_tx,
+                        %instance_id,
+                        %upstream_addr,
+                        phase = "not_found",
+                        "GET relay (task-per-tx): all peers exhausted — sending NotFound upstream"
+                    );
+                    if let Some(event) = crate::tracing::NetEventLog::get_not_found(
+                        &incoming_tx,
+                        &op_manager.ring,
+                        instance_id,
+                        None,
+                    ) {
+                        op_manager
+                            .ring
+                            .register_events(either::Either::Left(event))
+                            .await;
+                    }
+                    relay_send_not_found(op_manager, incoming_tx, instance_id, upstream_addr).await;
+                }
+                return Ok(());
+            }
+        };
+
+        // Send ForwardingAck BEFORE forwarding (mirrors get.rs:1628-1652).
+        // Only send once per relay invocation — subsequent retries don't
+        // resend it (the upstream already extended its timer on the first ack).
+        if !sent_forwarding_ack {
+            relay_send_forwarding_ack(op_manager, incoming_tx, instance_id, upstream_addr).await;
+            sent_forwarding_ack = true;
+        }
+
+        tracing::debug!(
+            tx = %incoming_tx,
+            %instance_id,
+            target = %peer,
+            target_addr = %peer_addr,
+            phase = "forward",
+            "GET relay (task-per-tx): forwarding request to downstream peer"
+        );
+
+        // Emit get_request telemetry for the relay forward.
+        let new_htl = htl.saturating_sub(1);
+        if let Some(event) = crate::tracing::NetEventLog::get_request(
+            &incoming_tx,
+            &op_manager.ring,
+            instance_id,
+            peer.clone(),
+            new_htl,
+        ) {
+            op_manager
+                .ring
+                .register_events(either::Either::Left(event))
+                .await;
+        }
+
+        // Build per-attempt tx (fresh per-attempt to satisfy single-use-per-tx).
+        let attempt_tx = Transaction::new::<GetMsg>();
+
+        let request = NetMessage::from(GetMsg::Request {
+            id: attempt_tx,
+            instance_id,
+            fetch_contract,
+            htl: new_htl,
+            visited: new_visited.clone(),
+            subscribe,
+        });
+
+        // Send to downstream peer and await reply.
+        let mut ctx = op_manager.op_ctx(attempt_tx);
+        let round_trip =
+            tokio::time::timeout(OPERATION_TTL, ctx.send_to_and_await(peer_addr, request)).await;
+
+        // Always release the per-attempt slot.
+        op_manager.release_pending_op_slot(attempt_tx).await;
+
+        let reply = match round_trip {
+            Ok(Ok(reply)) => reply,
+            Ok(Err(err)) => {
+                tracing::warn!(
+                    tx = %incoming_tx,
+                    attempt_tx = %attempt_tx,
+                    target = %peer,
+                    error = %err,
+                    "GET relay (task-per-tx): send_to_and_await failed; advancing to next peer"
+                );
+                // Continue loop to try next peer.
+                new_visited.mark_visited(peer_addr);
+                continue;
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
+                    tx = %incoming_tx,
+                    attempt_tx = %attempt_tx,
+                    target = %peer,
+                    timeout_secs = OPERATION_TTL.as_secs(),
+                    "GET relay (task-per-tx): attempt timed out; advancing to next peer"
+                );
+                new_visited.mark_visited(peer_addr);
+                continue;
+            }
+        };
+
+        // Classify the reply.
+        match classify(reply) {
+            AttemptOutcome::Terminal(Terminal::InlineFound {
+                key,
+                state,
+                contract,
+            }) => {
+                tracing::info!(
+                    tx = %incoming_tx,
+                    %instance_id,
+                    contract = %key,
+                    phase = "relay_found",
+                    "GET relay (task-per-tx): downstream returned Found — caching locally and bubbling upstream"
+                );
+
+                // Cache locally (relay opportunistically caches; side
+                // effects like `announce_contract_hosted` are skipped
+                // since relay is not the originator — `cache_contract_locally`
+                // handles the hosting LRU / interest manager for relay nodes).
+                cache_contract_locally(op_manager, key, state.clone(), contract.clone()).await;
+
+                // Bubble up to upstream.
+                relay_send_found(
+                    op_manager,
+                    incoming_tx,
+                    instance_id,
+                    upstream_addr,
+                    key,
+                    state,
+                    contract,
+                )
+                .await?;
+                return Ok(());
+            }
+            AttemptOutcome::Terminal(Terminal::Streaming { .. }) => {
+                // Streaming relay forwarding is out of scope for #3883 commit 1.
+                // Log and fall through to next peer (treat as NotFound for now).
+                // A follow-up PR will add proper chunk pipe-through.
+                tracing::warn!(
+                    tx = %incoming_tx,
+                    %instance_id,
+                    target = %peer,
+                    "GET relay (task-per-tx): downstream returned ResponseStreaming — \
+                     streaming relay forwarding not yet implemented (port plan §7); \
+                     trying next peer"
+                );
+                new_visited.mark_visited(peer_addr);
+                continue;
+            }
+            AttemptOutcome::Terminal(Terminal::LocalCompletion) => {
+                // A relay driver should never receive a Request-echo because
+                // `send_to_and_await` targets a specific remote peer (not loopback).
+                // If this arrives, treat it as Unexpected.
+                tracing::warn!(
+                    tx = %incoming_tx,
+                    %instance_id,
+                    "GET relay (task-per-tx): unexpected LocalCompletion (Request-echo) — trying next peer"
+                );
+                new_visited.mark_visited(peer_addr);
+                continue;
+            }
+            AttemptOutcome::Retry => {
+                tracing::debug!(
+                    tx = %incoming_tx,
+                    attempt_tx = %attempt_tx,
+                    target = %peer,
+                    "GET relay (task-per-tx): downstream returned NotFound; advancing to next peer"
+                );
+                // Mark the failed peer so future iterations don't re-select it.
+                new_visited.mark_visited(peer_addr);
+                // Loop iterates to next peer.
+                continue;
+            }
+            AttemptOutcome::Unexpected => {
+                tracing::warn!(
+                    tx = %incoming_tx,
+                    attempt_tx = %attempt_tx,
+                    target = %peer,
+                    "GET relay (task-per-tx): unexpected reply variant; advancing to next peer"
+                );
+                new_visited.mark_visited(peer_addr);
+                continue;
+            }
+        }
+    }
+}
+
+// ── End of relay GET driver ──────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1429,5 +2123,178 @@ mod tests {
         let body = &SOURCE[fn_start..];
         body.find("if !subscribe {")
             .expect("maybe_subscribe_child must short-circuit on !subscribe");
+    }
+
+    // ── Relay driver source-scrape tests (#3883) ─────────────────────────────
+    //
+    // These tests validate the structural invariants of the relay GET driver
+    // without requiring a full simulation harness.  They mirror the pattern
+    // established by the client driver tests above.
+
+    /// T1: HTL=0 short-circuit must send NotFound upstream without entering
+    /// the retry loop.  The source must contain the htl==0 guard BEFORE the
+    /// first `relay_advance_to_next_peer` call.
+    #[test]
+    fn relay_driver_htl_zero_guard_precedes_retry_loop() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let htl_guard = body
+            .find("if htl == 0")
+            .expect("drive_relay_get_inner must have an `if htl == 0` guard");
+        let retry_loop = body
+            .find("relay_advance_to_next_peer")
+            .expect("drive_relay_get_inner must call relay_advance_to_next_peer");
+        assert!(
+            htl_guard < retry_loop,
+            "HTL=0 guard must appear BEFORE the retry loop; \
+             otherwise HTL exhaustion enters the retry loop and forwards unnecessarily"
+        );
+    }
+
+    /// T2: Local cache short-circuit must send Found upstream without entering
+    /// the retry loop.  The source must contain the local-cache check BEFORE
+    /// `relay_advance_to_next_peer` and AFTER the HTL guard.
+    #[test]
+    fn relay_driver_local_cache_check_precedes_retry_loop() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let local_check = body
+            .find("check_local_with_interest_gate")
+            .expect("drive_relay_get_inner must call check_local_with_interest_gate");
+        let retry_loop = body
+            .find("relay_advance_to_next_peer")
+            .expect("drive_relay_get_inner must call relay_advance_to_next_peer");
+        assert!(
+            local_check < retry_loop,
+            "Local-cache check must appear BEFORE the retry loop; \
+             otherwise a hosting relay forwards instead of answering immediately"
+        );
+    }
+
+    /// T3: Interest gate in `check_local_with_interest_gate` — stale cache
+    /// (no local interest) must NOT return a local_value (must go to fallback).
+    #[test]
+    fn check_local_with_interest_gate_has_interest_check() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn check_local_with_interest_gate(");
+        assert!(
+            body.contains("has_local_interest"),
+            "check_local_with_interest_gate must call `has_local_interest` to gate \
+             whether stale cache is served immediately or deferred to network"
+        );
+        // The stale-cache branch must put the value into the fallback slot,
+        // not into local_value.
+        assert!(
+            body.contains("None, Some("),
+            "check_local_with_interest_gate must return (None, Some(fallback)) \
+             when there is local state but no active interest"
+        );
+    }
+
+    /// T4: Downstream `Response{Found}` must call `cache_contract_locally`
+    /// before calling `relay_send_found`.  Ensures relay opportunistically
+    /// caches contract code.
+    #[test]
+    fn relay_driver_caches_locally_on_found_response() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        // Find the InlineFound arm inside the loop.
+        let found_arm = body
+            .find("Terminal::InlineFound {")
+            .expect("drive_relay_get_inner must handle Terminal::InlineFound");
+        let tail = &body[found_arm..];
+        // Find cache and send in order within the arm.
+        let cache_pos = tail.find("cache_contract_locally").unwrap_or(usize::MAX);
+        let send_pos = tail.find("relay_send_found").unwrap_or(usize::MAX);
+        assert!(
+            cache_pos < send_pos,
+            "cache_contract_locally must be called BEFORE relay_send_found \
+             in the InlineFound arm — the relay must cache the contract before \
+             bubbling the response upstream"
+        );
+    }
+
+    /// T5: Exhaustion path must send NotFound upstream.
+    #[test]
+    fn relay_driver_exhaustion_sends_not_found_upstream() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        // Find the exhaustion branch (None arm of relay_advance_to_next_peer).
+        assert!(
+            body.contains("relay_send_not_found"),
+            "drive_relay_get_inner must call `relay_send_not_found` on exhaustion"
+        );
+    }
+
+    /// T6: ForwardingAck must be sent BEFORE the downstream `send_to_and_await`
+    /// call.  The source must contain `relay_send_forwarding_ack` before
+    /// `send_to_and_await` in the loop body.
+    #[test]
+    fn relay_driver_forwarding_ack_sent_before_downstream_request() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let ack_pos = body
+            .find("relay_send_forwarding_ack")
+            .expect("drive_relay_get_inner must call relay_send_forwarding_ack");
+        let send_pos = body
+            .find("send_to_and_await")
+            .expect("drive_relay_get_inner must call send_to_and_await");
+        assert!(
+            ack_pos < send_pos,
+            "relay_send_forwarding_ack must be called BEFORE send_to_and_await \
+             (ForwardingAck timing: upstream must extend its timer before we \
+             fire the downstream request)"
+        );
+    }
+
+    /// T7: `relay_advance_to_next_peer` must respect incoming `VisitedPeers`
+    /// by using the bloom filter as the skip list for `k_closest_potentially_hosting`.
+    #[test]
+    fn relay_advance_uses_visited_bloom_filter_as_skip_list() {
+        let src = production_source();
+        let body = extract_fn_body(src, "fn relay_advance_to_next_peer(");
+        assert!(
+            body.contains("k_closest_potentially_hosting"),
+            "relay_advance_to_next_peer must use k_closest_potentially_hosting"
+        );
+        assert!(
+            body.contains("new_visited"),
+            "relay_advance_to_next_peer must pass new_visited as the skip list \
+             so the upstream's VisitedPeers is respected"
+        );
+    }
+
+    /// T8: Classify reuse — relay driver must call `classify` (the same
+    /// function the client driver uses) for reply classification.
+    #[test]
+    fn relay_driver_reuses_classify_function() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        assert!(
+            body.contains("classify(reply)"),
+            "drive_relay_get_inner must call `classify(reply)` to classify \
+             downstream replies — reusing the client driver's classify avoids \
+             duplicate terminal-variant handling"
+        );
+    }
+
+    /// T9: start_relay_get is pub(crate) and dead code until commit 2.
+    /// Source-scrape verifies the #[allow(dead_code)] attribute is present
+    /// so the compiler doesn't warn about the intentionally-dead driver.
+    #[test]
+    fn relay_entry_point_annotated_dead_code_for_commit1() {
+        let src = production_source();
+        // Find start_relay_get and check that dead_code allow is near it.
+        let fn_start = src
+            .find("pub(crate) async fn start_relay_get(")
+            .expect("start_relay_get must exist");
+        // Look in the 500 chars before the fn signature for the attribute.
+        let window_start = fn_start.saturating_sub(500);
+        let window = &src[window_start..fn_start];
+        assert!(
+            window.contains("dead_code"),
+            "start_relay_get must be annotated with #[allow(dead_code)] in commit 1 \
+             to suppress the compiler warning for the intentionally-dead driver"
+        );
     }
 }

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -274,7 +274,14 @@ async fn drive_client_get_inner(
                     state,
                     contract,
                 } => {
-                    cache_contract_locally(op_manager, *key, state.clone(), contract.clone()).await;
+                    cache_contract_locally(
+                        op_manager,
+                        *key,
+                        state.clone(),
+                        contract.clone(),
+                        true, // client driver: this node initiated the GET
+                    )
+                    .await;
                     *key
                 }
                 Terminal::Streaming {
@@ -651,21 +658,33 @@ fn synthetic_key(instance_id: &ContractInstanceId) -> ContractKey {
 ///    state, skip `PutQuery` entirely so contracts that enforce
 ///    identical-state rejection in `update_state()` aren't invoked
 ///    redundantly.
-/// 2. **Unconditional hosting refresh** — `record_get_access`,
-///    `mark_local_client_access`, and interest-manager eviction
-///    cleanup run for BOTH the state-matches short-circuit AND the
-///    PutQuery-failed error paths. Legacy behaviour at
-///    `get.rs:2420-2435` continues these side effects on error so
-///    re-GETs keep refreshing the hosting LRU/TTL even when the
-///    executor rejected the write.
-/// 3. **Newly-hosted announcement** — only runs when the local
+/// 2. **Unconditional hosting refresh** — `record_get_access` and
+///    interest-manager eviction cleanup run for BOTH the
+///    state-matches short-circuit AND the PutQuery-failed error paths.
+///    Legacy behaviour at `get.rs:2420-2435` continues these side
+///    effects on error so re-GETs keep refreshing the hosting LRU/TTL
+///    even when the executor rejected the write.
+/// 3. **`mark_local_client_access` gated on `is_client_requester`** —
+///    the sticky flag that moves the contract into the
+///    `contracts_needing_renewal()` set (see `ring/hosting.rs:889`) must
+///    only fire when THIS node is the client-originating requester.
+///    Relay peers that merely cache a forwarded Found MUST NOT set it,
+///    or they permanently pay subscription-renewal cost for contracts
+///    no client on this node ever asked for. Legacy mirror:
+///    `get.rs:2260-2262, :2353-2355, :3056-3058`
+///    all gate the call on `is_original_requester =
+///    upstream_addr.is_none()`.
+/// 4. **Newly-hosted announcement** — only runs when the local
 ///    store actually transitioned from no-state to has-state
-///    (i.e., `access_result.is_new && put_persisted`).
+///    (i.e., `access_result.is_new && put_persisted`). NOT gated on
+///    `is_client_requester`; legacy announces on any first-time relay
+///    cache too (`get.rs:2278, 2370`).
 async fn cache_contract_locally(
     op_manager: &OpManager,
     key: ContractKey,
     state: WrappedState,
     contract: Option<ContractContainer>,
+    is_client_requester: bool,
 ) {
     let state_size = state.size() as u64;
 
@@ -757,7 +776,14 @@ async fn cache_contract_locally(
     // successful wire-level GET must refresh the hosting LRU/TTL
     // regardless of what the local executor did with the state.
     let access_result = op_manager.ring.record_get_access(key, state_size);
-    op_manager.ring.mark_local_client_access(&key);
+    // Sticky flag gating subscription renewal; only the client-originating
+    // node sets it. Relays that pass through a Found MUST NOT taint their
+    // own hosting cache with another node's client access. Legacy mirror:
+    // get.rs:2260-2262 / :2353-2355 / :3056-3058 all guard on
+    // `is_original_requester = upstream_addr.is_none()`.
+    if is_client_requester {
+        op_manager.ring.mark_local_client_access(&key);
+    }
 
     let mut removed_contracts = Vec::new();
     for evicted_key in &access_result.evicted {
@@ -851,7 +877,11 @@ async fn assemble_and_cache_stream(
         None
     };
 
-    cache_contract_locally(op_manager, payload.key, state, contract).await;
+    // Streaming assembly is reachable only from the client-driver side (the
+    // relay driver does not claim streams — port plan §7). The originator
+    // IS the client requester, so the sticky `local_client_access` flag
+    // applies.
+    cache_contract_locally(op_manager, payload.key, state, contract, true).await;
     Ok(())
 }
 
@@ -1414,7 +1444,11 @@ async fn drive_relay_get_inner(
         }
 
         // Cache locally first (relay already hosting, idempotent).
-        cache_contract_locally(op_manager, key, state.clone(), contract.clone()).await;
+        // `is_client_requester=false`: relay peers must not set the sticky
+        // `local_client_access` flag — that's exclusively for the client-
+        // originating node. Legacy mirror: `get.rs:2260-2262` gates on
+        // `is_original_requester`.
+        cache_contract_locally(op_manager, key, state.clone(), contract.clone(), false).await;
 
         relay_send_found(
             op_manager,
@@ -1462,7 +1496,10 @@ async fn drive_relay_get_inner(
                         contract = %key,
                         "GET relay (task-per-tx): all peers exhausted — serving local fallback"
                     );
-                    cache_contract_locally(op_manager, key, state.clone(), contract.clone()).await;
+                    // Relay path: is_client_requester=false (see top-of-loop
+                    // rationale).
+                    cache_contract_locally(op_manager, key, state.clone(), contract.clone(), false)
+                        .await;
                     relay_send_found(
                         op_manager,
                         incoming_tx,
@@ -1592,11 +1629,17 @@ async fn drive_relay_get_inner(
                     "GET relay (task-per-tx): downstream returned Found — caching locally and bubbling upstream"
                 );
 
-                // Cache locally (relay opportunistically caches; side
-                // effects like `announce_contract_hosted` are skipped
-                // since relay is not the originator — `cache_contract_locally`
-                // handles the hosting LRU / interest manager for relay nodes).
-                cache_contract_locally(op_manager, key, state.clone(), contract.clone()).await;
+                // Cache locally (relay opportunistically caches forwarded
+                // Found payloads). `is_client_requester=false` so this node
+                // does NOT set `mark_local_client_access` — the sticky flag
+                // belongs to the upstream client-originating node, not a
+                // forwarder. `announce_contract_hosted` DOES fire when
+                // `access_result.is_new && put_persisted` so first-time
+                // hosting at a relay is still broadcast (matches legacy
+                // `get.rs:2370` which announces on any first-time relay
+                // cache).
+                cache_contract_locally(op_manager, key, state.clone(), contract.clone(), false)
+                    .await;
 
                 // Bubble up to upstream.
                 relay_send_found(
@@ -1845,10 +1888,7 @@ mod tests {
             .find("#[cfg(test)]")
             .expect("file must have a #[cfg(test)] section");
         // The str literal outlives `cutoff`; slicing gives a &'static str.
-        #[allow(clippy::manual_unwrap_or_default)]
-        {
-            &FULL[..cutoff]
-        }
+        &FULL[..cutoff]
     }
 
     /// Isolate the body of a named function inside production source.
@@ -2913,6 +2953,196 @@ mod tests {
                 && !block.contains("has_get_op(contract_id)"),
             "Dispatch block must not gate on contract key (per-key dedup). \
              Found a suspicious has_get_op variant: {block}"
+        );
+    }
+
+    // ── C1: cache_contract_locally must gate mark_local_client_access ──────
+
+    /// Regression guard for the relay hosting-cache taint bug caught in
+    /// PR #3896 review. The legacy GET branch gates `mark_local_client_access`
+    /// on `is_original_requester = upstream_addr.is_none()` (see
+    /// `get.rs:2260-2262, :2353-2355, :3056-3058`). The task-per-tx driver
+    /// MUST respect that gate: relay peers that merely cache a forwarded
+    /// Found must NOT set the sticky `local_client_access` flag, or they
+    /// permanently pay subscription-renewal cost for contracts no client
+    /// on the relay node ever asked for.
+    ///
+    /// Source-scrape invariant: `cache_contract_locally` must accept an
+    /// `is_client_requester: bool` parameter and gate the
+    /// `mark_local_client_access` call on it.
+    #[test]
+    fn cache_contract_locally_gates_mark_local_client_access_on_requester() {
+        let src = production_source();
+        // Function signature must carry the new parameter.
+        let sig_start = src
+            .find("async fn cache_contract_locally(")
+            .expect("cache_contract_locally must exist");
+        let sig_window = &src[sig_start..(sig_start + 400).min(src.len())];
+        assert!(
+            sig_window.contains("is_client_requester: bool"),
+            "`cache_contract_locally` must accept `is_client_requester: bool` \
+             so relay callsites can opt out of the sticky local_client_access \
+             flag. Sig window: {sig_window}"
+        );
+        // Body must gate `mark_local_client_access` on the flag.
+        let body = extract_fn_body(src, "async fn cache_contract_locally(");
+        let gate_pos = body
+            .find("if is_client_requester {")
+            .expect("mark_local_client_access must be gated on is_client_requester");
+        let mark_pos = body
+            .find("mark_local_client_access")
+            .expect("mark_local_client_access must still be called under the gate");
+        assert!(
+            gate_pos < mark_pos,
+            "`if is_client_requester {{` must precede the \
+             `mark_local_client_access` call; otherwise the gate is \
+             structurally useless."
+        );
+        // Negative check: there must be NO unconditional (unguarded) call.
+        let guarded_snippet =
+            "if is_client_requester {\n        op_manager.ring.mark_local_client_access";
+        assert!(
+            body.contains(guarded_snippet),
+            "The `mark_local_client_access` call must be directly inside the \
+             `if is_client_requester {{ ... }}` block. Current body structure \
+             may have split the guard from the call.\n{body}"
+        );
+    }
+
+    /// All three relay-driver callsites must pass `false`.
+    /// Relay caches forwarded Found payloads but MUST NOT flag them as
+    /// client-accessed on the relay's own hosting cache. There are three
+    /// relay callsites in `drive_relay_get_inner`:
+    ///   1. Active-interest local Found (R4, immediate serve)
+    ///   2. Exhaustion fallback (R10, stale local state)
+    ///   3. Downstream Found bubble-up (R12a, forwarded payload)
+    #[test]
+    fn all_relay_callsites_pass_is_client_requester_false() {
+        let src = production_source();
+        let body = extract_fn_body(src, "async fn drive_relay_get_inner(");
+        let callsites: Vec<usize> = body
+            .match_indices("cache_contract_locally(")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            callsites.len(),
+            3,
+            "drive_relay_get_inner should have exactly three \
+             cache_contract_locally callsites (R4 immediate, R10 fallback, \
+             R12a bubble-up). Found {} — a refactor has changed the shape.",
+            callsites.len(),
+        );
+        // Each callsite must terminate with `, false)` (the
+        // `is_client_requester` argument). The body contains non-ASCII
+        // comment decorations, so walk by char rather than by byte to avoid
+        // slicing on a multi-byte boundary.
+        for (idx, &pos) in callsites.iter().enumerate() {
+            let tail = &body[pos..];
+            // End-of-args: first matching closing `)` at depth 0.
+            let mut depth: i32 = 0;
+            let mut end: Option<usize> = None;
+            for (i, c) in tail.char_indices() {
+                match c {
+                    '(' => depth += 1,
+                    ')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = Some(i);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let end = end.unwrap_or_else(|| {
+                panic!("unterminated cache_contract_locally call at relay callsite #{idx}")
+            });
+            let call = &tail[..=end];
+            // The last argument must be `false`. Normalize whitespace.
+            let normalized: String = call.chars().filter(|c| !c.is_whitespace()).collect();
+            assert!(
+                normalized.ends_with("false,).await") || normalized.ends_with("false)"),
+                "Relay callsite #{idx} of cache_contract_locally must pass \
+                 `false` for is_client_requester (relay is not the client). \
+                 Call text: {call}"
+            );
+        }
+    }
+
+    /// The `client_driver`-side callsite (drive_client_get_inner's
+    /// InlineFound arm) must pass `true`. Streaming assembly
+    /// (`assemble_and_cache_stream`) also must pass `true` — the stream
+    /// is only claimed by the client driver.
+    #[test]
+    fn client_driver_and_streaming_callsites_pass_is_client_requester_true() {
+        let src = production_source();
+        // Client driver InlineFound arm.
+        let drive_body = extract_fn_body(src, "async fn drive_client_get_inner(");
+        let drive_call_pos = drive_body
+            .find("cache_contract_locally(")
+            .expect("client driver must cache_contract_locally on InlineFound");
+        let drive_window =
+            &drive_body[drive_call_pos..(drive_call_pos + 400).min(drive_body.len())];
+        let drive_normalized: String = drive_window
+            .chars()
+            .take_while(|&c| c != ';')
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        assert!(
+            drive_normalized.contains("true"),
+            "Client driver's cache_contract_locally call must pass `true` for \
+             is_client_requester (this node initiated the GET). Call window: \
+             {drive_window}"
+        );
+        // Streaming assembly.
+        let stream_body = extract_fn_body(src, "async fn assemble_and_cache_stream(");
+        let stream_call_pos = stream_body
+            .find("cache_contract_locally(")
+            .expect("assemble_and_cache_stream must cache_contract_locally");
+        let stream_window =
+            &stream_body[stream_call_pos..(stream_call_pos + 400).min(stream_body.len())];
+        let stream_normalized: String = stream_window
+            .chars()
+            .take_while(|&c| c != ';')
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        assert!(
+            stream_normalized.contains("true"),
+            "assemble_and_cache_stream must pass `true` for is_client_requester \
+             (stream is only claimed by the client-originating driver). Call \
+             window: {stream_window}"
+        );
+    }
+
+    /// Docstring-level guard: the legacy-mirror references in
+    /// `cache_contract_locally`'s docstring (`get.rs:2260-2262, :2353-2355,
+    /// :3056-3058`) name the three legacy sites where the
+    /// `is_original_requester` gate lives. If those line numbers ever stop
+    /// referring to `mark_local_client_access` call sites, the docstring
+    /// has rotted and future maintenance may miss the invariant.
+    ///
+    /// This test anchors on the function-name reference rather than the
+    /// line numbers themselves (line numbers drift on unrelated edits) —
+    /// it just verifies the docstring still cites the function by name so
+    /// readers can grep for it.
+    #[test]
+    fn cache_contract_locally_docstring_cites_legacy_mirror() {
+        let src = production_source();
+        let fn_pos = src
+            .find("async fn cache_contract_locally(")
+            .expect("cache_contract_locally must exist");
+        // Look in the 1500 chars before the fn for the docstring.
+        let window_start = fn_pos.saturating_sub(1500);
+        let window = &src[window_start..fn_pos];
+        assert!(
+            window.contains("is_client_requester"),
+            "cache_contract_locally docstring must describe the \
+             is_client_requester parameter so callers know which value to pass."
+        );
+        assert!(
+            window.contains("mark_local_client_access"),
+            "cache_contract_locally docstring must name the legacy call \
+             (`mark_local_client_access`) it gates on is_client_requester."
         );
     }
 

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -95,6 +95,25 @@ pub static DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
 pub static RELAY_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
+/// Number of relay-GET driver tasks currently executing. Incremented
+/// on spawn, decremented on completion (both success and error paths).
+/// Surfaced via the periodic `memory_stats` dump so we can correlate
+/// RSS growth with spawn/complete rate and rule in/out a spawn storm
+/// vs. per-task memory bloat as the cause of phase-5 OOMs.
+pub static RELAY_INFLIGHT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Lifetime count of relay-GET driver spawns. Paired with
+/// `RELAY_COMPLETED_TOTAL` so the `memory_stats` dump can show whether
+/// spawn rate exceeds completion rate (drivers stuck in retry loops)
+/// vs. balanced (per-task bloat is the culprit).
+pub static RELAY_SPAWNED_TOTAL: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Lifetime count of relay-GET driver completions. See
+/// `RELAY_SPAWNED_TOTAL`.
+pub static RELAY_COMPLETED_TOTAL: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 /// Start a client-initiated GET, returning as soon as the task has been
 /// spawned (mirrors legacy `request_get` timing).
 ///
@@ -1082,6 +1101,19 @@ pub(crate) async fn start_relay_get(
     Ok(())
 }
 
+/// RAII guard that decrements `RELAY_INFLIGHT` and bumps
+/// `RELAY_COMPLETED_TOTAL` on drop. Using a guard (vs. matching every
+/// exit path) keeps the counter correct under panics and early
+/// returns so the memory_stats dump always reflects true steady-state.
+struct RelayInflightGuard;
+
+impl Drop for RelayInflightGuard {
+    fn drop(&mut self) {
+        RELAY_INFLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        RELAY_COMPLETED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_relay_get(
     op_manager: Arc<OpManager>,
@@ -1093,6 +1125,10 @@ async fn run_relay_get(
     fetch_contract: bool,
     subscribe: bool,
 ) {
+    RELAY_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RELAY_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let _guard = RelayInflightGuard;
+
     if let Err(err) = drive_relay_get(
         &op_manager,
         incoming_tx,

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1308,7 +1308,17 @@ fn relay_advance_to_next_peer(
     retries: &mut usize,
     new_visited: &VisitedPeers,
 ) -> Option<(PeerKeyLocation, SocketAddr)> {
-    const MAX_RELAY_RETRIES: usize = 3;
+    // Legacy relay does NOT retry alternative peers at each hop — it
+    // forwards once and bubbles back whatever downstream returned. The
+    // phase-5 task-per-tx migration introduced a 3-peer retry loop here
+    // that compounded fan-out to 3^HTL per origination under virtual
+    // time (ci-fault-loss run 24602255580 showed 16.9M spawns in 95s
+    // with single-use tx reuse still in place). Cap at 1 to match
+    // legacy semantics exactly. If downstream fails, we bubble
+    // NotFound to upstream and let the originator's client driver
+    // handle cross-peer retries (which IS legitimate in
+    // `drive_client_get_inner`'s retry loop).
+    const MAX_RELAY_RETRIES: usize = 1;
     if *retries >= MAX_RELAY_RETRIES {
         return None;
     }

--- a/crates/core/src/operations/get/op_ctx_task.rs
+++ b/crates/core/src/operations/get/op_ctx_task.rs
@@ -1184,6 +1184,24 @@ async fn run_relay_get(
             "GET relay (task-per-tx): infrastructure error in driver"
         );
     }
+
+    // Release the per-tx `pending_op_results` slot at driver exit.
+    // `relay_send_found` / `relay_send_not_found` / the send_to_and_await
+    // in the retry loop all leave `pending_op_results[incoming_tx]`
+    // populated with an is_closed sender that would only be reclaimed
+    // by the 60s periodic sweep; sending `TransactionCompleted` now
+    // removes the entry immediately so `test_pending_op_results_bounded`
+    // stays under its leak ceiling.
+    //
+    // Yield first so any in-flight `send_fire_and_forget` has time to
+    // run through the event loop's `handle_op_execution` and actually
+    // INSERT into `pending_op_results`. `release_pending_op_slot` uses
+    // the higher-priority notification channel, so without the yield
+    // the TransactionCompleted arrives before the insert and the
+    // cleanup is a no-op (per the caveat in `OpCtx::send_fire_and_forget`
+    // docs).
+    tokio::task::yield_now().await;
+    op_manager.release_pending_op_slot(incoming_tx).await;
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -409,12 +409,23 @@ impl Operation for PutOp {
                 })
             }
             Err(err) => {
-                tracing::error!(
-                    tx = %tx,
-                    error = %err,
-                    phase = "load_or_init",
-                    "Error popping operation"
-                );
+                // Already-completed is a benign race under task-per-tx retries
+                // (multiple NotFound retries against the same tx routinely hit
+                // it). Logging at ERROR here was producing 350k+ events/sec in
+                // ci-fault-loss, enough allocator churn to OOM the runner.
+                // Running is also expected (another task is mid-process).
+                // Keep ERROR for genuinely unexpected failures only.
+                match &err {
+                    crate::node::OpNotAvailable::Completed
+                    | crate::node::OpNotAvailable::Running => {
+                        tracing::debug!(
+                            tx = %tx,
+                            error = %err,
+                            phase = "load_or_init",
+                            "pop returned expected not-available state"
+                        );
+                    }
+                }
                 Err(err.into())
             }
         }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -7411,16 +7411,29 @@ fn test_get_succeeds_despite_readiness_gating() {
 ///
 #[test_log::test]
 fn test_get_routing_coverage_low_htl() {
-    use freenet::dev_tool::{NodeLabel, ScheduledOperation, SimOperation, register_crdt_contract};
+    use std::sync::atomic::Ordering;
+
+    use freenet::dev_tool::{
+        GET_RELAY_DRIVER_CALL_COUNT, NodeLabel, ScheduledOperation, SimOperation,
+        register_crdt_contract,
+    };
 
     // Seed updated: per-peer acceptor reliability scoring replaces binary
     // exclusion (PR #3659), changing the CONNECT routing code path and
-    // Turmoil scheduling. Previous seed: 0xC0DE_B0CA_0031 (PR #3621).
+    // Turmoil scheduling. Previous seed: 0xC0DE_B0CA_0032 (PR #3621).
     const SEED: u64 = 0xC0DE_B0CA_0032;
     const NETWORK_NAME: &str = "get-routing-coverage";
 
     GlobalTestMetrics::reset();
     setup_deterministic_state(SEED);
+
+    // Baseline the relay driver counter so we can assert that the
+    // dispatch gate in handle_pure_network_message_v1 actually routed
+    // relay hops through the task-per-tx driver (not the legacy
+    // handle_op_request fallthrough). This is the behavioral companion
+    // to the source-scrape tests in op_ctx_task.rs that only pin the
+    // dispatch-block SHAPE. #1454 phase 5 / #3883.
+    let relay_baseline = GET_RELAY_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
 
     let rt = create_runtime();
 
@@ -7524,6 +7537,24 @@ fn test_get_routing_coverage_low_htl() {
         nodes_without_state
     );
 
+    // Behavioral companion to the dispatch-gate source-scrape tests in
+    // op_ctx_task.rs: prove the relay task-per-tx driver actually ran
+    // on at least one intermediate hop during the 15-node / HTL=3 /
+    // 15 parallel GETs workload. If this assertion ever starts failing,
+    // something has silently regressed the dispatch split in
+    // handle_pure_network_message_v1 — inbound relay Requests are going
+    // through the legacy handle_op_request path again. #1454 phase 5 / #3883.
+    let relay_after = GET_RELAY_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
+    let relay_delta = relay_after.saturating_sub(relay_baseline);
+    assert!(
+        relay_delta > 0,
+        "RELAY_DRIVER_CALL_COUNT did not advance during the test — the \
+         relay task-per-tx driver never ran. With {num_nodes} nodes, HTL=3, \
+         and ~5 caching nodes, every non-caching requester should hit at \
+         least one relay hop. Dispatch gate in \
+         handle_pure_network_message_v1 has likely regressed. Baseline: {relay_baseline}, after: {relay_after}."
+    );
+
     // StateVerifier anomaly check
     let rt = create_runtime();
     let report = rt.block_on(async {
@@ -7532,9 +7563,10 @@ fn test_get_routing_coverage_low_htl() {
         verifier.verify()
     });
     tracing::info!(
-        "test_get_routing_coverage_low_htl PASSED: {} anomalies, {} events",
+        "test_get_routing_coverage_low_htl PASSED: {} anomalies, {} events, \
+         relay_driver_calls={relay_delta}",
         report.anomalies.len(),
-        report.total_events
+        report.total_events,
     );
 }
 

--- a/docs/port-plans/3883-relay-get-task-per-tx.md
+++ b/docs/port-plans/3883-relay-get-task-per-tx.md
@@ -1,0 +1,365 @@
+# Relay GET → task-per-tx port plan (#3883, #1454 phase 5)
+
+**Branch:** `issue-3883-relay-get-task` (rebased on origin/main @ `c3413946`)
+**Baseline:** phases 2b (SUBSCRIBE), 3a (PUT client), 3b (GET client), 3c
+(decouple SubOperationTracker), 4 (UPDATE client) all merged.
+
+## 1. Problem statement
+
+Today the **client-initiated** GET at an originator node is driven by
+`operations/get/op_ctx_task.rs::drive_client_get_inner` (phase 3b). But
+every **relay hop** that receives a `GetMsg::Request` on the wire still
+hits the legacy path:
+
+```
+node.rs:1073  NetMessageV1::Get
+  → handle_op_request::<get::GetOp, _>        (when not a terminal reply
+                                               for an active client driver)
+    → Op::process_message                     (get.rs ~line 1210)
+      → match GetMsg { Request | Response{Found} | Response{NotFound}
+                     | ResponseStreaming | ForwardingAck | ... }
+```
+
+The relay state (candidate list, HTL, upstream_addr, retry attempts,
+sub-operation tracking) lives in a `GetOp` stored in `OpManager.ops.get`.
+That `GetOp` is indexed by transaction ID and mutated by each incoming
+`GetMsg` through the `process_message` re-entry loop — the same pattern
+the task-per-tx refactor is eliminating.
+
+**Scope of this port:** migrate the relay-hop side of GET to a
+task-per-tx driver so that a relay that receives `GetMsg::Request` spawns
+a driver which owns routing / forwarding / NotFound-retry / Found-
+response-bubble-up in task locals, with **no `GetOp` in `OpManager.ops.get`
+for any relay hop of the transaction**.
+
+## 2. Architectural insight (end-to-end trace complete)
+
+Traced the originator loop-back path end-to-end. Findings:
+
+**Loop-back mechanism (phase-3b client driver):**
+1. `drive_client_get_inner` calls `send_and_await(Request, target=None)`
+   (`get/op_ctx_task.rs:535-544` builds the Request; `op_ctx.rs:155-156`
+   passes `target_addr=None`).
+2. `handle_op_execution` (`p2p_protoc.rs:3870-3891`): `None` target →
+   `ConnEvent::InboundMessage(msg)` — a pure local loop-back, no wire I/O.
+3. `handle_inbound_message` → `process_message_decoupled` →
+   `handle_pure_network_message_v1` with `source_addr=None`.
+4. `NetMessageV1::Get(Request)` bypass filter at `node.rs:1082-1091`
+   skips (Request not terminal) → `handle_op_request::<GetOp>` at
+   line 1093.
+5. `GetOp::load_or_init` (`get.rs:1170-1203`): no existing op for this
+   tx, message is `Request` not `Response`, so creates a **fresh GetOp**
+   with `GetState::ReceivedRequest` and `upstream_addr=None`. This is
+   identical to the real-relay entry with `source_addr=peer_addr`,
+   except `upstream_addr` is `None`.
+6. `GetOp::process_message(Request)` runs the relay state machine:
+   HTL check, local-cache lookup (`get.rs:1366-1428`). Cache hit →
+   returns `Ok(Some(op))` with `OperationResult { return_msg: None, ... }`
+   → `is_operation_completed` true →
+   `forward_pending_op_result_if_completed` (`node.rs:1102-1106`) echoes
+   the **original Request** into the driver's `pending_op_results`
+   callback.
+7. Driver's `classify` (`get/op_ctx_task.rs:505-507`) matches
+   `GetMsg::Request` → `Terminal::LocalCompletion` → driver assembles
+   HostResponse from local store.
+
+**Key discovery:** originator loop-back IS a relay call with
+`source_addr=None`. The same code path that handles true relay handles
+loop-back, distinguished only by `upstream_addr=None`.
+
+**Consequence for this port:**
+
+  **Option C — dispatch split** is the cleanest fit:
+  - `NetMessageV1::Get(Request)` with `source_addr.is_some()` → new
+    `start_relay_get` task-per-tx driver (true relay case).
+  - `NetMessageV1::Get(Request)` with `source_addr.is_none()` →
+    continue through `handle_op_request` → legacy `process_message`
+    relay arm (originator loop-back only).
+
+This preserves the phase-3b client driver's Request-echo contract
+without any phase-3b changes, and isolates the new driver to the true
+relay case. Commit 4 (dead-code removal) can safely delete only the
+real-relay code paths; the HTL check + local-cache-check branches
+remain live for loop-back but can eventually be inlined into the
+client driver in a follow-up.
+
+Alternative — **Option B** (migrate loop-back into client driver,
+delete legacy `GetMsg::Request` arm entirely) — is strictly cleaner
+long-term but requires rewriting phase 3b's local-completion
+plumbing. Out of scope for this PR.
+
+**This plan uses Option C.**
+
+## 3. Code map — what moves where
+
+### 3.1 Legacy relay code to remove (from `operations/get.rs`)
+
+| Region | Lines (current main) | Role |
+|---|---|---|
+| `GetState::ReceivedRequest` variant + construction | 504, 1316-1325 | Relay entry state |
+| `GetMsg::Request` match arm | 1239-1668 | HTL check, local cache check, forward-or-respond decision |
+| `GetMsg::Response{NotFound}` relay arm | 1672-1799 | Retry to next alternative peer, or upstream NotFound |
+| `GetMsg::Response{Found}` relay arm | 1811-2418 (relay side only — ~1800-2050 approx; originator-side kept) | Cache locally, forward upstream |
+| `GetMsg::ForwardingAck` handling | ~1175 (pattern), send at 1628-1652 | Fire-and-forget ack timing |
+| Relay-side `request_get()` call sites | 184-390 (partial — originator side kept, relay-side forwarding removed) | Initial forward from relay |
+
+(Line numbers to be re-verified before each commit; main moves.)
+
+The originator-path pieces in `operations/get.rs` that phase 3b left
+in place (because `process_message` loop-back uses them for local
+completion) remain. We're not rewriting phase 3b.
+
+### 3.2 New relay driver — `operations/get/op_ctx_task.rs` (same file)
+
+Add a second entry point + driver loop alongside `start_client_get`:
+
+```rust
+pub(crate) async fn start_relay_get(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,                 // reused, not a new tx
+    instance_id: ContractInstanceId,
+    htl: u8,                                   // already-decremented HTL
+    upstream_addr: SocketAddr,                 // who to bubble response to
+    skip_list: VisitedPeers,                   // peers upstream already tried
+    return_contract_code: bool,
+    subscribe: bool,
+) -> Result<(), OpError>
+```
+
+Driver structure mirrors `drive_client_get_inner` (get/op_ctx_task.rs:186-~410)
+but with different terminal semantics:
+
+- **No `HostResult`** (relay doesn't publish to a client).
+- **Terminal Found**: cache locally, send `GetMsg::Response{Found}` upstream,
+  send `ForwardingAck` if required, spawn subscription child-op only if
+  this node was the original requester (it isn't, for relay — so never).
+- **Terminal NotFound after exhaustion**: send `GetMsg::Response{NotFound}`
+  upstream.
+- **Local cache hit at relay entry**: answer immediately without spawning
+  a downstream attempt (preserving today's relay behavior in get.rs:1366-1428).
+
+Reuse infrastructure:
+- `RetryDriver` trait + `drive_retry_loop` from `operations/op_ctx.rs`.
+- `advance_to_next_peer` pattern from `put/op_ctx_task.rs:412` — copy/adapt
+  (peer-type differs: relay has `upstream_addr`, client doesn't).
+
+### 3.3 Dispatch wiring (`node.rs:1073-1134`)
+
+Currently `NetMessageV1::Get(op)` routes any non-terminal message to
+`handle_op_request::<get::GetOp, _>`. Change:
+
+```
+NetMessageV1::Get(op) =>
+  if terminal-for-active-client-driver:
+      try_forward_task_per_tx_reply (existing phase-3b bypass)
+  else if GetMsg::Request && source != self:
+      start_relay_get(...)                    // NEW
+      return Ok(None);
+  else:
+      handle_op_request::<get::GetOp, _>(...) // fallback for
+                                              // originator loop-back,
+                                              // GC-spawned retries,
+                                              // Response/Ack to legacy
+                                              // relay ops still in
+                                              // OpManager during
+                                              // rollout
+```
+
+**Rollout:** no feature flag. Matches phases 3b/4 which shipped the
+behavior change unconditionally. Rollback = revert the PR.
+
+### 3.4 Terminal-reply bypass (originator side)
+
+When the relay driver sends `GetMsg::Response{Found|NotFound}` back to
+the upstream addr, that upstream peer's `node.rs` sees the reply. If
+the upstream is the **originator** running a phase-3b client driver,
+the existing bypass at `node.rs:1082-1091` catches it — no change
+needed. If the upstream is **another relay node still running under
+the new driver**, the reply arrives as a non-terminal message for
+that node's relay driver — the per-tx reply channel established by
+`start_relay_get`'s `send_and_await` call must receive it.
+
+This is the same wiring `OpCtx::send_and_await` already implements for
+phases 2b/3a/3b/4. Reuse without modification.
+
+### 3.5 Auto-subscribe handoff (`operations.rs:637-649`)
+
+`auto_subscribe_on_get_response()` is called from the legacy
+`process_message` Response{Found} branch (get.rs:2306-2320) and is
+gated on `is_original_requester` (get.rs:2258, 2307). Relay nodes
+never satisfy that gate, so the relay driver does **not** need to
+call this helper. The phase-3b client driver (`drive_client_get_inner`)
+already calls it on terminal Found. Leave as-is.
+
+### 3.6 SubOperationTracker (phase 3c)
+
+Phase 3c decoupled drivers from `SubOperationTracker` for SUBSCRIBE,
+PUT, GET. The relay driver inherits that decoupling: it will register
+no sub-operations (the "subscribe-on-get" sub-op is an originator
+concern, not a relay concern).
+
+## 4. Tricky cases & how they're handled
+
+### 4.1 NotFound retry to next hop
+
+Legacy: `GetMsg::Response{NotFound}` at relay mutates `GetOp` to pop
+next candidate from `AwaitingResponseData` and re-forwards.
+
+Driver: same semantics, but candidate list lives in driver locals.
+`advance_to_next_peer` (adapt from PUT) returns either (a) next peer
+to forward to, or (b) `Exhausted` → send NotFound to upstream_addr
+and exit.
+
+### 4.2 ForwardingAck timing
+
+Legacy sends ForwardingAck at `get.rs:1628-1652` **before** forwarding
+the Request to the downstream peer. This is a fire-and-forget signal
+to upstream that "I'm taking responsibility for this hop, don't retry
+me." The driver must preserve this send-before-forward ordering (the
+upstream's retry timer uses ForwardingAck as the signal to extend).
+
+In the driver: after selecting the next peer but before calling
+`send_and_await`, synchronously send ForwardingAck to `upstream_addr`
+via the conn_manager. No await on ack — it's fire-and-forget.
+
+### 4.3 Local cache hit at relay entry
+
+Legacy: `get.rs:1366-1428` — if the relay has the contract state
+locally, it constructs a `GetMsg::Response{Found}` and sends it
+upstream without forwarding. HTL is irrelevant in this case.
+
+Driver: same check at driver entry, before the retry loop. If local
+store has the contract, short-circuit to response assembly + send +
+return.
+
+### 4.4 HTL = 0 handling
+
+Legacy: `get.rs:1291-1325` — HTL exhausted → NotFound to upstream.
+
+Driver: if `htl == 0`, short-circuit to NotFound + send + return.
+(HTL is passed in already decremented by `OpCtx::send_and_await`'s
+wire-layer convention — double-check during implementation.)
+
+### 4.5 Originator loop-back
+
+Phase-3b client driver calls `send_and_await` with a `GetMsg::Request`
+targeting itself for the local-completion cache-hit check
+(`get/op_ctx_task.rs:18-26`). `process_message` today echoes the
+Request as the terminal reply. Under this port, that code path is
+preserved because the dispatch wiring (§3.3) falls through to the
+legacy `handle_op_request` when `source == self`. No change needed.
+
+### 4.6 Streaming payloads
+
+Phase-3b left streamed-payload assembly and caching on the legacy
+path (`operations/get/op_ctx_task.rs:38-42`). Relay-side streaming
+assembly (where a relay forwards `ResponseStreaming` chunks upstream)
+is **out of scope for this port** — it stays on the legacy
+`process_message` path. Dispatch wiring (§3.3) routes
+`GetMsg::ResponseStreaming` and its Ack to `handle_op_request` as
+before. This matches phase-3b's scope boundary and keeps this PR's
+LOC controllable.
+
+Follow-up issue after this PR: migrate streaming-chunk forwarding.
+
+### 4.7 GC-spawned retries & `start_targeted_op`
+
+Per `get/op_ctx_task.rs:10-13`, GC-spawned retries and
+`start_targeted_op()` (UPDATE-triggered auto-fetch) stay on the legacy
+re-entry loop. This port does not change that. They will continue to
+produce `GetOp` entries in `OpManager.ops.get` and flow through
+`handle_op_request`. The dispatch wiring (§3.3) falls through to the
+legacy path whenever the incoming Request's transaction already has a
+`GetOp` registered, so GC-spawned retries keep working.
+
+## 5. Commit split (one PR, three commits)
+
+1. **`refactor(ops): add relay GET task-per-tx driver + helpers (#3883 scaffold)`**
+   Extract HTL-check / local-cache-check / peer-selection subroutines
+   from `GetMsg::Request` arm into free functions, AND add
+   `start_relay_get` + `drive_relay_get_inner` to
+   `operations/get/op_ctx_task.rs`. Driver reuses the extracted
+   helpers. Not yet wired to dispatch. Unit tests for driver using
+   the same `OpCtx` test harness phase 3b used. `cargo test -p freenet`
+   green — driver is dead code in integration tests (only unit tests
+   exercise it).
+
+2. **`refactor(ops): route relay GET requests through task-per-tx driver (#1454 phase 5)`**
+   Switch dispatch in `node.rs:1073-1134` to call `start_relay_get`
+   for relay-hop `GetMsg::Request` when `source_addr.is_some()`.
+   Preserve `source_addr.is_none()` loop-back → legacy `handle_op_request`
+   path (phase-3b client driver contract). Legacy `GetMsg::Request`
+   relay arm in `get.rs` becomes unreachable for true relay. Run
+   relay sim tests:
+   - `test_get_routing_coverage_low_htl`
+   - `test_get_retry_with_alternatives_sparse_topology`
+   - `test_get_reliability_diagnostic`
+   - `test_get_reliability_with_latency`
+   - `test_get_reliability_with_churn`
+
+3. **`refactor(ops): remove dead relay branches from get.rs (#3883 cleanup)`**
+   Delete `GetState::ReceivedRequest`-based code paths and relay arms
+   of `GetMsg::Request/Response{Found}/Response{NotFound}/ForwardingAck`
+   that are unreachable when `source_addr.is_some()`. Keep
+   loop-back-reachable code (local-cache-check branch) intact. Verify
+   nothing else references removed code (grep + compile).
+
+Each commit individually: `cargo fmt && cargo clippy -- -D warnings &&
+cargo test -p freenet` green. Commit 1 is strictly non-behavioral
+(new module + helper extraction). Commit 2 is the behavior flip.
+Commit 3 is unreachable-code removal.
+
+## 6. Validation gates
+
+### 6.1 Per-commit (all four)
+
+```
+cargo fmt
+cargo clippy -- -D warnings
+cargo test -p freenet
+```
+
+### 6.2 Commit 3 (behavior flip) — additional
+
+Integration / sim tests that exercise relay forwarding explicitly:
+- `tests/simulation_integration.rs::test_get_routing_coverage_low_htl`
+- `tests/simulation_integration.rs::test_get_retry_with_alternatives_sparse_topology`
+- `tests/simulation_integration.rs::test_get_reliability_diagnostic`
+- `tests/simulation_integration.rs::test_get_reliability_with_latency`
+- `tests/simulation_integration.rs::test_get_reliability_with_churn`
+
+### 6.3 macOS 127.x.x.x binding
+
+Integration tests that fail on macOS with "Can't assign requested
+address" must be validated via `/linux-test` (Docker). This is a
+known infrastructure blocker from phases 3b/4, not a code issue.
+
+## 7. Out of scope (defer to follow-ups)
+
+- Relay-side streaming-chunk forwarding (§4.6).
+- GC-spawned retry migration (§4.7).
+- `start_targeted_op` (UPDATE-triggered fetch) migration.
+- Removal of `GetState` / `GetOp` entirely (only possible once all
+  the above plus originator loop-back are migrated).
+
+## 8. Risks
+
+- **Thin-driver assumption (§2):** if the phase-3b client driver's
+  loop-back is more tangled with the legacy relay `GetMsg::Request`
+  arm than documented, commit 4's dead-code removal could break the
+  originator's local-completion path. Mitigation: commit 3's dispatch
+  change is gated so legacy path still runs for `source == self`;
+  commit 4 only removes relay-side code, preserving originator arms.
+
+- **ForwardingAck timing (§4.2):** if send-before-forward ordering is
+  violated, upstream peers will prematurely time out and retry,
+  causing duplicate GETs. Tests `test_get_reliability_with_latency`
+  and `test_get_retry_with_alternatives_sparse_topology` will catch
+  this if it regresses.
+
+- **NotFound-retry peer selection (§4.1):** the `VisitedPeers` /
+  `skip_list` semantics must match between relay driver and phase-3b
+  client driver (they share the trait but populate differently). A
+  divergence causes a peer to be re-tried or a valid peer to be
+  skipped. Unit tests in commit 2 must cover skip-list propagation
+  across retry attempts.


### PR DESCRIPTION
## Problem

Issue #3883 tracks the final phase of #1454's async transaction refactor for GET: the relay (non-client-initiated) hop. Before this PR, any peer receiving a `GetMsg::Request` from the wire instantiates a `GetOp` in `OpManager.ops.get` and drives routing/retry/forwarding through the legacy `process_message` re-entry loop. That was the last remaining producer of `GetOp` state for non-loopback traffic.

## Solution

Dispatch split in `handle_pure_network_message_v1`'s `NetMessageV1::Get` branch:

- **Fresh inbound `GetMsg::Request`** with `source_addr.is_some()` AND no existing `GetOp` tracked (checked via new readonly `OpManager::has_get_op`) → spawn `start_relay_get`, a task-per-tx driver that owns routing, NotFound bubble-up, and Found pass-through in its task locals. No `GetOp` inserted. Fire-and-forget: the driver publishes its own upstream response.
- **Fall-through to legacy `handle_op_request`** for:
  - `source_addr.is_none()` (originator loopback from phase-3b client driver's `send_and_await(target=None)` — preserves the Request-echo contract that `drive_client_get_inner::classify` relies on for `Terminal::LocalCompletion`).
  - Existing `GetOp` (GC-spawned retries, `start_targeted_op` UPDATE-triggered auto-fetch).
  - Non-`Request` variants (streaming chunks, acks — streaming-relay migration deferred per port plan §7).

## Behavioral parity with legacy

The driver mirrors legacy relay semantics exactly:

- **No retry-at-relay.** `MAX_RELAY_RETRIES = 1`. Legacy's `process_message::Request` arm forwards once via `k_closest_potentially_hosting(k=1)` and bubbles whatever downstream returned. Cross-peer retries only happen at the originator's client driver, unchanged by this PR.
- **End-to-end tx preservation.** The relay forwards downstream with `id: incoming_tx` (matches legacy). An earlier revision minted a fresh per-attempt tx per retry iteration — that interacted with virtual-time OPERATION_TTL to produce 3^HTL concurrent subtrees (see below).
- **No ForwardingAck emission.** Legacy's ack was a timer-extension signal on the upstream's GC state; the task-per-tx driver holds its own `tokio::time::timeout(OPERATION_TTL, ...)` and doesn't need the extension at hop scale. Reintroducing it would require a distinct ack tx (the reply path already consumes `incoming_tx`'s capacity-1 `pending_op_results` waiter, so ack-via-same-tx collided and triggered retry storms).
- **Per-node dedup.** `OpManager.active_relay_get_txs` (DashSet, RAII-cleared) blocks a second driver spawn for the same `incoming_tx` at the same node. This is the task-per-tx analog of legacy's `OpManager.pop → OpNotAvailable::Running` dedup; without it, retransmissions / routing bloom false-positives would spawn duplicate drivers.

## Memory regression fix (embedded in this PR)

Initial implementation (before the commits above) caused phase-5 ci-fault-loss to peak at **63 GB RSS** (workflow runs 24600168871 / 24600634908 / 24601267577 / 24601908758). Diagnostic counters showed 16.9 M relay spawns in 95 s for a 1000-event sim. Root cause was the compounding of four amplifiers:

1. `MAX_RELAY_RETRIES = 3` at relay hop (never existed in legacy).
2. Fresh `attempt_tx` per retry made downstream see every iteration as a brand-new Request and spawn a fresh subtree.
3. `ForwardingAck` shared tx with the reply, colliding with the capacity-1 waiter and forcing `AttemptOutcome::Unexpected`.
4. Virtual-time OPERATION_TTL collapses 60 s to milliseconds under `tokio::time::pause`, so the three "sequential" retries fired concurrently.

After the fix stack: **peak RSS 2.6 GB, 19 k total relay spawns, sim `rc=0`** (workflow run 24602538340).

## Commits

1. `refactor(ops): add relay GET task-per-tx driver + helpers (#3883 scaffold)` — pure scaffold, dead code, 9 unit tests.
2. `refactor(ops): route relay GET requests through task-per-tx driver (#1454 phase 5)` — dispatch flip, removes dead_code allows, adds `OpManager::has_get_op` + regression guard tests.
3. `test(ops): pin relay GET dispatch gates + behavioral invariants (#3883)` — T1–T9 / R1–R8 structural tests.
4. `fix(ops): gate mark_local_client_access on is_client_requester (#3883)` — relay-path fix to avoid setting the sticky client flag at forwarders.
5. `debug(ops): instrument relay-GET inflight/spawn/complete counters` — telemetry used to diagnose the OOM.
6. `fix(ops): demote put load_or_init error→debug for benign not-available` — hygiene (not the OOM cause).
7. `fix(ops): break phase-5 relay spawn amplification cycle` — ack removal + per-node dedup gate.
8. `fix(ops): reuse incoming_tx across relay-GET forwards (no fresh attempt_tx)` — tx-preservation parity with legacy.
9. `test(ops): update R8 to assert incoming_tx reuse in forwarded Request`.
10. `fix(ops): cap MAX_RELAY_RETRIES=1 to match legacy relay semantics` — the dominant amplifier.
11. `test(ops): narrow ForwardingAck absence check to literal construction`.

## Design docs

- Port plan: [docs/port-plans/3883-relay-get-task-per-tx.md](../blob/issue-3883-relay-get-task/docs/port-plans/3883-relay-get-task-per-tx.md) — end-to-end trace of the originator loopback path locking in the `source_addr`-based dispatch split (§2), commit-split rationale (§5), risk register (§8).

## Testing

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test -p freenet --lib` green (2373 passed, 16 ignored) on single-threaded runs.
- [x] `simulation-debug.yml` ci-fault-loss run 24602538340: peak RSS 2.6 GB, 19 k total relay spawns, `rc=0`, `min_success_rate=0.80` satisfied.
- [x] Full PR CI to confirm parallel-sim load stays under the 16 GB ubicloud-standard-16 ceiling.

## Follow-ups

- Streaming-chunk relay forwarding migration (port plan §7).
- GC-spawned retry + `start_targeted_op` migration (port plan §7).
- Dead-code removal of unreachable branches in `operations/get.rs` once telemetry confirms they no longer fire.
- ForwardingAck timer-extension via a dedicated ack tx (separate from reply waiter) if telemetry shows cross-continent chains exceeding OPERATION_TTL at the relay driver layer.

## Test plan

- [ ] `cargo fmt && cargo clippy --all-targets -- -D warnings` on CI.
- [ ] `cargo test -p freenet --lib` on CI.
- [ ] Sim integration tests on Linux CI (ci-fault-loss, ci-high-latency, ci-churn-20, ci-medium-50 nightly).

Refs: #1454, #3883