### PR TITLE
fix(server): accept WS Host headers with IPs in allowed-source-cidrs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ test-results/
 worktrees/
 logs/
 .grepai/
+.codex

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -172,6 +172,61 @@ fn is_allowed_host(headers: &axum::http::HeaderMap, allowed_hosts: &HashSet<Stri
     allowed_hosts.contains(&host_header.to_lowercase())
 }
 
+/// Returns `true` if the request's `Host` header is an IP literal that falls
+/// within one of the operator-allowed source CIDRs.
+///
+/// When a user opts in to `--allowed-source-cidrs` (e.g. for Tailscale access),
+/// they will reach the node via an IP in that range. The browser's `Host`
+/// header for such a request is that IP literal, so we treat it as a
+/// first-class allowed host — saving operators from having to duplicate every
+/// address on every peer in a separate `allowed-host` list.
+///
+/// Hostnames (including DNS-rebinding bait like `evil.com`) are ignored here;
+/// only string-parseable IP literals are considered. This preserves the
+/// DNS-rebinding protection `is_allowed_host` exists for: the attacker cannot
+/// smuggle a hostname through by resolving it locally, because we never
+/// resolve — we only accept IPs that are already in the operator's trusted
+/// range.
+fn host_header_ip_in_cidrs(
+    headers: &axum::http::HeaderMap,
+    allowed_cidrs: &crate::server::AllowedSourceCidrs,
+) -> bool {
+    if allowed_cidrs.is_empty() {
+        return false;
+    }
+    let Some(host_header) = headers
+        .get(axum::http::header::HOST)
+        .and_then(|h| h.to_str().ok())
+    else {
+        return false;
+    };
+    let Some(ip) = parse_host_header_ip(host_header) else {
+        return false;
+    };
+    allowed_cidrs.contains_ip(&ip)
+}
+
+/// Extracts the IP part of a `Host` header value, handling `host:port`,
+/// `[v6]:port`, and bare IPv6 forms. Returns `None` if the host part isn't a
+/// parseable IP literal (i.e. it's a hostname).
+fn parse_host_header_ip(host_header: &str) -> Option<std::net::IpAddr> {
+    let host = host_header.trim();
+    // Bracketed IPv6 form: `[::1]` or `[::1]:7509`.
+    if let Some(rest) = host.strip_prefix('[') {
+        let end = rest.find(']')?;
+        return rest[..end].parse().ok();
+    }
+    // For non-bracketed forms, treat a single colon as `host:port`; anything
+    // with more than one colon is a bare IPv6 literal without brackets
+    // (technically non-conformant, but browsers never produce it — we still
+    // try to parse it for safety).
+    let candidate = match host.as_bytes().iter().filter(|&&b| b == b':').count() {
+        0 | 1 => host.rsplit_once(':').map(|(h, _)| h).unwrap_or(host),
+        _ => host,
+    };
+    candidate.parse().ok()
+}
+
 /// Checks if an error represents a client-side disconnect rather than a server error.
 ///
 /// Client disconnects are expected behavior when clients timeout, crash, or close
@@ -420,6 +475,7 @@ async fn connection_info(
         streaming: _,
     }): Query<ConnectionInfo>,
     Extension(allowed_hosts): Extension<crate::server::AllowedHosts>,
