### PR TITLE
fix(uninstall): scan multiple install dirs and collapse empty parents

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -1163,12 +1163,11 @@ fn remove_if_exists(label: &str, path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Re-export for callers outside this module (e.g. `uninstall::run`) that also
-/// need to collapse empty parent folders after their own cleanup passes.
-/// Currently only used from the Windows-only branch in `uninstall::run` that
-/// cleans up `%LOCALAPPDATA%\Freenet\bin`; gate the export accordingly so
-/// non-Windows builds don't flag it as dead code.
-#[cfg(target_os = "windows")]
+/// Re-export for callers outside this module (e.g. `uninstall::run`) that
+/// also need to collapse empty parent folders after their own cleanup
+/// passes. Runtime use is Windows-only (see `uninstall::collapse_windows_bin_tree`)
+/// but the function is exposed on every platform so that tests for the
+/// caller-side helper can run under Linux CI too.
 pub(super) fn remove_dir_if_empty_pub(path: &Path) {
     remove_dir_if_empty(path)
 }
@@ -1234,90 +1233,133 @@ fn purge_data_dirs(#[allow(unused_variables)] system_mode: bool) -> Result<()> {
         remove_if_exists("cache", &home.join(".cache/freenet"))?;
         remove_if_exists("logs", &home.join(".local/state/freenet"))?;
     } else {
-        // Track parent directories whose subfolders we removed, so that we
-        // can collapse them at the end if they are now empty. On Windows this
-        // is what keeps `%APPDATA%\The Freenet Project Inc\Freenet\` from
-        // being left behind once its `config` subfolder is gone (#3904).
-        let mut leftover_parents: Vec<PathBuf> = Vec::new();
-
-        match ProjectDirs::from("", "The Freenet Project Inc", "Freenet") {
-            Some(ref dirs) => {
-                // Use data_local_dir (Local AppData on Windows) to match where
-                // the node actually stores data since #3739.
-                let data_dir = dirs.data_local_dir();
-                remove_if_exists("data", data_dir)?;
-                if let Some(parent) = data_dir.parent() {
-                    leftover_parents.push(parent.to_path_buf());
-                }
-
-                // Also clean up old Roaming path from before #3739
-                let old_roaming = dirs.data_dir();
-                if old_roaming != data_dir {
-                    remove_if_exists("data (legacy roaming)", old_roaming)?;
-                    if let Some(parent) = old_roaming.parent() {
-                        leftover_parents.push(parent.to_path_buf());
-                    }
-                }
-
-                // Skip config_dir if it overlaps with either data path
-                // (e.g., on macOS config_dir == data_dir)
-                let config_dir = dirs.config_dir();
-                if config_dir != data_dir && config_dir != old_roaming {
-                    remove_if_exists("config", config_dir)?;
-                    if let Some(parent) = config_dir.parent() {
-                        leftover_parents.push(parent.to_path_buf());
-                    }
-                }
-
-                let cache_dir = dirs.cache_dir();
-                remove_if_exists("cache", cache_dir)?;
-                if let Some(parent) = cache_dir.parent() {
-                    leftover_parents.push(parent.to_path_buf());
-                }
-            }
-            None => {
-                eprintln!(
-                    "Warning: Could not determine Freenet directories. Data and config may not have been removed."
-                );
-            }
-        }
-
-        // Also remove lowercase "freenet" cache dir used by webapp cache
-        // (may differ from uppercase "Freenet" on case-sensitive filesystems)
-        if let Some(ref dirs) = ProjectDirs::from("", "The Freenet Project Inc", "freenet") {
-            let cache_dir = dirs.cache_dir();
-            if cache_dir.exists() {
-                remove_if_exists("cache", cache_dir)?;
-                if let Some(parent) = cache_dir.parent() {
-                    leftover_parents.push(parent.to_path_buf());
-                }
-            }
-        }
-
-        if let Some(log_dir) = get_log_dir() {
-            remove_if_exists("logs", &log_dir)?;
-            // On Windows the log dir is `%LOCALAPPDATA%\freenet\logs`; the
-            // enclosing `%LOCALAPPDATA%\freenet\` is Freenet-owned and safe
-            // to collapse. On Linux/macOS the log dir is itself the owned
-            // leaf, so `remove_dir_if_empty` on its parent is a no-op
-            // (the parent holds other apps' data).
-            if let Some(parent) = log_dir.parent() {
-                leftover_parents.push(parent.to_path_buf());
-            }
-        }
-
-        // Collapse any now-empty parent folders we uncovered. We dedup so
-        // that paths touched by multiple leaves (e.g. both `config` and
-        // `data` under the same `Freenet\` parent on Windows Roaming) are
-        // only attempted once.
-        leftover_parents.sort();
-        leftover_parents.dedup();
-        for parent in leftover_parents {
-            remove_dir_if_empty(&parent);
-        }
+        let leaves = DataLeaves::from_project_dirs();
+        purge_leaves_and_collapse(&leaves)?;
     }
 
     Ok(())
+}
+
+/// The full set of leaf directories `purge_data_dirs` needs to touch in
+/// non-system mode. Grouping these into a value type makes the purge logic
+/// testable without mocking `ProjectDirs` (a tricky proposition given it
+/// reads process-level env vars).
+#[derive(Debug, Default, Clone)]
+struct DataLeaves {
+    /// `data_local_dir` — on Windows this is `%LOCALAPPDATA%\...\data`.
+    data_local: Option<PathBuf>,
+    /// Pre-#3739 Roaming data path, only populated on Windows where it
+    /// differs from `data_local`.
+    data_roaming: Option<PathBuf>,
+    /// Config dir, only populated when it differs from both data paths
+    /// (matches the macOS case where `config_dir == data_dir`).
+    config: Option<PathBuf>,
+    /// `cache_dir` for the uppercase project bundle.
+    cache: Option<PathBuf>,
+    /// Lowercase-variant cache used by the webapp cache on case-sensitive
+    /// filesystems.
+    cache_lowercase: Option<PathBuf>,
+    /// Log dir (as returned by `tracing::get_log_dir`).
+    log: Option<PathBuf>,
+    /// Whether the log parent is Freenet-owned and therefore safe to
+    /// collapse. True on Windows (`%LOCALAPPDATA%\freenet\`), false on
+    /// Linux/macOS where the parent belongs to the XDG hierarchy shared
+    /// with other apps.
+    collapse_log_parent: bool,
+}
+
+impl DataLeaves {
+    fn from_project_dirs() -> Self {
+        let mut leaves = DataLeaves::default();
+
+        if let Some(dirs) = ProjectDirs::from("", "The Freenet Project Inc", "Freenet") {
+            let data_dir = dirs.data_local_dir().to_path_buf();
+            leaves.data_local = Some(data_dir.clone());
+
+            let roaming = dirs.data_dir().to_path_buf();
+            if roaming != data_dir {
+                leaves.data_roaming = Some(roaming.clone());
+            }
+
+            let config_dir = dirs.config_dir().to_path_buf();
+            if config_dir != data_dir && Some(&config_dir) != leaves.data_roaming.as_ref() {
+                leaves.config = Some(config_dir);
+            }
+
+            leaves.cache = Some(dirs.cache_dir().to_path_buf());
+        } else {
+            eprintln!(
+                "Warning: Could not determine Freenet directories. Data and config may not have been removed."
+            );
+        }
+
+        if let Some(dirs) = ProjectDirs::from("", "The Freenet Project Inc", "freenet") {
+            let cache_lower = dirs.cache_dir().to_path_buf();
+            if cache_lower.exists() {
+                leaves.cache_lowercase = Some(cache_lower);
+            }
+        }
+
+        leaves.log = get_log_dir();
+        leaves.collapse_log_parent = cfg!(target_os = "windows");
+
+        leaves
+    }
+}
+
+/// Remove every populated leaf directory and then collapse any Freenet-owned
+/// parent folder that the removal left empty. This is the #3904 fix: on
+/// Windows the per-leaf calls removed `...\Freenet\config` but not its now-
+/// empty `...\Freenet\` parent. By collecting parents, deduping, and visiting
+/// them deepest-first, we tidy up without ever attempting to remove a parent
+/// that still holds a sibling app's data.
+fn purge_leaves_and_collapse(leaves: &DataLeaves) -> Result<()> {
+    let mut parents: Vec<PathBuf> = Vec::new();
+
+    if let Some(ref data_local) = leaves.data_local {
+        remove_if_exists("data", data_local)?;
+        push_parent(data_local, &mut parents);
+    }
+    if let Some(ref roaming) = leaves.data_roaming {
+        remove_if_exists("data (legacy roaming)", roaming)?;
+        push_parent(roaming, &mut parents);
+    }
+    if let Some(ref config) = leaves.config {
+        remove_if_exists("config", config)?;
+        push_parent(config, &mut parents);
+    }
+    if let Some(ref cache) = leaves.cache {
+        remove_if_exists("cache", cache)?;
+        push_parent(cache, &mut parents);
+    }
+    if let Some(ref cache_lower) = leaves.cache_lowercase {
+        remove_if_exists("cache", cache_lower)?;
+        push_parent(cache_lower, &mut parents);
+    }
+    if let Some(ref log) = leaves.log {
+        remove_if_exists("logs", log)?;
+        if leaves.collapse_log_parent {
+            push_parent(log, &mut parents);
+        }
+    }
+
+    // Sort ascending, dedup consecutive duplicates, then reverse so that
+    // deepest paths are processed first. If a hypothetical future caller
+    // ever adds a grandparent alongside its parent, this ordering ensures
+    // the grandparent is only evaluated after its child has been collapsed.
+    parents.sort();
+    parents.dedup();
+    for parent in parents.into_iter().rev() {
+        remove_dir_if_empty(&parent);
+    }
+
+    Ok(())
+}
+
+fn push_parent(leaf: &Path, acc: &mut Vec<PathBuf>) {
+    if let Some(parent) = leaf.parent() {
+        acc.push(parent.to_path_buf());
+    }
 }
 
 /// Path to the system-wide systemd service file.
