### PR TITLE
fix(report): surface WS query failures instead of silent None

### DIFF
--- a/crates/core/src/bin/commands/report.rs
+++ b/crates/core/src/bin/commands/report.rs
@@ -248,6 +248,10 @@ impl ReportCommand {
     /// diagnostics on success, or a human-readable error string on failure
     /// so the report can record *why* the field is missing rather than
     /// silently dropping it.
+    ///
+    /// Worst-case duration is `LOOPBACK_HOSTS.len() * (WS_RETRY_ATTEMPTS + 1) * WS_TIMEOUT_SECS`
+    /// seconds. Prints progress so the user isn't left staring at a blank
+    /// terminal during a degraded-node query.
     fn collect_network_status(&self, config_content: &Option<String>) -> Result<String, String> {
         let ws_port = config_content
             .as_ref()
@@ -257,7 +261,21 @@ impl ReportCommand {
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| format!("failed to create tokio runtime: {e}"))?;
 
-        rt.block_on(query_with_fallback(ws_port, WS_RETRY_ATTEMPTS))
+        let worst_case_secs =
+            LOOPBACK_HOSTS.len() as u64 * (WS_RETRY_ATTEMPTS as u64 + 1) * WS_TIMEOUT_SECS;
+        print!("  Querying local node diagnostics (up to {worst_case_secs}s)... ");
+        io::stdout().flush().ok();
+
+        let result = rt.block_on(query_with_fallback(
+            ws_port,
+            WS_RETRY_ATTEMPTS,
+            StdDuration::from_secs(WS_TIMEOUT_SECS),
+        ));
+        match &result {
+            Ok(_) => println!("ok"),
+            Err(e) => println!("unreachable ({e})"),
+        }
+        result
     }
 
     fn get_user_message(&self) -> Result<Option<String>> {
@@ -663,17 +681,22 @@ fn parse_ws_port_from_config(config: &str) -> Option<u16> {
 ///
 /// Retries are timeout-only: connection-refused errors are reported
 /// immediately since they indicate the node is not running on that host.
-async fn query_with_fallback(port: u16, retry_attempts: u32) -> Result<String, String> {
+///
+/// The `per_attempt_timeout` parameter exists for tests; production callers
+/// pass `Duration::from_secs(WS_TIMEOUT_SECS)`. Worst-case duration is
+/// `LOOPBACK_HOSTS.len() * (retry_attempts + 1) * per_attempt_timeout`.
+async fn query_with_fallback(
+    port: u16,
+    retry_attempts: u32,
+    per_attempt_timeout: StdDuration,
+) -> Result<String, String> {
     let mut errors: Vec<String> = Vec::new();
     let total_attempts = retry_attempts.saturating_add(1);
 
     for host in LOOPBACK_HOSTS {
         for attempt in 0..total_attempts {
-            match tokio::time::timeout(
-                StdDuration::from_secs(WS_TIMEOUT_SECS),
-                query_node_diagnostics(host, port),
-            )
-            .await
+            match tokio::time::timeout(per_attempt_timeout, query_node_diagnostics(host, port))
+                .await
             {
                 Ok(Ok(diag)) => return Ok(diag),
                 Ok(Err(e)) => {
@@ -684,7 +707,8 @@ async fn query_with_fallback(port: u16, retry_attempts: u32) -> Result<String, S
                 }
                 Err(_) => {
                     errors.push(format!(
-                        "{host}:{port}: timed out after {WS_TIMEOUT_SECS}s (attempt {}/{})",
+                        "{host}:{port}: timed out after {:?} (attempt {}/{})",
+                        per_attempt_timeout,
                         attempt + 1,
                         total_attempts
                     ));
@@ -974,6 +998,11 @@ stack backtrace:
         assert_eq!(original_size, panic_content.len() as u64);
     }
 
+    /// Short per-attempt timeout for tests that exercise the timeout path.
+    /// 200ms is long enough to avoid CI flakes but short enough that a
+    /// retry test can run multiple attempts in under a second.
+    const TEST_TIMEOUT: StdDuration = StdDuration::from_millis(200);
+
     /// Regression for issue #3897: when no node is listening, the report must
     /// surface a concrete error instead of silently setting `network_status`
     /// to `None`. Uses a port that nothing is bound to so `connect_async`
@@ -985,7 +1014,7 @@ stack backtrace:
         // explanation and the test is still telling us something useful.
         let port = 59111;
 
-        let result = query_with_fallback(port, 0).await;
+        let result = query_with_fallback(port, 0, TEST_TIMEOUT).await;
 
         let err = result.expect_err("no listener → must return Err, not silent None");
         assert!(
@@ -1017,19 +1046,20 @@ stack backtrace:
         let port = listener.local_addr().unwrap().port();
 
         // Accept the connection but never write any handshake bytes, so
-        // `connect_async` blocks until WS_TIMEOUT_SECS fires. Holding
-        // `_handle` keeps the accept task alive for the duration of the test.
+        // `connect_async` blocks until the per-attempt timeout fires.
+        // Holding `_handle` keeps the accept task alive.
         let _handle = tokio::spawn(async move {
-            let (_stream, _) = listener.accept().await.unwrap();
-            tokio::time::sleep(StdDuration::from_secs(60)).await;
+            loop {
+                let (_stream, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => break,
+                };
+                // Keep the stream alive so the client's handshake hangs.
+                std::mem::forget(_stream);
+            }
         });
 
-        // Outer wrapper bounds total test time: WS_TIMEOUT_SECS (15s) must
-        // fire once on the 127.0.0.1 attempt, so 20s leaves margin without
-        // exceeding CI's default timeouts.
-        let result = tokio::time::timeout(StdDuration::from_secs(20), query_with_fallback(port, 0))
-            .await
-            .expect("test wrapper timed out before WS_TIMEOUT_SECS fired");
+        let result = query_with_fallback(port, 0, TEST_TIMEOUT).await;
 
         let err = result.expect_err("handshake never completes → must return Err");
         assert!(
@@ -1039,6 +1069,57 @@ stack backtrace:
         assert!(
             err.contains(&port.to_string()),
             "error should include the port number, got: {err}"
+        );
+    }
+
+    /// Regression for issue #3897: verify `retry_attempts > 0` actually
+    /// causes a second attempt when the first times out. The production
+    /// config passes `WS_RETRY_ATTEMPTS=1`, so this path must be exercised
+    /// by the test suite.
+    #[tokio::test]
+    async fn test_query_with_fallback_retries_on_timeout() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let accepts = Arc::new(AtomicUsize::new(0));
+        let accepts_clone = accepts.clone();
+
+        // Accept every connection and hang (never complete handshake).
+        let _handle = tokio::spawn(async move {
+            loop {
+                let (_stream, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => break,
+                };
+                accepts_clone.fetch_add(1, Ordering::SeqCst);
+                std::mem::forget(_stream);
+            }
+        });
+
+        // retry_attempts=1 → 2 attempts per host × 1 host that accepts = 2 timeouts.
+        // ([::1] gets connection-refused immediately, not counted in accepts.)
+        let result = query_with_fallback(port, 1, TEST_TIMEOUT).await;
+        assert!(result.is_err());
+
+        // Give the accept task a moment to register both connections.
+        tokio::time::sleep(StdDuration::from_millis(50)).await;
+
+        let total_accepts = accepts.load(Ordering::SeqCst);
+        assert_eq!(
+            total_accepts, 2,
+            "retry_attempts=1 must produce 2 v4 accepts (initial + 1 retry); got {total_accepts}"
+        );
+
+        // Error string must mention both attempts so operators can see the
+        // retry actually happened.
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("attempt 1/2") && err.contains("attempt 2/2"),
+            "error should identify both attempts, got: {err}"
         );
     }
 

--- a/crates/core/src/bin/commands/report.rs
+++ b/crates/core/src/bin/commands/report.rs
@@ -30,8 +30,17 @@ const MAX_TOTAL_LOG_SIZE: usize = 2 * 1024 * 1024;
 const MAX_LINE_LENGTH: usize = 10 * 1024;
 /// Default WebSocket API port
 const DEFAULT_WS_API_PORT: u16 = 7509;
-/// Timeout for WebSocket connection and queries
-const WS_TIMEOUT_SECS: u64 = 5;
+/// Timeout for a single WebSocket connect+query attempt. A struggling node
+/// is exactly the case we most need diagnostics for, so err on the side of
+/// waiting longer rather than dropping the field silently.
+const WS_TIMEOUT_SECS: u64 = 15;
+/// Number of additional retry attempts after the initial query times out.
+/// Connection refused is not retried — that signals the node isn't running.
+const WS_RETRY_ATTEMPTS: u32 = 1;
+/// Loopback hosts to try, in order. Both are attempted so that
+/// `ws-api-address = "::"` combined with `IPV6_V6ONLY=1` (or a v4-only
+/// bind) doesn't silently drop the diagnostics.
+const LOOPBACK_HOSTS: &[&str] = &["127.0.0.1", "[::1]"];
 
 #[derive(Args, Debug, Clone)]
 pub struct ReportCommand {
@@ -64,8 +73,13 @@ pub struct DiagnosticReport {
     pub logs: LogContents,
     /// Config file contents (if available)
     pub config: Option<String>,
-    /// Network status (if node is running)
+    /// Network status (if node is running and responded successfully)
     pub network_status: Option<String>,
+    /// Reason `network_status` is missing (connection refused, timeout, etc.).
+    /// Populated whenever `network_status` is `None`, so the report never
+    /// silently drops the field without telling us why.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_status_error: Option<String>,
     /// User's problem description
     pub user_message: Option<String>,
 }
@@ -165,7 +179,10 @@ impl ReportCommand {
 
         let logs = self.collect_logs(config_dirs.log_dir().map(Path::to_path_buf))?;
         let config = self.collect_config(&config_dirs.config_dir());
-        let network_status = self.collect_network_status(&config);
+        let (network_status, network_status_error) = match self.collect_network_status(&config) {
+            Ok(diag) => (Some(diag), None),
+            Err(e) => (None, Some(e)),
+        };
         let user_message = self.get_user_message()?;
 
         let client_timestamp = chrono::Utc::now().to_rfc3339();
@@ -177,6 +194,7 @@ impl ReportCommand {
             logs,
             config,
             network_status,
+            network_status_error,
             user_message,
         })
     }
@@ -226,33 +244,20 @@ impl ReportCommand {
         None
     }
 
-    fn collect_network_status(&self, config_content: &Option<String>) -> Option<String> {
-        // Try to query the local node's WebSocket API
-        // This is optional - if the node isn't running, we just skip this
-
-        // Parse the WebSocket port from config, or use default
+    /// Query the local node for live diagnostics. Returns the serialized
+    /// diagnostics on success, or a human-readable error string on failure
+    /// so the report can record *why* the field is missing rather than
+    /// silently dropping it.
+    fn collect_network_status(&self, config_content: &Option<String>) -> Result<String, String> {
         let ws_port = config_content
             .as_ref()
             .and_then(|c| parse_ws_port_from_config(c))
             .unwrap_or(DEFAULT_WS_API_PORT);
 
-        // Create a runtime for the async WebSocket query
-        let rt = match tokio::runtime::Runtime::new() {
-            Ok(rt) => rt,
-            Err(_) => return None,
-        };
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(|e| format!("failed to create tokio runtime: {e}"))?;
 
-        rt.block_on(async {
-            match tokio::time::timeout(
-                StdDuration::from_secs(WS_TIMEOUT_SECS),
-                query_node_diagnostics(ws_port),
-            )
-            .await
-            {
-                Ok(Ok(diagnostics)) => Some(diagnostics),
-                Ok(Err(_)) | Err(_) => None,
-            }
-        })
+        rt.block_on(query_with_fallback(ws_port, WS_RETRY_ATTEMPTS))
     }
 
     fn get_user_message(&self) -> Result<Option<String>> {
@@ -335,14 +340,11 @@ impl ReportCommand {
                 "not found"
             }
         );
-        println!(
-            "  - Node status: {}",
-            if report.network_status.is_some() {
-                "running"
-            } else {
-                "not running or unreachable"
-            }
-        );
+        match (&report.network_status, &report.network_status_error) {
+            (Some(_), _) => println!("  - Node status: running"),
+            (None, Some(err)) => println!("  - Node status: unreachable ({err})"),
+            (None, None) => println!("  - Node status: not running or unreachable"),
+        }
     }
 
     fn save_local(&self, report: &DiagnosticReport, path: &PathBuf) -> Result<()> {
@@ -654,9 +656,51 @@ fn parse_ws_port_from_config(config: &str) -> Option<u16> {
     None
 }
 
+/// Attempt the diagnostics query against each loopback host in order, with
+/// a bounded number of retries on timeout. Returns the serialized
+/// diagnostics on success, or a concatenated error string describing every
+/// attempt on failure.
+///
+/// Retries are timeout-only: connection-refused errors are reported
+/// immediately since they indicate the node is not running on that host.
+async fn query_with_fallback(port: u16, retry_attempts: u32) -> Result<String, String> {
+    let mut errors: Vec<String> = Vec::new();
+    let total_attempts = retry_attempts.saturating_add(1);
+
+    for host in LOOPBACK_HOSTS {
+        for attempt in 0..total_attempts {
+            match tokio::time::timeout(
+                StdDuration::from_secs(WS_TIMEOUT_SECS),
+                query_node_diagnostics(host, port),
+            )
+            .await
+            {
+                Ok(Ok(diag)) => return Ok(diag),
+                Ok(Err(e)) => {
+                    // Connection-level failure (refused, no route, etc.).
+                    // Don't retry the same host — the error won't change.
+                    let msg = format!("{host}:{port}: {e:#}");
+                    errors.push(msg);
+                    break;
+                }
+                Err(_) => {
+                    let msg = format!(
+                        "{host}:{port}: timed out after {WS_TIMEOUT_SECS}s (attempt {}/{})",
+                        attempt + 1,
+                        total_attempts
+                    );
+                    errors.push(msg);
+                }
+            }
+        }
+    }
+
+    Err(errors.join("; "))
+}
+
 /// Query the node for diagnostics via WebSocket API.
-async fn query_node_diagnostics(port: u16) -> Result<String> {
-    let url = format!("ws://127.0.0.1:{port}/v1/contract/command?encodingProtocol=native");
+async fn query_node_diagnostics(host: &str, port: u16) -> Result<String> {
+    let url = format!("ws://{host}:{port}/v1/contract/command?encodingProtocol=native");
 
     let (stream, _) = connect_async(&url)
         .await
@@ -766,6 +810,7 @@ mod tests {
             },
             config: None,
             network_status: None,
+            network_status_error: None,
             user_message: Some("Test message".to_string()),
         };
 
@@ -929,6 +974,137 @@ stack backtrace:
             "Backtrace should be preserved"
         );
         assert_eq!(original_size, panic_content.len() as u64);
+    }
+
+    /// Regression for issue #3897: when no node is listening, the report must
+    /// surface a concrete error instead of silently setting `network_status`
+    /// to `None`. Uses a port that nothing is bound to so `connect_async`
+    /// fails with connection-refused.
+    #[tokio::test]
+    async fn test_query_with_fallback_connection_refused_reports_error() {
+        // Pick a port unlikely to have anything listening on loopback.
+        // If this ever flakes, a real listener on that port is the only
+        // explanation and the test is still telling us something useful.
+        let port = 59111;
+
+        let result = query_with_fallback(port, 0).await;
+
+        let err = result.expect_err("no listener → must return Err, not silent None");
+        assert!(
+            err.contains("127.0.0.1") && err.contains("[::1]"),
+            "error should mention BOTH loopback hosts, got: {err}"
+        );
+        assert!(
+            err.contains(&port.to_string()),
+            "error should include the port number, got: {err}"
+        );
+        // Must NOT be empty — the whole point is no silent failure.
+        assert!(!err.is_empty());
+    }
+
+    /// Regression for issue #3897: when the connect step hangs forever, the
+    /// query must time out and the error must identify timeout (not empty,
+    /// not connection-refused wording). Uses a TCP listener that accepts
+    /// the connection but never sends any WebSocket handshake bytes, so
+    /// tokio-tungstenite's `connect_async` blocks on the handshake until
+    /// our timeout fires.
+    #[tokio::test]
+    async fn test_query_with_fallback_timeout_reports_error() {
+        use tokio::net::TcpListener;
+
+        // Bind on IPv4 loopback only. IPv6 loopback ([::1]) will fail with
+        // connection-refused immediately, which is fine — we only need one
+        // of the two attempts to time out.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Accept-and-hold: drop the stream after accept so the peer blocks
+        // on handshake. We hold `_handle` for the duration of the test to
+        // keep the accept task alive.
+        let _handle = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            // Hold the connection open without ever writing a handshake.
+            tokio::time::sleep(StdDuration::from_secs(60)).await;
+        });
+
+        // Override the timeout for the duration of this test by using a
+        // shorter wrapping timeout — we can't change WS_TIMEOUT_SECS at
+        // runtime, so instead bound the whole call to stay under CI limits.
+        // In practice WS_TIMEOUT_SECS is 15s; bounding to 20s lets the real
+        // timeout fire once, produces a timeout error string, and keeps the
+        // test well within CI's default timeouts.
+        let result = tokio::time::timeout(StdDuration::from_secs(20), query_with_fallback(port, 0))
+            .await
+            .expect("test wrapper timed out before WS_TIMEOUT_SECS fired");
+
+        let err = result.expect_err("handshake never completes → must return Err");
+        assert!(
+            err.contains("timed out") || err.contains("timeout"),
+            "error should identify timeout, got: {err}"
+        );
+        assert!(
+            err.contains(&port.to_string()),
+            "error should include the port number, got: {err}"
+        );
+    }
+
+    /// Serialization must round-trip the new `network_status_error` field
+    /// and omit it from JSON when `None` so existing report schemas stay
+    /// unchanged on the server side.
+    #[test]
+    fn test_network_status_error_serialization() {
+        let base_report = || DiagnosticReport {
+            client_timestamp: "2026-04-17T00:00:00Z".to_string(),
+            system_info: SystemInfo {
+                os: "linux".into(),
+                arch: "x86_64".into(),
+                hostname: "test".into(),
+            },
+            version_info: VersionInfo {
+                version: "0.2.46".into(),
+                git_commit: "abc".into(),
+                git_dirty: false,
+                build_timestamp: "".into(),
+            },
+            logs: LogContents {
+                main_log: None,
+                error_log: None,
+                main_log_size_bytes: 0,
+                error_log_size_bytes: 0,
+                main_log_original_size_bytes: 0,
+                error_log_original_size_bytes: 0,
+            },
+            config: None,
+            network_status: None,
+            network_status_error: None,
+            user_message: None,
+        };
+
+        // None case: field must be omitted from JSON so older server
+        // deserializers don't see an unexpected key.
+        let report = base_report();
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(
+            !json.contains("network_status_error"),
+            "None should be skipped; got {json}"
+        );
+
+        // Some case: field must appear in JSON.
+        let mut report = base_report();
+        report.network_status_error = Some("timed out after 15s".to_string());
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(
+            json.contains("network_status_error"),
+            "Some should appear in JSON; got {json}"
+        );
+        assert!(json.contains("timed out after 15s"));
+
+        // Round-trip deserialization preserves the error string.
+        let restored: DiagnosticReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            restored.network_status_error.as_deref(),
+            Some("timed out after 15s")
+        );
     }
 
     #[test]

--- a/crates/core/src/bin/commands/report.rs
+++ b/crates/core/src/bin/commands/report.rs
@@ -35,7 +35,7 @@ const DEFAULT_WS_API_PORT: u16 = 7509;
 /// waiting longer rather than dropping the field silently.
 const WS_TIMEOUT_SECS: u64 = 15;
 /// Number of additional retry attempts after the initial query times out.
-/// Connection refused is not retried — that signals the node isn't running.
+/// Connection refused is not retried: that signals the node isn't running.
 const WS_RETRY_ATTEMPTS: u32 = 1;
 /// Loopback hosts to try, in order. Both are attempted so that
 /// `ws-api-address = "::"` combined with `IPV6_V6ONLY=1` (or a v4-only
@@ -678,18 +678,16 @@ async fn query_with_fallback(port: u16, retry_attempts: u32) -> Result<String, S
                 Ok(Ok(diag)) => return Ok(diag),
                 Ok(Err(e)) => {
                     // Connection-level failure (refused, no route, etc.).
-                    // Don't retry the same host — the error won't change.
-                    let msg = format!("{host}:{port}: {e:#}");
-                    errors.push(msg);
+                    // Don't retry the same host: the error won't change.
+                    errors.push(format!("{host}:{port}: {e:#}"));
                     break;
                 }
                 Err(_) => {
-                    let msg = format!(
+                    errors.push(format!(
                         "{host}:{port}: timed out after {WS_TIMEOUT_SECS}s (attempt {}/{})",
                         attempt + 1,
                         total_attempts
-                    );
-                    errors.push(msg);
+                    ));
                 }
             }
         }
@@ -998,7 +996,7 @@ stack backtrace:
             err.contains(&port.to_string()),
             "error should include the port number, got: {err}"
         );
-        // Must NOT be empty — the whole point is no silent failure.
+        // Must NOT be empty: the whole point is no silent failure.
         assert!(!err.is_empty());
     }
 