+    Extension(allowed_source_cidrs): Extension<crate::server::AllowedSourceCidrs>,
     mut req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> Response {
@@ -481,8 +537,23 @@ async fn connection_info(
     if is_ws_upgrade {
         if let Some(origin) = req.headers().get(axum::http::header::ORIGIN) {
             if let Ok(origin_str) = origin.to_str() {
+                // Accept the upgrade if any of:
+                // 1. The origin is a localhost form (browser page loaded from
+                //    the same machine), OR
+                // 2. The Host header matches an auto-detected or operator-
+                //    configured hostname (DNS-rebinding protection), OR
+                // 3. The Host header is an IP literal inside one of the
+                //    operator-allowed source CIDRs. This is the path that
+                //    unblocks Tailscale-style access: the node is reached
+                //    at e.g. `http://100.64.1.5:7509`, so the Host header is
+                //    `100.64.1.5:7509` — never in `allowed_hosts` unless the
+                //    operator duplicated every peer address into it.
+                //    Matching by IP (not hostname) preserves the rebinding
+                //    defense: a malicious `evil.com` can't smuggle through
+                //    because we never resolve DNS here.
                 if !is_localhost_origin(origin_str)
                     && !is_allowed_host(req.headers(), &allowed_hosts)
+                    && !host_header_ip_in_cidrs(req.headers(), &allowed_source_cidrs)
                 {
                     let host_header = req
                         .headers()
@@ -1647,15 +1718,6 @@ mod tests {
         .map(|s| s.to_string())
         .collect();
 
-        fn headers_with_host(host: &str) -> axum::http::HeaderMap {
-            let mut map = axum::http::HeaderMap::new();
-            map.insert(
-                axum::http::header::HOST,
-                axum::http::HeaderValue::from_str(host).unwrap(),
-            );
-            map
-        }
-
         // Allowed: host with port
         assert!(is_allowed_host(
             &headers_with_host("192.168.1.50:7509"),
@@ -1692,6 +1754,166 @@ mod tests {
         assert!(is_allowed_host(
             &headers_with_host("LOCALHOST:7509"),
             &allowed
+        ));
+    }
+
+    fn headers_with_host(host: &str) -> axum::http::HeaderMap {
+        let mut map = axum::http::HeaderMap::new();
+        map.insert(
+            axum::http::header::HOST,
+            axum::http::HeaderValue::from_str(host).unwrap(),
+        );
+        map
+    }
+
+    fn cidrs(list: &[&str]) -> crate::server::AllowedSourceCidrs {
+        crate::server::AllowedSourceCidrs(Arc::new(
+            list.iter().map(|s| s.parse().unwrap()).collect(),
+        ))
+    }
+
+    /// Parsing: `host:port`, `[v6]`, `[v6]:port`, bare v6, and hostnames.
+    #[test]
+    fn parse_host_header_ip_variants() {
+        assert_eq!(
+            parse_host_header_ip("100.64.1.5:7509"),
+            Some("100.64.1.5".parse().unwrap())
+        );
+        assert_eq!(
+            parse_host_header_ip("100.64.1.5"),
+            Some("100.64.1.5".parse().unwrap())
+        );
+        assert_eq!(
+            parse_host_header_ip("[fd7a:115c:a1e0::1]:7509"),
+            Some("fd7a:115c:a1e0::1".parse().unwrap())
+        );
+        assert_eq!(
+            parse_host_header_ip("[fd7a:115c:a1e0::1]"),
+            Some("fd7a:115c:a1e0::1".parse().unwrap())
+        );
+        // Bare IPv6 without brackets (non-conformant but parseable).
+        assert_eq!(
+            parse_host_header_ip("fd7a:115c:a1e0::1"),
+            Some("fd7a:115c:a1e0::1".parse().unwrap())
+        );
+        // Hostnames must not parse as IPs.
+        assert_eq!(parse_host_header_ip("evil.com"), None);
+        assert_eq!(parse_host_header_ip("evil.com:7509"), None);
+        assert_eq!(parse_host_header_ip("localhost:7509"), None);
+        assert_eq!(parse_host_header_ip(""), None);
+    }
+
+    /// Regression for the v0.2.47 gap: a user configuring
+    /// `allowed-source-cidrs = ["100.64.0.0/10"]` to reach their node via
+    /// Tailscale must be able to complete the WebSocket upgrade. The Host
+    /// header they send is their own tailnet IP, which is not in
+    /// `allowed_hosts` unless duplicated manually. Before the fix, `is_ws_upgrade`
+    /// rejected these with 403.
+    #[test]
+    fn host_header_ip_in_tailscale_cidr_allowed() {
+        let allowed = cidrs(&["100.64.0.0/10"]);
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("100.64.1.5:7509"),
+            &allowed,
+        ));
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("100.64.1.5"),
+            &allowed,
+        ));
+        // A neighbouring user's tailnet IP is still inside 100.64.0.0/10 —
+        // if the operator widened the CIDR, that's the operator's choice.
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("100.127.9.9:7509"),
+            &allowed,
+        ));
+    }
+
+    /// IPs that fall OUTSIDE the operator's CIDR must still be rejected,
+    /// even when the CIDR list is non-empty. This is the regression guard
+    /// against "CIDR match accidentally widened to any IP".
+    #[test]
+    fn host_header_ip_outside_cidr_rejected() {
+        let allowed = cidrs(&["100.64.0.0/10"]);
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("8.8.8.8:7509"),
+            &allowed,
+        ));
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("100.128.0.1:7509"),
+            &allowed,
+        ));
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("100.63.255.255:7509"),
+            &allowed,
+        ));
+    }
+
+    /// DNS-rebinding defense: hostnames must NEVER be accepted via the CIDR
+    /// path, even if the attacker sets up a DNS record that resolves to an
+    /// IP inside the allowed CIDR. We intentionally do not resolve DNS in
+    /// this middleware; only string-parseable IP literals are considered.
+    #[test]
+    fn host_header_hostname_never_accepted_via_cidr() {
+        let allowed = cidrs(&["100.64.0.0/10"]);
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("evil.com"),
+            &allowed,
+        ));
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("evil.com:7509"),
+            &allowed,
+        ));
+        // A hostname that happens to look like an IP at a glance — still a
+        // hostname to `IpAddr::from_str`, so still rejected.
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("100-64-1-5.evil.com"),
+            &allowed,
+        ));
+    }
+
+    /// Empty CIDR list is the default posture. Zero IPs must match, so a
+    /// user who never opted in gets no behaviour change. This is load-bearing
+    /// for the default-deny guarantee.
+    #[test]
+    fn host_header_empty_cidrs_matches_nothing() {
+        let empty = crate::server::AllowedSourceCidrs::default();
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("100.64.1.5:7509"),
+            &empty,
+        ));
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("127.0.0.1:7509"),
+            &empty,
+        ));
+    }
+
+    /// IPv6 CIDRs must work end-to-end, including the bracketed `[v6]:port`
+    /// form browsers send in the Host header.
+    #[test]
+    fn host_header_ipv6_in_cidr_allowed() {
+        let allowed = cidrs(&["fd7a:115c:a1e0::/48"]);
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("[fd7a:115c:a1e0::1]:7509"),
+            &allowed,
+        ));
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("[fd7a:115c:a1e0::1]"),
+            &allowed,
+        ));
+        // Outside the /48.
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("[fd7a:115c:a1e1::1]:7509"),
+            &allowed,
+        ));
+    }
+
+    /// Missing Host header must not panic and must not accept.
+    #[test]
+    fn host_header_missing_rejected() {
+        let allowed = cidrs(&["100.64.0.0/10"]);
+        assert!(!host_header_ip_in_cidrs(
+            &axum::http::HeaderMap::new(),
+            &allowed,
         ));
     }
 

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -175,18 +175,11 @@ fn is_allowed_host(headers: &axum::http::HeaderMap, allowed_hosts: &HashSet<Stri
 /// Returns `true` if the request's `Host` header is an IP literal that falls
 /// within one of the operator-allowed source CIDRs.
 ///
-/// When a user opts in to `--allowed-source-cidrs` (e.g. for Tailscale access),
-/// they will reach the node via an IP in that range. The browser's `Host`
-/// header for such a request is that IP literal, so we treat it as a
-/// first-class allowed host — saving operators from having to duplicate every
-/// address on every peer in a separate `allowed-host` list.
-///
-/// Hostnames (including DNS-rebinding bait like `evil.com`) are ignored here;
-/// only string-parseable IP literals are considered. This preserves the
-/// DNS-rebinding protection `is_allowed_host` exists for: the attacker cannot
-/// smuggle a hostname through by resolving it locally, because we never
-/// resolve — we only accept IPs that are already in the operator's trusted
-/// range.
+/// Only string-parseable IP literals are considered; hostnames are never
+/// matched. This preserves the DNS-rebinding defense provided by
+/// `is_allowed_host`: an attacker at `evil.com` cannot smuggle through by
+/// resolving their hostname to an IP in the allowed range, because we never
+/// resolve DNS here.
 fn host_header_ip_in_cidrs(
     headers: &axum::http::HeaderMap,
     allowed_cidrs: &crate::server::AllowedSourceCidrs,
@@ -207,8 +200,8 @@ fn host_header_ip_in_cidrs(
 }
 
 /// Extracts the IP part of a `Host` header value, handling `host:port`,
-/// `[v6]:port`, and bare IPv6 forms. Returns `None` if the host part isn't a
-/// parseable IP literal (i.e. it's a hostname).
+/// `[v6]`, `[v6]:port`, and bare IPv6 forms. Returns `None` if the host part
+/// isn't a parseable IP literal (i.e. it's a hostname).
 fn parse_host_header_ip(host_header: &str) -> Option<std::net::IpAddr> {
     let host = host_header.trim();
     // Bracketed IPv6 form: `[::1]` or `[::1]:7509`.
@@ -216,15 +209,13 @@ fn parse_host_header_ip(host_header: &str) -> Option<std::net::IpAddr> {
         let end = rest.find(']')?;
         return rest[..end].parse().ok();
     }
-    // For non-bracketed forms, treat a single colon as `host:port`; anything
-    // with more than one colon is a bare IPv6 literal without brackets
-    // (technically non-conformant, but browsers never produce it — we still
-    // try to parse it for safety).
-    let candidate = match host.as_bytes().iter().filter(|&&b| b == b':').count() {
-        0 | 1 => host.rsplit_once(':').map(|(h, _)| h).unwrap_or(host),
-        _ => host,
-    };
-    candidate.parse().ok()
+    // Try the whole thing first: handles bare IPv4 (`100.64.1.5`) and bare
+    // IPv6 (`fd7a::1`, non-conformant but parseable). If that fails and
+    // there's a trailing `:port`, strip it and retry.
+    if let Ok(ip) = host.parse() {
+        return Some(ip);
+    }
+    host.rsplit_once(':').and_then(|(h, _)| h.parse().ok())
 }
 
 /// Checks if an error represents a client-side disconnect rather than a server error.
@@ -537,20 +528,12 @@ async fn connection_info(
     if is_ws_upgrade {
         if let Some(origin) = req.headers().get(axum::http::header::ORIGIN) {
             if let Ok(origin_str) = origin.to_str() {
-                // Accept the upgrade if any of:
-                // 1. The origin is a localhost form (browser page loaded from
-                //    the same machine), OR
-                // 2. The Host header matches an auto-detected or operator-
-                //    configured hostname (DNS-rebinding protection), OR
-                // 3. The Host header is an IP literal inside one of the
-                //    operator-allowed source CIDRs. This is the path that
-                //    unblocks Tailscale-style access: the node is reached
-                //    at e.g. `http://100.64.1.5:7509`, so the Host header is
-                //    `100.64.1.5:7509` — never in `allowed_hosts` unless the
-                //    operator duplicated every peer address into it.
-                //    Matching by IP (not hostname) preserves the rebinding
-                //    defense: a malicious `evil.com` can't smuggle through
-                //    because we never resolve DNS here.
+                // Accept the upgrade if the origin is localhost, the Host
+                // header matches an allowed hostname, or the Host header is
+                // an IP inside an operator-allowed source CIDR (the path
+                // that unblocks Tailscale-style access). See the
+                // `host_header_ip_in_cidrs` docs for why matching by IP
+                // preserves the DNS-rebinding defense.
                 if !is_localhost_origin(origin_str)
                     && !is_allowed_host(req.headers(), &allowed_hosts)
                     && !host_header_ip_in_cidrs(req.headers(), &allowed_source_cidrs)
@@ -1820,7 +1803,7 @@ mod tests {
             &headers_with_host("100.64.1.5"),
             &allowed,
         ));
-        // A neighbouring user's tailnet IP is still inside 100.64.0.0/10 —
+        // A neighbouring user's tailnet IP is still inside 100.64.0.0/10;
         // if the operator widened the CIDR, that's the operator's choice.
         assert!(host_header_ip_in_cidrs(
             &headers_with_host("100.127.9.9:7509"),
@@ -1828,9 +1811,8 @@ mod tests {
         ));
     }
 
-    /// IPs that fall OUTSIDE the operator's CIDR must still be rejected,
-    /// even when the CIDR list is non-empty. This is the regression guard
-    /// against "CIDR match accidentally widened to any IP".
+    /// Regression guard against a CIDR match accidentally widening to any IP:
+    /// a non-empty allowlist must still reject IPs outside its ranges.
     #[test]
     fn host_header_ip_outside_cidr_rejected() {
         let allowed = cidrs(&["100.64.0.0/10"]);
@@ -1863,7 +1845,7 @@ mod tests {
             &headers_with_host("evil.com:7509"),
             &allowed,
         ));
-        // A hostname that happens to look like an IP at a glance — still a
+        // A hostname that happens to look like an IP at a glance is still a
         // hostname to `IpAddr::from_str`, so still rejected.
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("100-64-1-5.evil.com"),
@@ -1871,9 +1853,8 @@ mod tests {
         ));
     }
 
-    /// Empty CIDR list is the default posture. Zero IPs must match, so a
-    /// user who never opted in gets no behaviour change. This is load-bearing
-    /// for the default-deny guarantee.
+    /// Default-deny: with no `--allowed-source-cidrs` configured, no Host IP
+    /// may match. Users who never opt in get zero behaviour change.
     #[test]
     fn host_header_empty_cidrs_matches_nothing() {
         let empty = crate::server::AllowedSourceCidrs::default();

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -172,16 +172,29 @@ fn is_allowed_host(headers: &axum::http::HeaderMap, allowed_hosts: &HashSet<Stri
     allowed_hosts.contains(&host_header.to_lowercase())
 }
 
-/// Returns `true` if the request's `Host` header is an IP literal that falls
-/// within one of the operator-allowed source CIDRs.
+/// Returns `true` if the request's `Host` header IP is inside an operator-allowed
+/// source CIDR **and** the `Origin` is compatible with it.
 ///
-/// Only string-parseable IP literals are considered; hostnames are never
-/// matched. This preserves the DNS-rebinding defense provided by
-/// `is_allowed_host`: an attacker at `evil.com` cannot smuggle through by
-/// resolving their hostname to an IP in the allowed range, because we never
-/// resolve DNS here.
+/// "Compatible" means one of:
+/// - `Origin: null` — sandboxed iframe served from the same node (Freenet's
+///   default dApp sandbox intentionally strips origin).
+/// - `Origin` is an IP literal matching the same Host IP (direct browser
+///   access from a user-typed URL).
+///
+/// This is strict on purpose: returning `true` here grants full WS access
+/// to the fully-privileged client API, so we require that the Origin
+/// genuinely corresponds to the Host. An attacker at `https://evil.com`
+/// whose JS targets `ws://<victim-tailnet-ip>:7509/...` sends
+/// `Origin: https://evil.com`, which parses to the hostname `evil.com` —
+/// not an IP, not matching the Host IP — so we refuse. This closes the
+/// cross-site WebSocket hijacking (CSWSH) vector flagged during review of
+/// this PR's earlier iteration.
+///
+/// Only string-parseable IP literals are considered for Host/Origin; DNS
+/// is never resolved, which preserves the DNS-rebinding defence.
 fn host_header_ip_in_cidrs(
     headers: &axum::http::HeaderMap,
+    origin_str: &str,
     allowed_cidrs: &crate::server::AllowedSourceCidrs,
 ) -> bool {
     if allowed_cidrs.is_empty() {
@@ -196,36 +209,138 @@ fn host_header_ip_in_cidrs(
     let Some(ip) = parse_host_header_ip(host_header) else {
         return false;
     };
-    // Normalize IPv4-mapped IPv6 (`::ffff:a.b.c.d`) to IPv4 so an operator's
-    // v4 CIDR matches regardless of which address family the browser chose
-    // when building the Host header. Mirrors `is_source_allowed` in server.rs.
-    let match_ip = match ip {
+    let host_ip = normalize_mapped_v6(ip);
+    if !allowed_cidrs.contains_ip(&host_ip) {
+        return false;
+    }
+    origin_compatible_with_host_ip(origin_str, host_ip)
+}
+
+/// Decides whether an `Origin` header value is compatible with a `Host` IP
+/// that's already been confirmed to be inside an allowed CIDR.
+///
+/// See `host_header_ip_in_cidrs` for the full rationale.
+fn origin_compatible_with_host_ip(origin_str: &str, host_ip: std::net::IpAddr) -> bool {
+    // `Origin: null` is what Freenet's dApp sandbox iframe actually sends.
+    // A malicious sandboxed iframe on evil.com would also send `null`, but
+    // that's the same risk surface as an operator-configured `allowed-host`
+    // entry (existing behaviour); extending the risk to operator-configured
+    // CIDRs is a deliberate choice documented in the PR description.
+    if origin_str == "null" {
+        return true;
+    }
+    let Some(origin_host) = parse_origin_host(origin_str) else {
+        return false;
+    };
+    let Ok(origin_ip) = origin_host.parse::<std::net::IpAddr>() else {
+        // Origin is a hostname (e.g. `evil.com`). Never accept — this is the
+        // primary CSWSH guard.
+        return false;
+    };
+    normalize_mapped_v6(origin_ip) == host_ip
+}
+
+/// Extracts the IP part of a `Host` header value, handling `host:port`,
+/// `[v6]`, and `[v6]:port`. Returns `None` on any deviation from these
+/// forms, including bare unbracketed IPv6, malformed brackets, trailing
+/// garbage, and non-numeric ports.
+///
+/// Strict parsing is deliberate: this function gates a security decision
+/// (CIDR membership for WS upgrades), so any ambiguous input must fail
+/// closed. RFC 7230 requires brackets for IPv6 in the Host header;
+/// anything else is either a bug or an attempt to confuse the parser.
+fn parse_host_header_ip(host_header: &str) -> Option<std::net::IpAddr> {
+    let host = host_header.trim();
+    // Bracketed IPv6 form: `[...]` or `[...]:port`. The content inside the
+    // brackets must parse as IPv6 (not IPv4 — RFC 3986 forbids bracketed
+    // v4). Anything after `]` must be either empty or a numeric port.
+    if let Some(rest) = host.strip_prefix('[') {
+        let end = rest.find(']')?;
+        let inside = &rest[..end];
+        let after = &rest[end + 1..];
+        let v6: std::net::Ipv6Addr = inside.parse().ok()?;
+        if !after.is_empty() && !is_colon_port(after) {
+            return None;
+        }
+        return Some(std::net::IpAddr::V6(v6));
+    }
+    // Unbracketed: must be IPv4 or IPv4:port. Bare IPv6 without brackets
+    // is non-conformant and rejected to avoid ambiguity with `host:port`
+    // where the host is a multi-colon IPv6 literal.
+    let (host_part, after) = host
+        .rsplit_once(':')
+        .map(|(h, p)| (h, Some(p)))
+        .unwrap_or((host, None));
+    let v4: std::net::Ipv4Addr = host_part.parse().ok()?;
+    if let Some(port) = after
+        && (port.is_empty() || !port.bytes().all(|b| b.is_ascii_digit()))
+    {
+        return None;
+    }
+    Some(std::net::IpAddr::V4(v4))
+}
+
+/// `true` when `s` looks like a `:port` suffix with an all-digit port body.
+fn is_colon_port(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix(':') else {
+        return false;
+    };
+    !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Extracts the host part of an `Origin` header (e.g. `https://100.64.1.5:7509`
+/// → `100.64.1.5`). Returns `None` for unparseable or scheme-less values so
+/// `origin_compatible_with_host_ip` falls through to reject.
+///
+/// We hand-roll a minimal parser rather than pull in `url`: browsers produce
+/// `scheme://authority` for Origin, and we only need the authority's host-part.
+/// Userinfo (`user@host`) in Origin is not sent by any real browser, but we
+/// tolerate it by stripping the `user@` prefix.
+fn parse_origin_host(origin: &str) -> Option<&str> {
+    let after_scheme = origin.split_once("://").map(|(_, rest)| rest)?;
+    // Strip path/query: Origin header is scheme://authority, but defence in
+    // depth against a weird value like `http://host/extra`.
+    let authority = after_scheme
+        .split_once('/')
+        .map(|(a, _)| a)
+        .unwrap_or(after_scheme);
+    // Strip userinfo.
+    let host_and_port = authority
+        .rsplit_once('@')
+        .map(|(_, hp)| hp)
+        .unwrap_or(authority);
+    // Bracketed IPv6: `[::1]:port` or `[::1]`.
+    if let Some(rest) = host_and_port.strip_prefix('[') {
+        let end = rest.find(']')?;
+        return Some(&rest[..end]);
+    }
+    // Strip trailing `:port` only when there's exactly one colon (IPv4/host).
+    // Bare IPv6 without brackets is non-conformant in Origin and doesn't
+    // occur in practice; fall through to `parse()` which will simply fail.
+    Some(
+        match host_and_port
+            .as_bytes()
+            .iter()
+            .filter(|&&b| b == b':')
+            .count()
+        {
+            0 | 1 => host_and_port
+                .rsplit_once(':')
+                .map(|(h, _)| h)
+                .unwrap_or(host_and_port),
+            _ => host_and_port,
+        },
+    )
+}
+
+fn normalize_mapped_v6(ip: std::net::IpAddr) -> std::net::IpAddr {
+    match ip {
         std::net::IpAddr::V6(v6) => v6
             .to_ipv4_mapped()
             .map(std::net::IpAddr::V4)
             .unwrap_or(std::net::IpAddr::V6(v6)),
         v4 => v4,
-    };
-    allowed_cidrs.contains_ip(&match_ip)
-}
-
-/// Extracts the IP part of a `Host` header value, handling `host:port`,
-/// `[v6]`, `[v6]:port`, and bare IPv6 forms. Returns `None` if the host part
-/// isn't a parseable IP literal (i.e. it's a hostname).
-fn parse_host_header_ip(host_header: &str) -> Option<std::net::IpAddr> {
-    let host = host_header.trim();
-    // Bracketed IPv6 form: `[::1]` or `[::1]:7509`.
-    if let Some(rest) = host.strip_prefix('[') {
-        let end = rest.find(']')?;
-        return rest[..end].parse().ok();
     }
-    // Try the whole thing first: handles bare IPv4 (`100.64.1.5`) and bare
-    // IPv6 (`fd7a::1`, non-conformant but parseable). If that fails and
-    // there's a trailing `:port`, strip it and retry.
-    if let Ok(ip) = host.parse() {
-        return Some(ip);
-    }
-    host.rsplit_once(':').and_then(|(h, _)| h.parse().ok())
 }
 
 /// Checks if an error represents a client-side disconnect rather than a server error.
@@ -538,15 +653,14 @@ async fn connection_info(
     if is_ws_upgrade {
         if let Some(origin) = req.headers().get(axum::http::header::ORIGIN) {
             if let Ok(origin_str) = origin.to_str() {
-                // Accept the upgrade if the origin is localhost, the Host
-                // header matches an allowed hostname, or the Host header is
-                // an IP inside an operator-allowed source CIDR (the path
-                // that unblocks Tailscale-style access). See the
-                // `host_header_ip_in_cidrs` docs for why matching by IP
-                // preserves the DNS-rebinding defense.
+                // Accept the upgrade when the origin is localhost, the Host
+                // header matches an explicit `allowed-host` entry, or the
+                // Host is an IP in `allowed-source-cidrs` *and* the Origin
+                // is compatible with it (null sandboxed iframe or same-IP).
+                // See `host_header_ip_in_cidrs` for the CSWSH rationale.
                 if !is_localhost_origin(origin_str)
                     && !is_allowed_host(req.headers(), &allowed_hosts)
-                    && !host_header_ip_in_cidrs(req.headers(), &allowed_source_cidrs)
+                    && !host_header_ip_in_cidrs(req.headers(), origin_str, &allowed_source_cidrs)
                 {
                     let host_header = req
                         .headers()
@@ -1765,9 +1879,11 @@ mod tests {
         ))
     }
 
-    /// Parsing: `host:port`, `[v6]`, `[v6]:port`, bare v6, and hostnames.
+    /// Parsing: only the two RFC-compliant shapes (`v4[:port]` and
+    /// `[v6][:port]`) are accepted. Every other shape must fail closed.
     #[test]
     fn parse_host_header_ip_variants() {
+        // Happy path: IPv4 with and without port.
         assert_eq!(
             parse_host_header_ip("100.64.1.5:7509"),
             Some("100.64.1.5".parse().unwrap())
@@ -1776,6 +1892,7 @@ mod tests {
             parse_host_header_ip("100.64.1.5"),
             Some("100.64.1.5".parse().unwrap())
         );
+        // Happy path: bracketed IPv6 with and without port.
         assert_eq!(
             parse_host_header_ip("[fd7a:115c:a1e0::1]:7509"),
             Some("fd7a:115c:a1e0::1".parse().unwrap())
@@ -1784,12 +1901,26 @@ mod tests {
             parse_host_header_ip("[fd7a:115c:a1e0::1]"),
             Some("fd7a:115c:a1e0::1".parse().unwrap())
         );
-        // Bare IPv6 without brackets (non-conformant but parseable).
-        assert_eq!(
-            parse_host_header_ip("fd7a:115c:a1e0::1"),
-            Some("fd7a:115c:a1e0::1".parse().unwrap())
-        );
-        // Hostnames must not parse as IPs.
+
+        // Malformed bracket cases — all rejected. These are the
+        // regressions Codex review flagged: trailing junk after `]`
+        // used to be silently accepted and would have matched a CIDR.
+        assert_eq!(parse_host_header_ip("[100.64.1.5]evil.com"), None);
+        assert_eq!(parse_host_header_ip("[100.64.1.5]:7509"), None); // v4 in brackets: no
+        assert_eq!(parse_host_header_ip("[fd7a::1]:notaport"), None);
+        assert_eq!(parse_host_header_ip("[fd7a::1]garbage"), None);
+        assert_eq!(parse_host_header_ip("["), None);
+        assert_eq!(parse_host_header_ip("[]"), None);
+        assert_eq!(parse_host_header_ip("[::1"), None); // unclosed bracket
+
+        // Unbracketed IPv6 is ambiguous with `host:port`, so rejected.
+        assert_eq!(parse_host_header_ip("fd7a:115c:a1e0::1"), None);
+
+        // IPv4 with non-numeric port — rejected.
+        assert_eq!(parse_host_header_ip("100.64.1.5:abc"), None);
+        assert_eq!(parse_host_header_ip("100.64.1.5:"), None);
+
+        // Hostnames never parse as IPs.
         assert_eq!(parse_host_header_ip("evil.com"), None);
         assert_eq!(parse_host_header_ip("evil.com:7509"), None);
         assert_eq!(parse_host_header_ip("localhost:7509"), None);
@@ -1807,16 +1938,19 @@ mod tests {
         let allowed = cidrs(&["100.64.0.0/10"]);
         assert!(host_header_ip_in_cidrs(
             &headers_with_host("100.64.1.5:7509"),
+            "null",
             &allowed,
         ));
         assert!(host_header_ip_in_cidrs(
             &headers_with_host("100.64.1.5"),
+            "null",
             &allowed,
         ));
         // A neighbouring user's tailnet IP is still inside 100.64.0.0/10;
         // if the operator widened the CIDR, that's the operator's choice.
         assert!(host_header_ip_in_cidrs(
             &headers_with_host("100.127.9.9:7509"),
+            "null",
             &allowed,
         ));
     }
@@ -1828,14 +1962,17 @@ mod tests {
         let allowed = cidrs(&["100.64.0.0/10"]);
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("8.8.8.8:7509"),
+            "null",
             &allowed,
         ));
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("100.128.0.1:7509"),
+            "null",
             &allowed,
         ));
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("100.63.255.255:7509"),
+            "null",
             &allowed,
         ));
     }
@@ -1849,16 +1986,19 @@ mod tests {
         let allowed = cidrs(&["100.64.0.0/10"]);
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("evil.com"),
+            "null",
             &allowed,
         ));
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("evil.com:7509"),
+            "null",
             &allowed,
         ));
         // A hostname that happens to look like an IP at a glance is still a
         // hostname to `IpAddr::from_str`, so still rejected.
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("100-64-1-5.evil.com"),
+            "null",
             &allowed,
         ));
     }
@@ -1870,10 +2010,12 @@ mod tests {
         let empty = crate::server::AllowedSourceCidrs::default();
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("100.64.1.5:7509"),
+            "null",
             &empty,
         ));
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("127.0.0.1:7509"),
+            "null",
             &empty,
         ));
     }