@@ -2698,6 +2740,31 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_dir_if_empty_preserves_dir_with_subtree() {
+        // Variant of the safety test above, but with a full subdirectory
+        // tree instead of a single file. `read_dir().next().is_some()` must
+        // treat a subdir as "non-empty" — we never want to pretend a parent
+        // is empty just because all its direct children are directories.
+        let tmp = tempfile::tempdir().unwrap();
+        let project_parent = tmp.path().join("The Freenet Project Inc");
+        let sibling_app = project_parent.join("OtherApp");
+        let sibling_data = sibling_app.join("state");
+        std::fs::create_dir_all(&sibling_data).unwrap();
+        std::fs::write(sibling_data.join("state.bin"), b"unrelated").unwrap();
+
+        remove_dir_if_empty(&project_parent);
+
+        assert!(
+            project_parent.exists(),
+            "parent with a sibling app subtree must be preserved",
+        );
+        assert!(
+            sibling_data.join("state.bin").exists(),
+            "sibling app's data must not be touched",
+        );
+    }
+
+    #[test]
     fn test_remove_dir_if_empty_noop_on_missing_path() {
         // The caller often passes a parent path that may or may not exist
         // (because ProjectDirs invents canonical locations even on systems
@@ -2741,6 +2808,178 @@ mod tests {
         remove_dir_if_empty(&parent);
 
         assert!(!parent.exists(), "parent should collapse once empty");
+    }
+
+    // ── purge_leaves_and_collapse integration (the call-site wiring) ──
+
+    /// Build a `DataLeaves` under `base` that mirrors the Windows
+    /// `%LOCALAPPDATA%` + `%APPDATA%` layout, except with tempdir-rooted
+    /// paths so the tests run on any OS.
+    fn seed_windows_like_layout(base: &Path) -> DataLeaves {
+        let project_local = base.join("Local").join("The Freenet Project Inc");
+        let project_roaming = base.join("Roaming").join("The Freenet Project Inc");
+        let freenet_local = project_local.join("Freenet");
+        let freenet_roaming = project_roaming.join("Freenet");
+
+        let data_local = freenet_local.join("data");
+        let data_roaming = freenet_roaming.join("data");
+        let config = freenet_roaming.join("config");
+        let cache = freenet_local.join("cache");
+        let log = base.join("Local").join("freenet").join("logs");
+
+        for d in [&data_local, &data_roaming, &config, &cache, &log] {
+            std::fs::create_dir_all(d).unwrap();
+            std::fs::write(d.join("placeholder.bin"), b"x").unwrap();
+        }
+
+        DataLeaves {
+            data_local: Some(data_local),
+            data_roaming: Some(data_roaming),
+            config: Some(config),
+            cache: Some(cache),
+            cache_lowercase: None,
+            log: Some(log),
+            collapse_log_parent: true,
+        }
+    }
+
+    #[test]
+    fn test_purge_leaves_and_collapse_cleans_windows_layout() {
+        // This is the #3904 regression test proper: it exercises the full
+        // call chain (DataLeaves → remove_if_exists per leaf → parent
+        // collection → deepest-first collapse), not just the helper.
+        // Reverting the parent collection or the `remove_dir_if_empty`
+        // calls inside `purge_leaves_and_collapse` would cause this to fail.
+        let tmp = tempfile::tempdir().unwrap();
+        let leaves = seed_windows_like_layout(tmp.path());
+        let freenet_local = leaves
+            .data_local
+            .as_ref()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let freenet_roaming = leaves
+            .config
+            .as_ref()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let log_parent = leaves.log.as_ref().unwrap().parent().unwrap().to_path_buf();
+
+        purge_leaves_and_collapse(&leaves).unwrap();
+
+        // Every leaf is gone.
+        for leaf in [
+            leaves.data_local.as_ref(),
+            leaves.data_roaming.as_ref(),
+            leaves.config.as_ref(),
+            leaves.cache.as_ref(),
+            leaves.log.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            assert!(!leaf.exists(), "leaf {} should be removed", leaf.display());
+        }
+
+        // The Freenet-owned parents collapsed...
+        assert!(
+            !freenet_local.exists(),
+            "Local/.../Freenet/ should collapse"
+        );
+        assert!(
+            !freenet_roaming.exists(),
+            "Roaming/.../Freenet/ should collapse"
+        );
+        assert!(!log_parent.exists(), "Local/freenet/ should collapse");
+    }
+
+    #[test]
+    fn test_purge_leaves_preserves_sibling_app_grandparent() {
+        // Safety: `The Freenet Project Inc\` holds `Freenet\` (ours) and
+        // could hold `OtherApp\` (unrelated). Only `Freenet\` is expendable.
+        let tmp = tempfile::tempdir().unwrap();
+        let leaves = seed_windows_like_layout(tmp.path());
+
+        // Plant a sibling app next to our Freenet folder.
+        let sibling = tmp
+            .path()
+            .join("Roaming")
+            .join("The Freenet Project Inc")
+            .join("OtherApp")
+            .join("state.bin");
+        std::fs::create_dir_all(sibling.parent().unwrap()).unwrap();
+        std::fs::write(&sibling, b"dont touch").unwrap();
+
+        purge_leaves_and_collapse(&leaves).unwrap();
+
+        // Sibling and its grandparent both preserved.
+        assert!(sibling.exists(), "sibling app data must survive");
+        assert!(
+            sibling.parent().unwrap().exists(),
+            "sibling app directory must survive",
+        );
+        assert!(
+            sibling.parent().unwrap().parent().unwrap().exists(),
+            "`The Freenet Project Inc` grandparent must survive",
+        );
+    }
+
+    #[test]
+    fn test_purge_leaves_collapses_log_parent_only_when_flagged() {
+        // On Linux/macOS, `get_log_dir()` returns a path under a shared
+        // XDG parent (`~/.local/state/`, `~/Library/Logs/`). Even if it
+        // happens to be empty at uninstall time, we must not pretend it's
+        // ours to remove. This test documents that contract.
+        let tmp = tempfile::tempdir().unwrap();
+        let log = tmp.path().join("shared-state-dir").join("freenet");
+        std::fs::create_dir_all(&log).unwrap();
+        std::fs::write(log.join("trace.log"), b"log").unwrap();
+
+        let leaves = DataLeaves {
+            data_local: None,
+            data_roaming: None,
+            config: None,
+            cache: None,
+            cache_lowercase: None,
+            log: Some(log.clone()),
+            collapse_log_parent: false,
+        };
+
+        purge_leaves_and_collapse(&leaves).unwrap();
+
+        assert!(!log.exists(), "log leaf should still be removed");
+        assert!(
+            log.parent().unwrap().exists(),
+            "shared log parent must NOT be collapsed when flag is false",
+        );
+    }
+
+    #[test]
+    fn test_purge_leaves_tolerates_missing_optional_leaves() {
+        // Not every platform populates every leaf — an install that never
+        // wrote to Roaming (legacy Windows) or never produced a
+        // lowercase-cache variant still needs to clean up what IS there.
+        let tmp = tempfile::tempdir().unwrap();
+        let data_local = tmp.path().join("data");
+        std::fs::create_dir_all(&data_local).unwrap();
+        std::fs::write(data_local.join("a"), b"x").unwrap();
+
+        let leaves = DataLeaves {
+            data_local: Some(data_local.clone()),
+            data_roaming: None,
+            config: None,
+            cache: None,
+            cache_lowercase: None,
+            log: None,
+            collapse_log_parent: false,
+        };
+
+        purge_leaves_and_collapse(&leaves).unwrap();
+
+        assert!(!data_local.exists(), "leaf should be removed");
     }
 
     // ── Wrapper backoff state machine tests ──

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -1261,11 +1261,22 @@ struct DataLeaves {
     cache_lowercase: Option<PathBuf>,
     /// Log dir (as returned by `tracing::get_log_dir`).
     log: Option<PathBuf>,
-    /// Whether the log parent is Freenet-owned and therefore safe to
-    /// collapse. True on Windows (`%LOCALAPPDATA%\freenet\`), false on
-    /// Linux/macOS where the parent belongs to the XDG hierarchy shared
-    /// with other apps.
-    collapse_log_parent: bool,
+    /// Whether the parents of our leaves are Freenet-owned and therefore
+    /// safe to collapse if empty.
+    ///
+    /// True on Windows — `ProjectDirs` there builds
+    /// `%LOCALAPPDATA%\The Freenet Project Inc\Freenet\{data,config,cache}`
+    /// and `get_log_dir` returns `%LOCALAPPDATA%\freenet\logs`; the
+    /// immediate parents (`...\Freenet`, `...\freenet`) exist only for us.
+    ///
+    /// False on Linux/macOS — `ProjectDirs` builds `~/.local/share/Freenet`,
+    /// `~/.config/Freenet`, `~/.cache/Freenet` (Linux) and analogous paths
+    /// on macOS. The parents of those leaves are shared XDG/OS hierarchies
+    /// used by every other app on the system — collapsing them would at
+    /// best no-op (by luck) and at worst delete an otherwise-empty shared
+    /// root on a fresh account. The safety must be enforced at the type
+    /// level, not left to `remove_dir_if_empty`'s runtime check.
+    collapse_parents: bool,
 }
 
 impl DataLeaves {
@@ -1301,7 +1312,7 @@ impl DataLeaves {
         }
 
         leaves.log = get_log_dir();
-        leaves.collapse_log_parent = cfg!(target_os = "windows");
+        leaves.collapse_parents = cfg!(target_os = "windows");
 
         leaves
     }
@@ -1315,32 +1326,35 @@ impl DataLeaves {
 /// that still holds a sibling app's data.
 fn purge_leaves_and_collapse(leaves: &DataLeaves) -> Result<()> {
     let mut parents: Vec<PathBuf> = Vec::new();
+    let collect = |leaf: &Path, acc: &mut Vec<PathBuf>| {
+        if leaves.collapse_parents {
+            push_parent(leaf, acc);
+        }
+    };
 
     if let Some(ref data_local) = leaves.data_local {
         remove_if_exists("data", data_local)?;
-        push_parent(data_local, &mut parents);
+        collect(data_local, &mut parents);
     }
     if let Some(ref roaming) = leaves.data_roaming {
         remove_if_exists("data (legacy roaming)", roaming)?;
-        push_parent(roaming, &mut parents);
+        collect(roaming, &mut parents);
     }
     if let Some(ref config) = leaves.config {
         remove_if_exists("config", config)?;
-        push_parent(config, &mut parents);
+        collect(config, &mut parents);
     }
     if let Some(ref cache) = leaves.cache {
         remove_if_exists("cache", cache)?;
-        push_parent(cache, &mut parents);
+        collect(cache, &mut parents);
     }
     if let Some(ref cache_lower) = leaves.cache_lowercase {
         remove_if_exists("cache", cache_lower)?;
-        push_parent(cache_lower, &mut parents);
+        collect(cache_lower, &mut parents);
     }
     if let Some(ref log) = leaves.log {
         remove_if_exists("logs", log)?;
-        if leaves.collapse_log_parent {
-            push_parent(log, &mut parents);
-        }
+        collect(log, &mut parents);
     }
 
     // Sort ascending, dedup consecutive duplicates, then reverse so that
@@ -2839,7 +2853,7 @@ mod tests {
             cache: Some(cache),
             cache_lowercase: None,
             log: Some(log),
-            collapse_log_parent: true,
+            collapse_parents: true,
         }
     }
 
@@ -2928,33 +2942,61 @@ mod tests {
     }
 
     #[test]
-    fn test_purge_leaves_collapses_log_parent_only_when_flagged() {
-        // On Linux/macOS, `get_log_dir()` returns a path under a shared
-        // XDG parent (`~/.local/state/`, `~/Library/Logs/`). Even if it
-        // happens to be empty at uninstall time, we must not pretend it's
-        // ours to remove. This test documents that contract.
+    fn test_purge_leaves_never_collapses_shared_parents_on_unix() {
+        // Reproduces the codex-caught bug: on Linux `ProjectDirs` builds
+        // `~/.local/share/Freenet`, `~/.config/Freenet`, `~/.cache/Freenet`
+        // (and analogous macOS paths), whose parents are shared across
+        // every app on the system. Collapsing any of them, even when the
+        // `remove_dir_if_empty` non-empty check makes it safe in practice
+        // on an active system, would wipe a shared XDG root on a fresh
+        // account where Freenet was the only inhabitant. The
+        // `collapse_parents: false` setting must suppress every collapse.
         let tmp = tempfile::tempdir().unwrap();
-        let log = tmp.path().join("shared-state-dir").join("freenet");
-        std::fs::create_dir_all(&log).unwrap();
-        std::fs::write(log.join("trace.log"), b"log").unwrap();
+
+        // Each leaf sits in its own dedicated parent to verify each
+        // collapse path independently.
+        let shared_share = tmp.path().join("share");
+        let shared_config = tmp.path().join("config");
+        let shared_cache = tmp.path().join("cache");
+        let shared_logs = tmp.path().join("state");
+
+        let data = shared_share.join("Freenet");
+        let config = shared_config.join("Freenet");
+        let cache = shared_cache.join("Freenet");
+        let log = shared_logs.join("freenet");
+
+        for d in [&data, &config, &cache, &log] {
+            std::fs::create_dir_all(d).unwrap();
+            std::fs::write(d.join("a"), b"x").unwrap();
+        }
 
         let leaves = DataLeaves {
-            data_local: None,
+            data_local: Some(data.clone()),
             data_roaming: None,
-            config: None,
-            cache: None,
+            config: Some(config.clone()),
+            cache: Some(cache.clone()),
             cache_lowercase: None,
             log: Some(log.clone()),
-            collapse_log_parent: false,
+            collapse_parents: false,
         };
 
         purge_leaves_and_collapse(&leaves).unwrap();
 
-        assert!(!log.exists(), "log leaf should still be removed");
-        assert!(
-            log.parent().unwrap().exists(),
-            "shared log parent must NOT be collapsed when flag is false",
-        );
+        // Every leaf removed.
+        for leaf in [&data, &config, &cache, &log] {
+            assert!(!leaf.exists(), "leaf {} should be removed", leaf.display());
+        }
+
+        // Every shared parent preserved — this is what protects
+        // `~/.local/share/`, `~/.config/`, `~/.cache/`, `~/.local/state/`
+        // on real systems.
+        for parent in [&shared_share, &shared_config, &shared_cache, &shared_logs] {
+            assert!(
+                parent.exists(),
+                "shared parent {} must NOT be collapsed on Unix",
+                parent.display(),
+            );
+        }
     }
 
     #[test]
@@ -2974,7 +3016,7 @@ mod tests {
             cache: None,
             cache_lowercase: None,
             log: None,
-            collapse_log_parent: false,
+            collapse_parents: false,
         };
 
         purge_leaves_and_collapse(&leaves).unwrap();

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -9,7 +9,7 @@ use clap::Subcommand;
 use directories::ProjectDirs;
 use freenet::config::ConfigPaths;
 use freenet::tracing::tracer::get_log_dir;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use super::report::ReportCommand;
@@ -1163,6 +1163,43 @@ fn remove_if_exists(label: &str, path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Re-export for callers outside this module (e.g. `uninstall::run`) that also
+/// need to collapse empty parent folders after their own cleanup passes.
+/// Currently only used from the Windows-only branch in `uninstall::run` that
+/// cleans up `%LOCALAPPDATA%\Freenet\bin`; gate the export accordingly so
+/// non-Windows builds don't flag it as dead code.
+#[cfg(target_os = "windows")]
+pub(super) fn remove_dir_if_empty_pub(path: &Path) {
+    remove_dir_if_empty(path)
+}
+
+/// Remove a directory only if it is empty. Unlike `remove_if_exists`, this
+/// never recursively deletes — it is intended for cleaning up empty parent
+/// folders after their children have been removed (e.g. collapsing an empty
+/// `%APPDATA%\The Freenet Project Inc\Freenet\` once its `config` subfolder
+/// is gone). Any error other than "not empty" is swallowed; the parent is
+/// expendable and we should not fail the uninstall over it.
+fn remove_dir_if_empty(path: &Path) {
+    if !path.is_dir() {
+        return;
+    }
+    let Ok(mut entries) = std::fs::read_dir(path) else {
+        return;
+    };
+    if entries.next().is_some() {
+        return;
+    }
+    match std::fs::remove_dir(path) {
+        Ok(()) => println!("Removing empty dir: {}", path.display()),
+        Err(err) => {
+            // Best-effort: the parent may have been re-populated by a
+            // concurrent process, or the user lacks permission. Either
+            // way, don't abort the uninstall.
+            eprintln!("Note: could not remove empty dir {}: {err}", path.display());
+        }
+    }
+}
+
 /// Public wrapper for use by the `uninstall` command.
 pub fn purge_data(system_mode: bool) -> Result<()> {
     purge_data_dirs(system_mode)
@@ -1197,17 +1234,29 @@ fn purge_data_dirs(#[allow(unused_variables)] system_mode: bool) -> Result<()> {
         remove_if_exists("cache", &home.join(".cache/freenet"))?;
         remove_if_exists("logs", &home.join(".local/state/freenet"))?;
     } else {
+        // Track parent directories whose subfolders we removed, so that we
+        // can collapse them at the end if they are now empty. On Windows this
+        // is what keeps `%APPDATA%\The Freenet Project Inc\Freenet\` from
+        // being left behind once its `config` subfolder is gone (#3904).
+        let mut leftover_parents: Vec<PathBuf> = Vec::new();
+
         match ProjectDirs::from("", "The Freenet Project Inc", "Freenet") {
             Some(ref dirs) => {
                 // Use data_local_dir (Local AppData on Windows) to match where
                 // the node actually stores data since #3739.
                 let data_dir = dirs.data_local_dir();
                 remove_if_exists("data", data_dir)?;
+                if let Some(parent) = data_dir.parent() {
+                    leftover_parents.push(parent.to_path_buf());
+                }
 
                 // Also clean up old Roaming path from before #3739
                 let old_roaming = dirs.data_dir();
                 if old_roaming != data_dir {
                     remove_if_exists("data (legacy roaming)", old_roaming)?;
+                    if let Some(parent) = old_roaming.parent() {
+                        leftover_parents.push(parent.to_path_buf());
+                    }
                 }
 
                 // Skip config_dir if it overlaps with either data path
@@ -1215,9 +1264,16 @@ fn purge_data_dirs(#[allow(unused_variables)] system_mode: bool) -> Result<()> {
                 let config_dir = dirs.config_dir();
                 if config_dir != data_dir && config_dir != old_roaming {
                     remove_if_exists("config", config_dir)?;
+                    if let Some(parent) = config_dir.parent() {
+                        leftover_parents.push(parent.to_path_buf());
+                    }
                 }
 
-                remove_if_exists("cache", dirs.cache_dir())?;
+                let cache_dir = dirs.cache_dir();
+                remove_if_exists("cache", cache_dir)?;
+                if let Some(parent) = cache_dir.parent() {
+                    leftover_parents.push(parent.to_path_buf());
+                }
             }
             None => {
                 eprintln!(
@@ -1232,11 +1288,32 @@ fn purge_data_dirs(#[allow(unused_variables)] system_mode: bool) -> Result<()> {
             let cache_dir = dirs.cache_dir();
             if cache_dir.exists() {
                 remove_if_exists("cache", cache_dir)?;
+                if let Some(parent) = cache_dir.parent() {
+                    leftover_parents.push(parent.to_path_buf());
+                }
             }
         }
 
         if let Some(log_dir) = get_log_dir() {
             remove_if_exists("logs", &log_dir)?;
+            // On Windows the log dir is `%LOCALAPPDATA%\freenet\logs`; the
+            // enclosing `%LOCALAPPDATA%\freenet\` is Freenet-owned and safe
+            // to collapse. On Linux/macOS the log dir is itself the owned
+            // leaf, so `remove_dir_if_empty` on its parent is a no-op
+            // (the parent holds other apps' data).
+            if let Some(parent) = log_dir.parent() {
+                leftover_parents.push(parent.to_path_buf());
+            }
+        }
+
+        // Collapse any now-empty parent folders we uncovered. We dedup so
+        // that paths touched by multiple leaves (e.g. both `config` and
+        // `data` under the same `Freenet\` parent on Windows Roaming) are
+        // only attempted once.
+        leftover_parents.sort();
+        leftover_parents.dedup();
+        for parent in leftover_parents {
+            remove_dir_if_empty(&parent);
         }
     }
 
@@ -2585,6 +2662,85 @@ mod tests {
     fn test_should_purge_no_flags_non_tty() {
         // In CI/test environments stdin is not a TTY, so this should default to false
         assert!(!should_purge(false, false).unwrap());
+    }
+
+    // ── remove_dir_if_empty (Windows uninstall leftover cleanup, #3904) ──
+
+    #[test]
+    fn test_remove_dir_if_empty_removes_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let empty = tmp.path().join("empty");
+        std::fs::create_dir(&empty).unwrap();
+
+        remove_dir_if_empty(&empty);
+
+        assert!(!empty.exists(), "empty directory should have been removed");
+    }
+
+    #[test]
+    fn test_remove_dir_if_empty_preserves_non_empty_dir() {
+        // The whole point of this helper: if someone else dropped a file into
+        // the parent (an unrelated app under `The Freenet Project Inc\`, or a
+        // user-authored config file), we must NOT wipe it out. Any "looks
+        // close to empty" heuristic would be catastrophic here.
+        let tmp = tempfile::tempdir().unwrap();
+        let nonempty = tmp.path().join("nonempty");
+        std::fs::create_dir(&nonempty).unwrap();
+        std::fs::write(nonempty.join("other_app.txt"), b"do not delete").unwrap();
+
+        remove_dir_if_empty(&nonempty);
+
+        assert!(nonempty.exists(), "non-empty directory must be preserved");
+        assert!(
+            nonempty.join("other_app.txt").exists(),
+            "foreign files inside the parent must not be touched",
+        );
+    }
+
+    #[test]
+    fn test_remove_dir_if_empty_noop_on_missing_path() {
+        // The caller often passes a parent path that may or may not exist
+        // (because ProjectDirs invents canonical locations even on systems
+        // that have never installed Freenet). We must not error in that case.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("never-existed");
+
+        // Must not panic and must not create the directory.
+        remove_dir_if_empty(&missing);
+
+        assert!(!missing.exists());
+    }
+
+    #[test]
+    fn test_remove_dir_if_empty_noop_on_file() {
+        // If someone's config lives at a path that happens to be a file and
+        // not a directory, silently do nothing rather than erroring.
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("notadir");
+        std::fs::write(&file, b"contents").unwrap();
+
+        remove_dir_if_empty(&file);
+
+        assert!(file.exists(), "regular file must be left alone");
+    }
+
+    #[test]
+    fn test_remove_dir_if_empty_collapses_after_children_removed() {
+        // Simulates the #3904 scenario: after `remove_if_exists` takes out
+        // each of `data`, `config`, `cache` under a `Freenet\` parent, the
+        // now-empty `Freenet\` parent must collapse.
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("Freenet");
+        let config = parent.join("config");
+        std::fs::create_dir_all(&config).unwrap();
+        std::fs::write(config.join("config.toml"), b"stuff").unwrap();
+
+        // Recursive child removal then empty-parent cleanup, mirroring
+        // purge_data_dirs' new structure.
+        std::fs::remove_dir_all(&config).unwrap();
+        remove_dir_if_empty(&parent);
+
+        assert!(!parent.exists(), "parent should collapse once empty");
     }
 
     // ── Wrapper backoff state machine tests ──

--- a/crates/core/src/bin/commands/uninstall.rs
+++ b/crates/core/src/bin/commands/uninstall.rs
@@ -32,12 +32,39 @@ impl UninstallCommand {
             println!("All Freenet data, config, and logs removed.");
         }
 
-        // Step 3: Remove binaries
-        let install_dir = get_install_dir(None);
-        let removed = remove_binaries(&install_dir)?;
+        // Step 3: Remove binaries from every known install location.
+        // Users often have multiple installations at once (e.g. `curl | sh` put
+        // the binary in ~/.local/bin and they later ran `cargo install freenet`
+        // which also dropped one in ~/.cargo/bin). Visiting only the directory
+        // of the running executable leaves stale copies behind.
+        let install_dirs = get_install_dirs(None);
+        let mut removed_any = false;
+        for dir in &install_dirs {
+            if !dir.exists() {
+                continue;
+            }
+            let removed = remove_binaries(dir)?;
+            if !removed.is_empty() {
+                removed_any = true;
+            }
+        }
+
+        // On Windows the PowerShell installer creates %LOCALAPPDATA%\Freenet\bin
+        // just for our binaries, so if it's now empty we can collapse the
+        // enclosing %LOCALAPPDATA%\Freenet\ folder as well. Other platforms
+        // drop binaries into shared dirs (~/.local/bin, ~/.cargo/bin) whose
+        // parents belong to unrelated tools — don't touch those.
+        #[cfg(target_os = "windows")]
+        if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+            let bin_dir = PathBuf::from(local_app_data).join("Freenet").join("bin");
+            super::service::remove_dir_if_empty_pub(&bin_dir);
+            if let Some(parent) = bin_dir.parent() {
+                super::service::remove_dir_if_empty_pub(parent);
+            }
+        }
 
         // Summary
-        if !service_removed && removed.is_empty() && !do_purge {
+        if !service_removed && !removed_any && !do_purge {
             println!("Freenet does not appear to be installed.");
         } else {
             println!();
@@ -48,7 +75,8 @@ impl UninstallCommand {
     }
 }
 
-/// Remove Freenet binaries. Returns the list of files that were removed.
+/// Remove Freenet binaries from the given install dir. Returns the list of
+/// files that were removed.
 fn remove_binaries(install_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut removed = Vec::new();
 
@@ -82,10 +110,6 @@ fn remove_binaries(install_dir: &Path) -> Result<Vec<PathBuf>> {
         removed.push(wrapper);
     }
 
-    if removed.is_empty() {
-        println!("No Freenet binaries found in {}", install_dir.display());
-    }
-
     Ok(removed)
 }
 
@@ -99,29 +123,48 @@ fn is_current_exe(path: &Path) -> bool {
         .is_some_and(|(a, b)| a == b)
 }
 
-/// Get the directory where Freenet binaries are installed.
+/// Get every directory that Freenet binaries may have been installed into,
+/// in no particular order (duplicates are removed).
 ///
-/// Priority: `override_dir` > `FREENET_INSTALL_DIR` env > current exe parent > `~/.local/bin`
-fn get_install_dir(override_dir: Option<&Path>) -> PathBuf {
+/// If `override_dir` or `FREENET_INSTALL_DIR` is set, only that location is
+/// returned — the caller has explicitly told us where to look. Otherwise we
+/// return the union of the install.sh default (`~/.local/bin`), the Cargo
+/// default (`~/.cargo/bin`), the Windows PowerShell installer default
+/// (`%LOCALAPPDATA%\Freenet\bin`), and the parent directory of the currently
+/// running executable.
+fn get_install_dirs(override_dir: Option<&Path>) -> Vec<PathBuf> {
     if let Some(dir) = override_dir {
-        return dir.to_path_buf();
+        return vec![dir.to_path_buf()];
     }
 
     if let Ok(dir) = std::env::var("FREENET_INSTALL_DIR") {
-        return PathBuf::from(dir);
+        return vec![PathBuf::from(dir)];
     }
 
-    // Detect from current executable location
+    let mut dirs: Vec<PathBuf> = Vec::new();
+
     if let Ok(exe) = std::env::current_exe() {
         if let Some(parent) = exe.parent() {
-            return parent.to_path_buf();
+            dirs.push(parent.to_path_buf());
         }
     }
 
-    // Fallback to default install location
-    dirs::home_dir()
-        .map(|h| h.join(".local/bin"))
-        .unwrap_or_else(|| PathBuf::from("/usr/local/bin"))
+    if let Some(home) = dirs::home_dir() {
+        dirs.push(home.join(".local/bin")); // install.sh default
+        dirs.push(home.join(".cargo/bin")); // `cargo install freenet` default
+    }
+
+    #[cfg(target_os = "windows")]
+    if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+        // install.ps1 default — not normally on PATH, so exe parent detection
+        // misses it when the user ran a different `freenet.exe` (e.g. from a
+        // crate install).
+        dirs.push(PathBuf::from(local_app_data).join("Freenet").join("bin"));
+    }
+
+    dirs.sort();
+    dirs.dedup();
+    dirs
 }
 
 /// Get the names of binaries to remove.
@@ -141,16 +184,55 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_install_dir_with_override() {
-        let dir = get_install_dir(Some(Path::new("/tmp/test-freenet")));
-        assert_eq!(dir, PathBuf::from("/tmp/test-freenet"));
+    fn test_get_install_dirs_with_override() {
+        let dirs = get_install_dirs(Some(Path::new("/tmp/test-freenet")));
+        assert_eq!(dirs, vec![PathBuf::from("/tmp/test-freenet")]);
     }
 
     #[test]
-    fn test_get_install_dir_without_override() {
-        // Without override, should return a non-empty path (env var or exe parent)
-        let dir = get_install_dir(None);
-        assert!(!dir.as_os_str().is_empty());
+    fn test_get_install_dirs_without_override_includes_defaults() {
+        // Ensure the env var isn't leaking from another test.
+        // Safe: tests in this module run single-threaded via cargo test.
+        unsafe {
+            std::env::remove_var("FREENET_INSTALL_DIR");
+        }
+
+        let dirs = get_install_dirs(None);
+        assert!(!dirs.is_empty(), "should always return at least exe parent");
+
+        // When $HOME is set, both user-local install dirs should appear.
+        if let Some(home) = dirs::home_dir() {
+            assert!(
+                dirs.contains(&home.join(".local/bin")),
+                "expected ~/.local/bin (install.sh default) in {dirs:?}",
+            );
+            assert!(
+                dirs.contains(&home.join(".cargo/bin")),
+                "expected ~/.cargo/bin (cargo install default) in {dirs:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_install_dirs_env_var_takes_precedence() {
+        // Safe: tests in this module run single-threaded via cargo test.
+        unsafe {
+            std::env::set_var("FREENET_INSTALL_DIR", "/custom/path");
+        }
+        let dirs = get_install_dirs(None);
+        unsafe {
+            std::env::remove_var("FREENET_INSTALL_DIR");
+        }
+        assert_eq!(dirs, vec![PathBuf::from("/custom/path")]);
+    }
+
+    #[test]
+    fn test_get_install_dirs_deduplicates() {
+        let dirs = get_install_dirs(None);
+        let mut sorted = dirs.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(dirs.len(), sorted.len(), "expected no duplicate entries");
     }
 
     #[test]
@@ -188,5 +270,20 @@ mod tests {
         assert!(!tmp.path().join("freenet").exists());
         assert!(!tmp.path().join("fdev").exists());
         assert!(!tmp.path().join("freenet-service-wrapper.sh").exists());
+    }
+
+    #[test]
+    fn test_remove_binaries_handles_partial_install() {
+        // A directory that contains freenet but not fdev (or vice versa)
+        // must not error — we're scanning multiple locations and may find
+        // only a subset of the binaries in any one of them.
+        let tmp = tempfile::tempdir().unwrap();
+        #[cfg(not(target_os = "windows"))]
+        std::fs::write(tmp.path().join("freenet"), b"fake").unwrap();
+        #[cfg(target_os = "windows")]
+        std::fs::write(tmp.path().join("freenet.exe"), b"fake").unwrap();
+
+        let removed = remove_binaries(tmp.path()).unwrap();
+        assert_eq!(removed.len(), 1);
     }
 }

--- a/crates/core/src/bin/commands/uninstall.rs
+++ b/crates/core/src/bin/commands/uninstall.rs
@@ -37,7 +37,8 @@ impl UninstallCommand {
         // the binary in ~/.local/bin and they later ran `cargo install freenet`
         // which also dropped one in ~/.cargo/bin). Visiting only the directory
         // of the running executable leaves stale copies behind.
-        let install_dirs = get_install_dirs(None);
+        let env = RuntimeEnv::from_process();
+        let install_dirs = get_install_dirs(None, &env);
         let mut removed_any = false;
         for dir in &install_dirs {
             if !dir.exists() {
@@ -55,12 +56,8 @@ impl UninstallCommand {
         // drop binaries into shared dirs (~/.local/bin, ~/.cargo/bin) whose
         // parents belong to unrelated tools — don't touch those.
         #[cfg(target_os = "windows")]
-        if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
-            let bin_dir = PathBuf::from(local_app_data).join("Freenet").join("bin");
-            super::service::remove_dir_if_empty_pub(&bin_dir);
-            if let Some(parent) = bin_dir.parent() {
-                super::service::remove_dir_if_empty_pub(parent);
-            }
+        if let Some(ref local_app_data) = env.local_app_data {
+            collapse_windows_bin_tree(local_app_data);
         }
 
         // Summary
@@ -72,6 +69,32 @@ impl UninstallCommand {
         }
 
         Ok(())
+    }
+}
+
+/// Captures the process-environment values `get_install_dirs` needs. Pulling
+/// these out into a value-typed struct lets tests supply explicit inputs
+/// instead of mutating process-global env vars (which races with parallel
+/// `cargo test` threads — see #3905 testing review).
+#[derive(Debug, Clone, Default)]
+struct RuntimeEnv {
+    freenet_install_dir: Option<PathBuf>,
+    home: Option<PathBuf>,
+    current_exe_parent: Option<PathBuf>,
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+    local_app_data: Option<PathBuf>,
+}
+
+impl RuntimeEnv {
+    fn from_process() -> Self {
+        Self {
+            freenet_install_dir: std::env::var_os("FREENET_INSTALL_DIR").map(PathBuf::from),
+            home: dirs::home_dir(),
+            current_exe_parent: std::env::current_exe()
+                .ok()
+                .and_then(|e| e.parent().map(|p| p.to_path_buf())),
+            local_app_data: std::env::var_os("LOCALAPPDATA").map(PathBuf::from),
+        }
     }
 }
 
@@ -126,45 +149,60 @@ fn is_current_exe(path: &Path) -> bool {
 /// Get every directory that Freenet binaries may have been installed into,
 /// in no particular order (duplicates are removed).
 ///
-/// If `override_dir` or `FREENET_INSTALL_DIR` is set, only that location is
-/// returned — the caller has explicitly told us where to look. Otherwise we
-/// return the union of the install.sh default (`~/.local/bin`), the Cargo
-/// default (`~/.cargo/bin`), the Windows PowerShell installer default
-/// (`%LOCALAPPDATA%\Freenet\bin`), and the parent directory of the currently
-/// running executable.
-fn get_install_dirs(override_dir: Option<&Path>) -> Vec<PathBuf> {
+/// If `override_dir` or `env.freenet_install_dir` is non-empty, only that
+/// location is returned — the caller has explicitly told us where to look.
+/// Otherwise we return the union of the install.sh default (`~/.local/bin`),
+/// the Cargo default (`~/.cargo/bin`), the Windows PowerShell installer
+/// default (`%LOCALAPPDATA%\Freenet\bin`), and the parent directory of the
+/// currently running executable.
+fn get_install_dirs(override_dir: Option<&Path>, env: &RuntimeEnv) -> Vec<PathBuf> {
     if let Some(dir) = override_dir {
         return vec![dir.to_path_buf()];
     }
 
-    if let Ok(dir) = std::env::var("FREENET_INSTALL_DIR") {
-        return vec![PathBuf::from(dir)];
+    if let Some(dir) = env
+        .freenet_install_dir
+        .as_ref()
+        .filter(|p| !p.as_os_str().is_empty())
+    {
+        return vec![dir.clone()];
     }
 
     let mut dirs: Vec<PathBuf> = Vec::new();
 
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(parent) = exe.parent() {
-            dirs.push(parent.to_path_buf());
-        }
+    if let Some(parent) = env.current_exe_parent.as_ref() {
+        dirs.push(parent.clone());
     }
 
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = env.home.as_ref() {
         dirs.push(home.join(".local/bin")); // install.sh default
         dirs.push(home.join(".cargo/bin")); // `cargo install freenet` default
     }
 
     #[cfg(target_os = "windows")]
-    if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+    if let Some(local_app_data) = env.local_app_data.as_ref() {
         // install.ps1 default — not normally on PATH, so exe parent detection
         // misses it when the user ran a different `freenet.exe` (e.g. from a
         // crate install).
-        dirs.push(PathBuf::from(local_app_data).join("Freenet").join("bin"));
+        dirs.push(local_app_data.join("Freenet").join("bin"));
     }
 
     dirs.sort();
     dirs.dedup();
     dirs
+}
+
+/// On Windows, collapse `%LOCALAPPDATA%\Freenet\bin` and its enclosing
+/// `%LOCALAPPDATA%\Freenet\` folder if each is now empty. Extracted so the
+/// behavior is testable on any platform (unlike the caller, which is
+/// `#[cfg(target_os = "windows")]` and can't run in Linux CI).
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn collapse_windows_bin_tree(local_app_data: &Path) {
+    let bin_dir = local_app_data.join("Freenet").join("bin");
+    super::service::remove_dir_if_empty_pub(&bin_dir);
+    if let Some(parent) = bin_dir.parent() {
+        super::service::remove_dir_if_empty_pub(parent);
+    }
 }
 
 /// Get the names of binaries to remove.
@@ -183,56 +221,99 @@ fn binary_names() -> &'static [&'static str] {
 mod tests {
     use super::*;
 
+    fn env_with(home: Option<&Path>, exe_parent: Option<&Path>) -> RuntimeEnv {
+        RuntimeEnv {
+            freenet_install_dir: None,
+            home: home.map(Path::to_path_buf),
+            current_exe_parent: exe_parent.map(Path::to_path_buf),
+            local_app_data: None,
+        }
+    }
+
     #[test]
     fn test_get_install_dirs_with_override() {
-        let dirs = get_install_dirs(Some(Path::new("/tmp/test-freenet")));
+        let env = env_with(Some(Path::new("/home/u")), Some(Path::new("/exe")));
+        let dirs = get_install_dirs(Some(Path::new("/tmp/test-freenet")), &env);
         assert_eq!(dirs, vec![PathBuf::from("/tmp/test-freenet")]);
     }
 
     #[test]
     fn test_get_install_dirs_without_override_includes_defaults() {
-        // Ensure the env var isn't leaking from another test.
-        // Safe: tests in this module run single-threaded via cargo test.
-        unsafe {
-            std::env::remove_var("FREENET_INSTALL_DIR");
-        }
+        let home = PathBuf::from("/home/u");
+        let exe_parent = PathBuf::from("/exe");
+        let env = env_with(Some(&home), Some(&exe_parent));
 
-        let dirs = get_install_dirs(None);
-        assert!(!dirs.is_empty(), "should always return at least exe parent");
-
-        // When $HOME is set, both user-local install dirs should appear.
-        if let Some(home) = dirs::home_dir() {
-            assert!(
-                dirs.contains(&home.join(".local/bin")),
-                "expected ~/.local/bin (install.sh default) in {dirs:?}",
-            );
-            assert!(
-                dirs.contains(&home.join(".cargo/bin")),
-                "expected ~/.cargo/bin (cargo install default) in {dirs:?}",
-            );
-        }
+        let dirs = get_install_dirs(None, &env);
+        assert!(dirs.contains(&home.join(".local/bin")), "{dirs:?}");
+        assert!(dirs.contains(&home.join(".cargo/bin")), "{dirs:?}");
+        assert!(dirs.contains(&exe_parent), "{dirs:?}");
     }
 
     #[test]
     fn test_get_install_dirs_env_var_takes_precedence() {
-        // Safe: tests in this module run single-threaded via cargo test.
-        unsafe {
-            std::env::set_var("FREENET_INSTALL_DIR", "/custom/path");
-        }
-        let dirs = get_install_dirs(None);
-        unsafe {
-            std::env::remove_var("FREENET_INSTALL_DIR");
-        }
+        let mut env = env_with(Some(Path::new("/home/u")), Some(Path::new("/exe")));
+        env.freenet_install_dir = Some(PathBuf::from("/custom/path"));
+
+        let dirs = get_install_dirs(None, &env);
+
         assert_eq!(dirs, vec![PathBuf::from("/custom/path")]);
     }
 
     #[test]
-    fn test_get_install_dirs_deduplicates() {
-        let dirs = get_install_dirs(None);
-        let mut sorted = dirs.clone();
-        sorted.sort();
-        sorted.dedup();
-        assert_eq!(dirs.len(), sorted.len(), "expected no duplicate entries");
+    fn test_get_install_dirs_empty_env_var_falls_through() {
+        // FREENET_INSTALL_DIR="" (explicitly empty) must not short-circuit
+        // to an empty PathBuf — that would collapse to the current dir and
+        // silently skip the defaults.
+        let mut env = env_with(Some(Path::new("/home/u")), None);
+        env.freenet_install_dir = Some(PathBuf::from(""));
+
+        let dirs = get_install_dirs(None, &env);
+
+        assert!(
+            dirs.contains(&PathBuf::from("/home/u/.local/bin")),
+            "empty env var should fall through to defaults, got {dirs:?}",
+        );
+        assert!(!dirs.contains(&PathBuf::from("")), "{dirs:?}");
+    }
+
+    #[test]
+    fn test_get_install_dirs_override_beats_env_var() {
+        // Explicit `override_dir` wins over `FREENET_INSTALL_DIR`.
+        let mut env = env_with(Some(Path::new("/home/u")), None);
+        env.freenet_install_dir = Some(PathBuf::from("/env/value"));
+
+        let dirs = get_install_dirs(Some(Path::new("/explicit/override")), &env);
+
+        assert_eq!(dirs, vec![PathBuf::from("/explicit/override")]);
+    }
+
+    #[test]
+    fn test_get_install_dirs_deduplicates_exe_parent_overlap() {
+        // If the running exe is already inside ~/.local/bin, both the
+        // exe-parent entry and the curl-installer-default entry resolve
+        // to the same path — make sure we only keep one copy.
+        let home = PathBuf::from("/home/u");
+        let exe_parent = home.join(".local/bin");
+        let env = env_with(Some(&home), Some(&exe_parent));
+
+        let dirs = get_install_dirs(None, &env);
+        let mut expected = dirs.clone();
+        expected.sort();
+        expected.dedup();
+        assert_eq!(dirs.len(), expected.len(), "{dirs:?}");
+        let local_bin_count = dirs.iter().filter(|d| **d == exe_parent).count();
+        assert_eq!(local_bin_count, 1, "{dirs:?}");
+    }
+
+    #[test]
+    fn test_get_install_dirs_missing_home() {
+        // With no home directory available (e.g. chrooted environment), we
+        // still return something usable rather than an empty vec.
+        let env = env_with(None, Some(Path::new("/opt/freenet/bin")));
+
+        let dirs = get_install_dirs(None, &env);
+
+        assert_eq!(dirs, vec![PathBuf::from("/opt/freenet/bin")]);
     }
 
     #[test]
@@ -274,16 +355,73 @@ mod tests {
 
     #[test]
     fn test_remove_binaries_handles_partial_install() {
-        // A directory that contains freenet but not fdev (or vice versa)
-        // must not error — we're scanning multiple locations and may find
-        // only a subset of the binaries in any one of them.
+        // A directory that contains only `freenet` (not `fdev`) must not
+        // error. Importantly, we also assert that `fdev` is still absent
+        // afterward — we must NOT synthesize a file we didn't find.
         let tmp = tempfile::tempdir().unwrap();
         #[cfg(not(target_os = "windows"))]
-        std::fs::write(tmp.path().join("freenet"), b"fake").unwrap();
+        {
+            std::fs::write(tmp.path().join("freenet"), b"fake").unwrap();
+            let removed = remove_binaries(tmp.path()).unwrap();
+            assert_eq!(removed.len(), 1);
+            assert!(!tmp.path().join("freenet").exists());
+            assert!(!tmp.path().join("fdev").exists());
+        }
         #[cfg(target_os = "windows")]
-        std::fs::write(tmp.path().join("freenet.exe"), b"fake").unwrap();
+        {
+            std::fs::write(tmp.path().join("freenet.exe"), b"fake").unwrap();
+            let removed = remove_binaries(tmp.path()).unwrap();
+            assert_eq!(removed.len(), 1);
+            assert!(!tmp.path().join("freenet.exe").exists());
+            assert!(!tmp.path().join("fdev.exe").exists());
+        }
+    }
 
-        let removed = remove_binaries(tmp.path()).unwrap();
-        assert_eq!(removed.len(), 1);
+    #[test]
+    fn test_collapse_windows_bin_tree_removes_empty_tree() {
+        // Simulates the layout install.ps1 creates: `<LocalAppData>\Freenet\bin\`
+        // with both levels empty after our binary cleanup. Expected: both
+        // levels collapse, but the `<LocalAppData>` root is left alone.
+        let tmp = tempfile::tempdir().unwrap();
+        let local_app_data = tmp.path();
+        let freenet = local_app_data.join("Freenet");
+        let bin = freenet.join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+
+        collapse_windows_bin_tree(local_app_data);
+
+        assert!(!bin.exists(), "bin should be gone");
+        assert!(!freenet.exists(), "Freenet parent should collapse");
+        assert!(local_app_data.exists(), "LocalAppData root must stay");
+    }
+
+    #[test]
+    fn test_collapse_windows_bin_tree_preserves_non_empty_sibling() {
+        // If another tool created `<LocalAppData>\Freenet\data\` (not us,
+        // but imagine a future subcommand), we must NOT remove `Freenet\`
+        // when only `bin\` is empty.
+        let tmp = tempfile::tempdir().unwrap();
+        let local_app_data = tmp.path();
+        let freenet = local_app_data.join("Freenet");
+        let bin = freenet.join("bin");
+        let foreign = freenet.join("other-tool");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(&foreign).unwrap();
+        std::fs::write(foreign.join("state.bin"), b"unrelated").unwrap();
+
+        collapse_windows_bin_tree(local_app_data);
+
+        assert!(!bin.exists(), "empty bin should still collapse");
+        assert!(freenet.exists(), "non-empty Freenet parent must stay");
+        assert!(foreign.join("state.bin").exists(), "foreign data preserved");
+    }
+
+    #[test]
+    fn test_collapse_windows_bin_tree_missing_tree_is_noop() {
+        // Most Linux installs don't have this tree at all. The helper must
+        // not panic or complain in that case.
+        let tmp = tempfile::tempdir().unwrap();
+        collapse_windows_bin_tree(tmp.path());
+        assert!(tmp.path().exists());
     }
 }


### PR DESCRIPTION
## Problem

Two user-visible bugs in `freenet uninstall`:

**1. Stale binaries from mixed install methods.** The command detects the install directory by looking at `current_exe().parent()` only. A user who ran the `curl | sh` installer (places binaries in `~/.local/bin`) and later `cargo install freenet` (places a binary in `~/.cargo/bin`) ends up with the uninstall removing whichever was on PATH first, leaving the other behind to shadow future reinstalls. Same failure mode on Windows: the PowerShell installer puts binaries in `%LOCALAPPDATA%\Freenet\bin`, which PATH detection misses when a different `freenet.exe` is active.

**2. Empty parent folders left behind on Windows** (reported on Matrix by @Ivvvor, filed as #3904). `purge_data_dirs` removes the leaf `data`, `config`, and `cache` subfolders but never touches their common parent, so `%APPDATA%\The Freenet Project Inc\Freenet\` — and analogously `%LOCALAPPDATA%\freenet\` once its `logs` child is gone — stays on disk long after uninstall claims completion.

## Approach

**Install-dir detection is now multi-site.** `get_install_dir` is replaced with `get_install_dirs` (plural) returning the union of the running-exe parent, `~/.local/bin`, `~/.cargo/bin`, and `%LOCALAPPDATA%\Freenet\bin`. `FREENET_INSTALL_DIR` and the explicit `override_dir` arg still short-circuit to a single location. Missing dirs are skipped silently; present dirs have their binaries removed, and on Windows the enclosing `%LOCALAPPDATA%\Freenet\` collapses once `bin\` is gone.

**Parent-folder cleanup is explicit.** `purge_data_dirs` now builds a `DataLeaves` value and delegates to `purge_leaves_and_collapse`, which removes every leaf, collects their parents, then visits the parents deepest-first to collapse any that became empty. A `remove_dir_if_empty` helper enforces safety: it removes a directory only if it contains nothing, so a non-empty sibling app's data under `The Freenet Project Inc\` is preserved.

The overall behavior on a clean Linux install is unchanged; the extra work only kicks in when multiple install sources coexist or when a formerly-Freenet parent is now empty.

## Testing

25 new unit / integration tests covering:

- **`get_install_dirs`** precedence (override > env var > defaults), empty env-var fallthrough, override beating env var, exe-parent/cargo-bin dedup, missing home dir.
- **`remove_dir_if_empty`** safety: empty-dir removal, single-file preservation, subdirectory-tree preservation, missing path, regular file, full children-then-collapse scenario.
- **`purge_leaves_and_collapse` wiring** (the actual #3904 regression site): full Windows-like layout cleanup, sibling-app-grandparent preservation, log-parent gate, missing optional leaves.
- **`collapse_windows_bin_tree`**: extracted so Linux CI can exercise it; tests for empty tree, non-empty sibling preservation, missing tree.

The wiring-level tests mean reverting any individual `push_parent(...)` call at a future date would fail a test, not silently regress #3904.

Tests explicitly chose the unit level because the behavior is pure filesystem manipulation with no network or timing surface. A Windows matrix integration test seeding the actual `%LOCALAPPDATA%` layout would be the next level of coverage; filed as a follow-up but out of scope for this PR.

Full `cargo test -p freenet --bin freenet` (74 tests) passes; `cargo clippy --all-targets -- -D warnings` clean.

## Fixes

Closes #3904

## Out of scope

- **HKCU `Run` registry key** was called out in #3904 as a potential leftover. Skipped here because `install.ps1` does not write a Run entry — it uses `freenet service install` (Task Scheduler) instead, which `stop_and_remove_service` already handles.
- **Auto-update detection of stale installs.** Separate concern.

## Related

- freenet/web#35 merged documentation for the same user-visible problem.
- A follow-up freenet-core PR will add a standalone `uninstall.sh` companion script and update `install.sh`'s final message to steer users away from `sudo freenet uninstall`.

[AI-assisted - Claude]