### PR TITLE
ci: restore ci-medium-50 sim to PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,14 +487,23 @@ jobs:
           # 8 minute cap per sim, SIGKILL 30s later if it refuses to die.
           # Background directly (no function) so $! refers to the actual child
           # of this shell, which `wait` can then reap.
-          #
-          # ci-medium-50 (46 nodes, 2000 events, seed 0xDEADBEEF) has been
-          # moved to simulation-nightly.yml: under concurrent load with the
-          # other three sims + nextest it pushed the ubicloud-standard-16
-          # runner past its 16 GB memory ceiling, producing silent OOM kills
-          # (exit 143) that masqueraded as test failures. Nightly covers the
-          # same scale via `nightly-medium-50-alt` (seed 0xCAFEBABE) and the
-          # 500-node large-scale run.
+          {
+            echo "== $(date -u +%H:%M:%S) ci-medium-50 starting"
+            timeout --kill-after=30s 8m target/release/fdev test \
+              --name "ci-medium-50" \
+              --seed 0xDEADBEEF \
+              --gateways 4 --nodes 46 --events 2000 \
+              --ring-max-htl 12 --max-connections 20 --min-connections 6 \
+              --latency-min 10 --latency-max 50 \
+              --min-success-rate 1.0 \
+              --print-summary --print-network-stats \
+              single-process 2>&1
+            rc=$?
+            echo "== $(date -u +%H:%M:%S) ci-medium-50 done rc=${rc}"
+            exit $rc
+          } > sim-logs/ci-medium-50.log 2>&1 &
+          PID1=$!
+
           {
             echo "== $(date -u +%H:%M:%S) ci-fault-loss starting"
             timeout --kill-after=30s 8m target/release/fdev test \
@@ -547,11 +556,12 @@ jobs:
           } > sim-logs/ci-churn-20.log 2>&1 &
           PID4=$!
 
-          echo "Started: nextest=$NEXTEST_PID fault=$PID2 latency=$PID3 churn=$PID4"
+          echo "Started: nextest=$NEXTEST_PID medium=$PID1 fault=$PID2 latency=$PID3 churn=$PID4"
 
           # Wait for all and fail if any failed
           FAILED=0
           wait $NEXTEST_PID || { echo "nextest FAILED"; FAILED=1; }
+          wait $PID1 || { echo "ci-medium-50 FAILED"; FAILED=1; }
           wait $PID2 || { echo "ci-fault-loss FAILED"; FAILED=1; }
           wait $PID3 || { echo "ci-high-latency FAILED"; FAILED=1; }
           wait $PID4 || { echo "ci-churn-20 FAILED"; FAILED=1; }

--- a/.github/workflows/simulation-nightly.yml
+++ b/.github/workflows/simulation-nightly.yml
@@ -1,11 +1,8 @@
 name: Simulation Tests (Nightly)
 
 # Long-running and large-scale simulation tests too slow for PR CI.
-# PR CI runs the smaller fault-loss / high-latency / churn sims in parallel;
-# this workflow covers:
-#   - Medium scale (46 nodes, 2000 events) — both the primary seed
-#     0xDEADBEEF and the alt seed 0xCAFEBABE, each in isolation so their
-#     ~5 GB RSS does not compete on the 16 GB runner
+# Medium-scale fdev tests (50 nodes, fault tolerance, high latency, churn
+# resilience) now run in the main CI workflow. This workflow covers:
 #   - Nightly-gated nextest tests (1h virtual time, 250-contract scale)
 #   - Large scale (500 nodes, 10000 events)
 
@@ -81,23 +78,8 @@ jobs:
       - name: Build fdev
         run: cargo build -p fdev --release
 
-      # Medium scale, primary seed. Moved out of PR CI because running
-      # alongside the other fdev sims + nextest OOM-killed the
-      # ubicloud-standard-16 runner (~5 GB RSS × 4 concurrent sims >
-      # 16 GB). Runs in isolation here.
-      - name: Medium scale test (50 nodes, seed 0xDEADBEEF)
-        run: |
-          target/release/fdev test \
-            --name "nightly-medium-50" \
-            --seed 0xDEADBEEF \
-            --gateways 4 --nodes 46 --events 2000 \
-            --ring-max-htl 12 --max-connections 20 --min-connections 6 \
-            --latency-min 10 --latency-max 50 \
-            --min-success-rate 1.0 \
-            --print-summary --print-network-stats \
-            single-process
-
       # Medium scale with alternate seed (explores different code paths).
+      # The primary seed (0xDEADBEEF) runs in PR CI; this covers a second path.
       - name: Medium scale test (50 nodes, seed 0xCAFEBABE)
         run: |
           target/release/fdev test \


### PR DESCRIPTION
## Problem

#3899 moved the `ci-medium-50` sim (46 nodes, 2000 events, seed
`0xDEADBEEF`) out of PR CI into `simulation-nightly.yml` because the
ubicloud-standard-16 runner was being OOM-killed (exit 143) a few
minutes into the combined sim step — silently, with no per-sim
summary. At the time the failure looked like the sim itself was
over the runner's 16 GB budget.

That diagnosis was incorrect. The sim's own working set is ~5 GB;
the explosive growth came from elsewhere.

## Solution

Root cause was log-spam allocator churn introduced by the phase-5
relay-GET task-per-tx migration (#3896): `operations::put::put.rs`
was logging `ERROR` on every already-completed-tx retry hit,
producing ~350k events/s. Each event allocated `fmt::Arguments`
strings *before* the rate-limit filter fired, driving ~350 MB/s
linear RSS growth — matching the observed 63 GB peak under
`ci-fault-loss` exactly.

The fix stack landed on #3883:

- `bce6e2cb` — demote `load_or_init` error→debug for the benign
  "operation completed" path
- `3d70e676` — `MAX_RELAY_RETRIES=1` (legacy alignment; legacy relay
  never retried alternative peers at a hop)
- `b04a73ab` — reuse `incoming_tx` across relay-GET forwards
- `3c7b3ea7` — drop ForwardingAck emission + per-node dedup gate
- `3e616f0e` — release `pending_op_results` slot on relay driver exit

Result on #3883's branch (workflow run 24602538340): peak RSS
**2.6 GB** (was 63 GB), relay spawns **19k** (was 16.9M), rc=0.

With the churn source fixed, the four PR-CI sims + nextest fit
comfortably inside the runner ceiling again. `ci-medium-50` belongs
back on every PR rather than once a night — the canonical seed
coverage was the whole point of running it in PR CI.

This PR is a straight revert of #3899.

## Testing

- [ ] PR CI "Simulation tests" job stays under the 16 GB runner
      ceiling with all four sims + nextest running in parallel
- [ ] `ci-medium-50` publishes its per-sim summary (i.e. no silent
      exit 143)
- [ ] `simulation-nightly.yml` still runs its 0xCAFEBABE alt-seed
      and 500-node large-scale jobs (only the duplicate primary-seed
      job is removed from nightly)

## Refs

Reverts #3899. Related: #3896 (phase-5 memory symptom), #3883
(phase-5 fix stack that made this revert safe).