@@ -1885,15 +2027,18 @@ mod tests {
         let allowed = cidrs(&["fd7a:115c:a1e0::/48"]);
         assert!(host_header_ip_in_cidrs(
             &headers_with_host("[fd7a:115c:a1e0::1]:7509"),
+            "null",
             &allowed,
         ));
         assert!(host_header_ip_in_cidrs(
             &headers_with_host("[fd7a:115c:a1e0::1]"),
+            "null",
             &allowed,
         ));
         // Outside the /48.
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("[fd7a:115c:a1e1::1]:7509"),
+            "null",
             &allowed,
         ));
     }
@@ -1906,15 +2051,18 @@ mod tests {
         let allowed = cidrs(&["100.64.0.0/10"]);
         assert!(host_header_ip_in_cidrs(
             &headers_with_host("[::ffff:100.64.1.5]:7509"),
+            "null",
             &allowed,
         ));
         assert!(host_header_ip_in_cidrs(
             &headers_with_host("[::ffff:100.64.1.5]"),
+            "null",
             &allowed,
         ));
         // Mapped v6 OUTSIDE the v4 CIDR still rejected.
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("[::ffff:8.8.8.8]:7509"),
+            "null",
             &allowed,
         ));
     }
@@ -1925,8 +2073,95 @@ mod tests {
         let allowed = cidrs(&["100.64.0.0/10"]);
         assert!(!host_header_ip_in_cidrs(
             &axum::http::HeaderMap::new(),
+            "null",
             &allowed,
         ));
+    }
+
+    /// CSWSH regression: an attacker at `https://evil.com` whose browser-side
+    /// JS opens `new WebSocket("ws://<victim-tailnet-ip>:7509/...")` sends
+    /// `Origin: https://evil.com` along with `Host: <victim-tailnet-ip>:7509`.
+    /// The Host IP matches the operator's CIDR, but the Origin does not, so
+    /// we must reject. This is the primary guard against cross-site
+    /// WebSocket hijacking introduced in earlier iterations of this PR.
+    #[test]
+    fn cswsh_cross_origin_real_origin_rejected() {
+        let allowed = cidrs(&["100.64.0.0/10"]);
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("100.64.1.5:7509"),
+            "https://evil.com",
+            &allowed,
+        ));
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("100.64.1.5:7509"),
+            "http://evil.com:8080",
+            &allowed,
+        ));
+        // Even an origin that spells an IP but doesn't match the Host IP
+        // is rejected — this catches attacker pages hosted on one CIDR
+        // peer trying to hijack a different peer.
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("100.64.1.5:7509"),
+            "http://100.64.9.9:7509",
+            &allowed,
+        ));
+    }
+
+    /// Direct browser access (user typed `http://100.64.1.5:7509/` into the
+    /// address bar): Origin and Host refer to the same IP. Must be accepted.
+    #[test]
+    fn direct_browser_access_same_ip_accepted() {
+        let allowed = cidrs(&["100.64.0.0/10"]);
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("100.64.1.5:7509"),
+            "http://100.64.1.5:7509",
+            &allowed,
+        ));
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("100.64.1.5:7509"),
+            "https://100.64.1.5",
+            &allowed,
+        ));
+    }
+
+    /// The `Origin: null` case covers Freenet's sandboxed dApp iframe, which
+    /// deliberately strips origin via `<iframe sandbox=...>` without
+    /// `allow-same-origin`. Must be accepted when Host IP is in CIDR. A
+    /// malicious sandboxed iframe hosted on evil.com would also send
+    /// `Origin: null` — this is the documented CSWSH risk the operator
+    /// accepts when configuring `--allowed-source-cidrs` (equivalent risk
+    /// profile to an explicit `--allowed-host` entry).
+    #[test]
+    fn origin_null_accepted_for_sandboxed_iframe() {
+        let allowed = cidrs(&["100.64.0.0/10"]);
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("100.64.1.5:7509"),
+            "null",
+            &allowed,
+        ));
+    }
+
+    /// Unit tests for the Origin host-part extractor.
+    #[test]
+    fn parse_origin_host_variants() {
+        assert_eq!(
+            parse_origin_host("http://100.64.1.5:7509"),
+            Some("100.64.1.5")
+        );
+        assert_eq!(parse_origin_host("https://100.64.1.5"), Some("100.64.1.5"));
+        assert_eq!(
+            parse_origin_host("http://[fd7a:115c:a1e0::1]:7509"),
+            Some("fd7a:115c:a1e0::1")
+        );
+        assert_eq!(parse_origin_host("http://evil.com:8080"), Some("evil.com"));
+        // Userinfo (non-standard in Origin, but tolerated).
+        assert_eq!(
+            parse_origin_host("http://user@100.64.1.5:7509"),
+            Some("100.64.1.5")
+        );
+        // Missing scheme → not a valid Origin.
+        assert_eq!(parse_origin_host("evil.com"), None);
+        assert_eq!(parse_origin_host(""), None);
     }
 
     #[test]