@@ -1012,27 +1010,23 @@ stack backtrace:
     async fn test_query_with_fallback_timeout_reports_error() {
         use tokio::net::TcpListener;
 
-        // Bind on IPv4 loopback only. IPv6 loopback ([::1]) will fail with
-        // connection-refused immediately, which is fine — we only need one
-        // of the two attempts to time out.
+        // Bind on IPv4 loopback only. The [::1] attempt will fail with
+        // connection-refused immediately; we only need one of the two
+        // attempts to hit the timeout path.
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
-        // Accept-and-hold: drop the stream after accept so the peer blocks
-        // on handshake. We hold `_handle` for the duration of the test to
-        // keep the accept task alive.
+        // Accept the connection but never write any handshake bytes, so
+        // `connect_async` blocks until WS_TIMEOUT_SECS fires. Holding
+        // `_handle` keeps the accept task alive for the duration of the test.
         let _handle = tokio::spawn(async move {
             let (_stream, _) = listener.accept().await.unwrap();
-            // Hold the connection open without ever writing a handshake.
             tokio::time::sleep(StdDuration::from_secs(60)).await;
         });
 
-        // Override the timeout for the duration of this test by using a
-        // shorter wrapping timeout — we can't change WS_TIMEOUT_SECS at
-        // runtime, so instead bound the whole call to stay under CI limits.
-        // In practice WS_TIMEOUT_SECS is 15s; bounding to 20s lets the real
-        // timeout fire once, produces a timeout error string, and keeps the
-        // test well within CI's default timeouts.
+        // Outer wrapper bounds total test time: WS_TIMEOUT_SECS (15s) must
+        // fire once on the 127.0.0.1 attempt, so 20s leaves margin without
+        // exceeding CI's default timeouts.
         let result = tokio::time::timeout(StdDuration::from_secs(20), query_with_fallback(port, 0))
             .await
             .expect("test wrapper timed out before WS_TIMEOUT_SECS fired");


### PR DESCRIPTION
## Problem

Diagnostic reports (`crates/core/src/bin/commands/report.rs`) attempt to include live node state via `NodeDiagnostics` over the local WebSocket API. When that query fails — for any reason — the field is silently set to `None` and the report contains no indication of why.

Report **FVQ7X3** (Raspberry Pi 4, aarch64, v0.2.46) exhibited this exactly: the user was actively complaining about slow GETs with ~4 peers, but `network_status: null` and the log capture was 122 lines of a single "Channel overflow: dropped packets" warning. The one piece of data that would have answered "why 4 peers?" (`connections_by_location.len()`, `pending_reservations`, subscription tree state) was the field that silently dropped out.

Three failure modes all produce the same silent `null`:

1. **5-second timeout too tight** on a loaded node where the event loop is saturated (exactly the case we most need diagnostics for).
2. **IPv4/IPv6 mismatch:** `ws-api-address = "::"` default with `IPV6_V6ONLY=1` breaks the hardcoded `ws://127.0.0.1:PORT` connect.
3. **Node running in a degraded state** (WS task backlogged, rejecting new clients).

In all three cases the report contains no signal at all.

## Solution

1. **Add `network_status_error: Option<String>`** to `DiagnosticReport`. When the query fails, the field records the concrete reason (`timed out after 15s`, `connection refused`, etc.) instead of silently dropping the data. Optional and `skip_serializing_if = "Option::is_none"` so existing server deserializers are unaffected.
2. **Bump `WS_TIMEOUT_SECS` from 5s to 15s** and retry once on timeout. Connection-refused is not retried — that indicates the node isn't running on that host.
3. **Try both `127.0.0.1` and `[::1]`** in order, so `ws-api-address = "::"` with v4-only or v6-only configurations doesn't silently drop the query.
4. **Update `print_summary`** to distinguish "running" / "unreachable (reason)" / "not running or unreachable", so the user sees why the query failed instead of the ambiguous "not running or unreachable".

The issue also suggested a fallback snapshot from the event log on disk; I've intentionally scoped this PR to items 1–4 (surfacing the failure and closing the two specific connection gaps) and left the event-log fallback for a follow-up if this fix proves insufficient in practice.

## Testing

Three new unit tests in `crates/core/src/bin/commands/report.rs`:

- `test_query_with_fallback_connection_refused_reports_error` — binds nothing to a port, asserts `query_with_fallback` returns `Err` mentioning both loopback hosts and the port. This would fail against `main`, which returns `None` silently.
- `test_query_with_fallback_timeout_reports_error` — accepts a TCP connection but never completes the WebSocket handshake, asserts the error string identifies "timed out" and the port. Exercises the 15s timeout path end-to-end.
- `test_network_status_error_serialization` — confirms the new field is omitted from JSON when `None` (wire compat) and round-trips correctly when `Some`.

All 54 tests in `cargo test -p freenet --bin freenet` pass. `cargo fmt` + `cargo clippy --bin freenet --all-targets -- -D warnings` clean.

## Fixes

Closes #3897

[AI-assisted - Claude]