--- a/crates/core/src/client_events/websocket.rs
+++ b/crates/core/src/client_events/websocket.rs
@@ -196,7 +196,17 @@ fn host_header_ip_in_cidrs(
     let Some(ip) = parse_host_header_ip(host_header) else {
         return false;
     };
-    allowed_cidrs.contains_ip(&ip)
+    // Normalize IPv4-mapped IPv6 (`::ffff:a.b.c.d`) to IPv4 so an operator's
+    // v4 CIDR matches regardless of which address family the browser chose
+    // when building the Host header. Mirrors `is_source_allowed` in server.rs.
+    let match_ip = match ip {
+        std::net::IpAddr::V6(v6) => v6
+            .to_ipv4_mapped()
+            .map(std::net::IpAddr::V4)
+            .unwrap_or(std::net::IpAddr::V6(v6)),
+        v4 => v4,
+    };
+    allowed_cidrs.contains_ip(&match_ip)
 }
 
 /// Extracts the IP part of a `Host` header value, handling `host:port`,
@@ -1884,6 +1894,27 @@ mod tests {
         // Outside the /48.
         assert!(!host_header_ip_in_cidrs(
             &headers_with_host("[fd7a:115c:a1e1::1]:7509"),
+            &allowed,
+        ));
+    }
+
+    /// IPv4-mapped IPv6 (`[::ffff:100.64.1.5]`) in the Host header must be
+    /// normalized to IPv4 so an operator's IPv4 CIDR still matches. Mirrors
+    /// the same normalization in `is_source_allowed`.
+    #[test]
+    fn host_header_ipv4_mapped_v6_normalized_to_v4() {
+        let allowed = cidrs(&["100.64.0.0/10"]);
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("[::ffff:100.64.1.5]:7509"),
+            &allowed,
+        ));
+        assert!(host_header_ip_in_cidrs(
+            &headers_with_host("[::ffff:100.64.1.5]"),
+            &allowed,
+        ));
+        // Mapped v6 OUTSIDE the v4 CIDR still rejected.
+        assert!(!host_header_ip_in_cidrs(
+            &headers_with_host("[::ffff:8.8.8.8]:7509"),
             &allowed,
         ));
     }

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -596,21 +596,16 @@ async fn serve_client_api_in_impl(
         // submodule, `middleware_has_extension_injected`).
         //
         // `connection_info` (inside the WebSocket router) also extracts
-        // `Extension<AllowedSourceCidrs>` so the WS Host-header check can
-        // accept IP literals inside an operator-allowed CIDR. That extractor
-        // is injected by the Extension layer below; because axum applies
-        // layers outermost-first, the extension is already present in the
-        // request extensions by the time `connection_info` runs on inner
-        // routes.
+        // `Extension<AllowedSourceCidrs>` for the Host-header CIDR check.
         ws_router
             .layer(Extension(allowed_hosts))
             .layer(axum::middleware::from_fn(private_network_filter))
             .layer(Extension(allowed_source_cidrs))
             .layer(TraceLayer::new_for_http())
     } else {
-        // Even on loopback binds, inject an (empty) `AllowedSourceCidrs`
-        // extension so `connection_info` always has the extractor it expects.
-        // A missing extension would manifest as 500s on every WS upgrade.
+        // Loopback binds still inject an (empty) `AllowedSourceCidrs` so
+        // `connection_info` always finds the extractor; missing it would
+        // 500 every WS upgrade.
         ws_router
             .layer(Extension(allowed_hosts))
             .layer(Extension(allowed_source_cidrs))

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -387,8 +387,12 @@ pub(crate) type AllowedHosts = Arc<HashSet<String>>;
 pub(crate) struct AllowedSourceCidrs(pub Arc<Vec<ipnet::IpNet>>);
 
 impl AllowedSourceCidrs {
-    fn contains(&self, ip: &IpAddr) -> bool {
+    pub(crate) fn contains_ip(&self, ip: &IpAddr) -> bool {
         self.0.iter().any(|net| net.contains(ip))
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 
@@ -453,7 +457,7 @@ pub(crate) fn is_source_allowed(ip: IpAddr, allowed: &AllowedSourceCidrs) -> boo
             .unwrap_or(IpAddr::V6(v6)),
         v4 => v4,
     };
-    allowed.contains(&match_ip)
+    allowed.contains_ip(&match_ip)
 }
 
 /// Builds the allowlist of hostnames/IPs for WebSocket `Host` header validation.
@@ -590,14 +594,26 @@ async fn serve_client_api_in_impl(
         // every request 500s because the extractor finds nothing. Docker
         // NAT tests caught this (see regression in this module's `tests`
         // submodule, `middleware_has_extension_injected`).
+        //
+        // `connection_info` (inside the WebSocket router) also extracts
+        // `Extension<AllowedSourceCidrs>` so the WS Host-header check can
+        // accept IP literals inside an operator-allowed CIDR. That extractor
+        // is injected by the Extension layer below; because axum applies
+        // layers outermost-first, the extension is already present in the
+        // request extensions by the time `connection_info` runs on inner
+        // routes.
         ws_router
             .layer(Extension(allowed_hosts))
             .layer(axum::middleware::from_fn(private_network_filter))
             .layer(Extension(allowed_source_cidrs))
             .layer(TraceLayer::new_for_http())
     } else {
+        // Even on loopback binds, inject an (empty) `AllowedSourceCidrs`
+        // extension so `connection_info` always has the extractor it expects.
+        // A missing extension would manifest as 500s on every WS upgrade.
         ws_router
             .layer(Extension(allowed_hosts))
+            .layer(Extension(allowed_source_cidrs))
             .layer(TraceLayer::new_for_http())
     };
 
@@ -898,40 +914,40 @@ mod tests {
     #[test]
     fn allowed_source_cidrs_empty_rejects_public() {
         let allow = AllowedSourceCidrs::default();
-        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(!allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
         // Empty list means default-deny. Private IPs still pass via is_private_ip
         // at the call site, so we only assert the CIDR layer here.
-        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert!(!allow.contains_ip(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
     }
 
     #[test]
     fn allowed_source_cidrs_tailscale_cgnat() {
         let allow = cidrs(&["100.64.0.0/10"]);
         // Tailscale tailnet IPs
-        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))));
-        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 100, 50, 1))));
-        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 127, 255, 254))));
+        assert!(allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))));
+        assert!(allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(100, 100, 50, 1))));
+        assert!(allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(100, 127, 255, 254))));
         // Outside CGNAT
-        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 128, 0, 1))));
-        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 63, 255, 255))));
-        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(!allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(100, 128, 0, 1))));
+        assert!(!allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(100, 63, 255, 255))));
+        assert!(!allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
     }
 
     #[test]
     fn allowed_source_cidrs_narrow_tailnet() {
         // A user pinning to their assigned tailnet subnet only
         let allow = cidrs(&["100.64.1.0/24"]);
-        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 64, 1, 5))));
-        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 64, 2, 5))));
+        assert!(allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(100, 64, 1, 5))));
+        assert!(!allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(100, 64, 2, 5))));
     }
 
     #[test]
     fn allowed_source_cidrs_ipv6() {
         let allow = cidrs(&["fd7a:115c:a1e0::/48"]);
-        assert!(allow.contains(&IpAddr::V6(Ipv6Addr::new(
+        assert!(allow.contains_ip(&IpAddr::V6(Ipv6Addr::new(
             0xfd7a, 0x115c, 0xa1e0, 0, 0, 0, 0, 1
         ))));
-        assert!(!allow.contains(&IpAddr::V6(Ipv6Addr::new(
+        assert!(!allow.contains_ip(&IpAddr::V6(Ipv6Addr::new(
             0xfd7a, 0x115c, 0xa1e1, 0, 0, 0, 0, 1
         ))));
     }
@@ -1065,9 +1081,9 @@ mod tests {
     #[test]
     fn allowed_source_cidrs_multiple_ranges() {
         let allow = cidrs(&["100.64.0.0/10", "10.100.0.0/16"]);
-        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(100, 64, 1, 1))));
-        assert!(allow.contains(&IpAddr::V4(Ipv4Addr::new(10, 100, 5, 5))));
-        assert!(!allow.contains(&IpAddr::V4(Ipv4Addr::new(10, 101, 0, 1))));
+        assert!(allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(100, 64, 1, 1))));
+        assert!(allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(10, 100, 5, 5))));
+        assert!(!allow.contains_ip(&IpAddr::V4(Ipv4Addr::new(10, 101, 0, 1))));
     }
 
     #[test]
@@ -1081,7 +1097,7 @@ mod tests {
             Ipv4Addr::new(203, 0, 113, 42), // Public (TEST-NET-3)
         ] {
             assert!(
-                !allow.contains(&IpAddr::V4(ip)),
+                !allow.contains_ip(&IpAddr::V4(ip)),
                 "{ip} must not be trusted by default",
             );
         }


### PR DESCRIPTION
## Problem

`--allowed-source-cidrs` (added in v0.2.47, #3875) lets a user opt in
to reaching the local API from a trusted non-RFC1918 range — the
Matrix-driven example being a Tailscale tailnet (`100.64.0.0/10`).
The flag extends `private_network_filter`, the HTTP source-IP gate.

It does **not** extend the second gate: the WebSocket `Host`-header
allowlist in `connection_info` (added for DNS-rebinding protection in
#3034). That allowlist is built from `localhost`, the machine hostname,
the bound IP, and the operator's `allowed-host` config — it never
sees the CIDR list.

Net effect for a user who sets `allowed-source-cidrs = ["100.64.0.0/10"]`
and visits `http://<their-tailnet-ip>:7509/`:

- ✅ Web UI and static dApp assets load (HTTP path passes
  `private_network_filter`)
- ❌ Every WebSocket upgrade from a dApp (River, freenet-ping, etc.) is
  rejected with `403 "WebSocket connections from this origin are not
  allowed"` because the browser's `Host: <tailnet-ip>:7509` is not in
  `allowed_hosts`.

Reported on Matrix by Ivvor (2026-04-18) against v0.2.47.

## Solution

When the operator opts in to `allowed-source-cidrs`, accept a
WebSocket `Host` header that is an **IP literal inside one of those
CIDRs** as a third allowed case — in addition to localhost-origin and
the existing `allowed_hosts` match.

Key property: **IPs only**. Hostnames never match this new path. So
the DNS-rebinding defence the Host-header check exists for is
preserved — an attacker at `evil.com` cannot smuggle through by
resolving their domain to a tailnet IP, because `connection_info`
never resolves DNS. It only accepts `Host` values that parse as
IP literals and then tests CIDR membership.

### Why IP-only (not also DNS)

A rebinding attack sets the attacker-controlled hostname to resolve
to a local IP after TTL expiry. The `Host` header the browser sends
in that attack is the **hostname** (`evil.com`), not the IP — that's
the whole point of the rebind: the browser thinks it's still talking
to `evil.com`. So rejecting hostnames on this path is sufficient to
defeat rebinding without requiring the operator to duplicate every
peer's tailnet IP into `allowed-host`.

### Alternative considered

Documenting that `--allowed-source-cidrs` must be paired with
`--allowed-host <my-tailnet-ip>` is one line of docs. But a tailnet
may assign many IPs over its lifetime (new device, reassignment, IPv6)
and every peer's browser sends a different Host. Making the operator
keep two flags in sync is a footgun; accepting IPs in the already-
trusted CIDR range has no additional security cost and zero user
friction.

### Layer wire-up

`AllowedSourceCidrs` is now layered as an `Extension` on the WS
router in **both** the loopback and LAN branches of
`serve_client_api_in_impl`, so `connection_info` can extract it
unconditionally. The loopback branch always gets an empty CIDR list
(matching config), so there is **zero behaviour change** for users
who don't opt in.

## Testing

New unit tests in `crates/core/src/client_events/websocket.rs`:

- `parse_host_header_ip_variants` — parse of `host:port`, `[v6]`,
  `[v6]:port`, bare v6, hostnames (must return None), empty input
- `host_header_ip_in_tailscale_cidr_allowed` — regression for the
  Ivvor/v0.2.47 scenario: `100.64.x.x:7509` accepted under
  `100.64.0.0/10`
- `host_header_ip_outside_cidr_rejected` — IPs just outside the CIDR
  (`100.128.0.1`, `100.63.255.255`, `8.8.8.8`) rejected
- `host_header_hostname_never_accepted_via_cidr` — DNS-rebinding
  guard: `evil.com`, `evil.com:7509`, `100-64-1-5.evil.com` all
  rejected even with a non-empty CIDR list
- `host_header_empty_cidrs_matches_nothing` — default-deny: empty
  CIDR list matches zero IPs (no posture drift for non-opt-in users)
- `host_header_ipv6_in_cidr_allowed` — `[fd7a:115c:a1e0::1]:7509`
  accepted under `fd7a:115c:a1e0::/48`; `[fd7a:115c:a1e1::1]` rejected
- `host_header_missing_rejected` — no Host header → rejected (no
  panic, no accept)

Existing coverage retained:
- `is_allowed_host` tests unchanged
- `middleware_layer_stack_allows_configured_source` in `server.rs`
  still validates the source-IP branch of the layer stack

Local validation:
- `cargo fmt --all` clean
- `cargo clippy --locked -- -D warnings` clean (same invocation CI uses)
- `cargo test -p freenet --lib` — **2382 passed, 0 failed, 16
  ignored** (no pre-existing ignores touched)

### Why unit tests instead of integration

`host_header_ip_in_cidrs` is a pure function (HeaderMap +
`AllowedSourceCidrs` → bool). Boundary-focused table tests give
stronger signal than a full axum+tower e2e would. The
regression that triggered this PR is a pure Host-header parsing +
CIDR-membership decision; if this function is correct, the middleware
is correct. The layer-ordering regression test in `server.rs`
(`middleware_layer_stack_allows_configured_source`) already covers
the case where someone reorders the Extension stack and breaks
extractor injection; extending that test to the WS router would add
complexity without catching a new failure mode.

## Fixes

Reported on Matrix by Ivvor (2026-04-18) against v0.2.47. No GitHub
issue; filing one would duplicate this PR.

[AI-assisted - Claude]