### PR TITLE
refactor(ops): relay UPDATE task-per-tx (slice A) — #1454 phase 5 follow-up

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -28,12 +28,13 @@ paths:
 > (`RequestUpdateStreaming`, `BroadcastToStreaming`) and the deprecated
 > `Broadcasting` wire variant, CONNECT, and SUBSCRIBE's renewal /
 > PUT-sub-op / executor / intermediate-peer entry points. Phase 5
-> follow-up (slice A) migrated fresh inbound non-streaming relay
-> `UpdateMsg::RequestUpdate` and `UpdateMsg::BroadcastTo` to
+> follow-up slice A (PR #3910) migrated fresh inbound non-streaming
+> relay `UpdateMsg::RequestUpdate` and `UpdateMsg::BroadcastTo` to
 > `operations/update/op_ctx_task.rs::start_relay_request_update` /
 > `start_relay_broadcast_to` (gated on `source_addr.is_some()` AND
 > `!has_update_op(id)`); GC retries / `start_targeted_op` UPDATE
-> auto-fetch / originator loopback still go through legacy.
+> auto-fetch / originator loopback still go through legacy. Slices B
+> (streaming variants) and C (legacy arm cleanup) follow.
 >
 > Task-per-tx drivers have their own invariants documented in the
 > `op_ctx_task.rs` module doc and in `OpCtx::send_and_await`'s rustdoc.

--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -24,8 +24,16 @@ paths:
 > state-machine path**, which still serves: GC-spawned GET retries and
 > `start_targeted_op` UPDATE-triggered auto-fetch (streaming relay and
 > originator loopback also remain on legacy per #3883 port plan §7),
-> PUT relay/GC paths, UPDATE relay/broadcast, CONNECT, and SUBSCRIBE's
-> renewal / PUT-sub-op / executor / intermediate-peer entry points.
+> PUT relay/GC paths, UPDATE relay streaming variants
+> (`RequestUpdateStreaming`, `BroadcastToStreaming`) and the deprecated
+> `Broadcasting` wire variant, CONNECT, and SUBSCRIBE's renewal /
+> PUT-sub-op / executor / intermediate-peer entry points. Phase 5
+> follow-up (slice A) migrated fresh inbound non-streaming relay
+> `UpdateMsg::RequestUpdate` and `UpdateMsg::BroadcastTo` to
+> `operations/update/op_ctx_task.rs::start_relay_request_update` /
+> `start_relay_broadcast_to` (gated on `source_addr.is_some()` AND
+> `!has_update_op(id)`); GC retries / `start_targeted_op` UPDATE
+> auto-fetch / originator loopback still go through legacy.
 >
 > Task-per-tx drivers have their own invariants documented in the
 > `op_ctx_task.rs` module doc and in `OpCtx::send_and_await`'s rustdoc.

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -55,10 +55,20 @@ Plus task-per-transaction drivers from #1454 Phase 2b onwards:
   subscribe/op_ctx_task.rs → client-initiated SUBSCRIBE driver
   put/op_ctx_task.rs       → client-initiated PUT driver (Phase 3a)
   get/op_ctx_task.rs       → client-initiated GET driver (Phase 3b)
-  update/op_ctx_task.rs    → client-initiated UPDATE driver (Phase 4, fire-and-forget)
-    All use the shared `RetryDriver` trait from `op_ctx.rs` and
-    bypass the OpManager.ops DashMap, owning retry state in task locals.
-    Relay GETs stay on the legacy state machine (tracked in #3883).
+                             + fresh inbound relay GET driver (Phase 5,
+                             PR #3896, `start_relay_get`)
+  update/op_ctx_task.rs    → client-initiated UPDATE driver (Phase 4,
+                             fire-and-forget) + fresh inbound non-streaming
+                             relay UPDATE drivers (Phase 5 follow-up slice
+                             A: `start_relay_request_update`,
+                             `start_relay_broadcast_to`)
+    Client + relay GET / UPDATE share the per-node dedup gate
+    (`active_relay_get_txs`, `active_relay_update_txs`) and the
+    `Relay*InflightGuard` RAII pattern. Streaming UPDATE relay variants
+    (`RequestUpdateStreaming`, `BroadcastToStreaming`) and the
+    deprecated `Broadcasting` variant remain on the legacy path
+    pending slice B. PUT and SUBSCRIBE relay paths still go through
+    the legacy state machine.
 ```
 
 ## Module Map

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1189,6 +1189,90 @@ where
                 .await;
             }
             NetMessageV1::Update(ref op) => {
+                // #1454 phase 5 follow-up (slice A): relay UPDATE
+                // task-per-tx dispatch.
+                //
+                // For true relay hops (source_addr.is_some() AND incoming
+                // variant is non-streaming UpdateMsg::RequestUpdate or
+                // UpdateMsg::BroadcastTo AND no UpdateOp already exists in
+                // OpManager for this tx), spawn the relay driver and
+                // return. The driver owns local apply or single forward
+                // in its task locals. UPDATE is fire-and-forget end-to-end
+                // — there's no upstream reply to await.
+                //
+                // source_addr.is_none() means the caller is internal (e.g.
+                // start_op_with_id from start_targeted_op): fall through
+                // to the legacy path. Existing UpdateOp means GC-spawned
+                // retry or pre-registered op: also fall through.
+                //
+                // Streaming variants (RequestUpdateStreaming /
+                // BroadcastToStreaming) and the deprecated Broadcasting
+                // wire variant stay on the legacy path in slice A — see
+                // port plan §3 / §9.
+                if let Some(sender_addr) = source_addr {
+                    #[allow(clippy::wildcard_enum_match_arm)]
+                    match op {
+                        update::UpdateMsg::RequestUpdate {
+                            id,
+                            key,
+                            related_contracts,
+                            value,
+                        } if !op_manager.has_update_op(id) => {
+                            if let Err(err) = update::op_ctx_task::start_relay_request_update(
+                                op_manager.clone(),
+                                *id,
+                                *key,
+                                related_contracts.clone(),
+                                value.clone(),
+                                sender_addr,
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    tx = %id,
+                                    %key,
+                                    error = %err,
+                                    "UPDATE relay dispatch: start_relay_request_update failed"
+                                );
+                            }
+                            return Ok(None);
+                        }
+                        update::UpdateMsg::BroadcastTo {
+                            id,
+                            key,
+                            payload,
+                            sender_summary_bytes,
+                        } if !op_manager.has_update_op(id) => {
+                            if let Err(err) = update::op_ctx_task::start_relay_broadcast_to(
+                                op_manager.clone(),
+                                *id,
+                                *key,
+                                payload.clone(),
+                                sender_summary_bytes.clone(),
+                                sender_addr,
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    tx = %id,
+                                    %key,
+                                    error = %err,
+                                    "UPDATE relay dispatch: start_relay_broadcast_to failed"
+                                );
+                            }
+                            return Ok(None);
+                        }
+                        // Streaming variants (RequestUpdateStreaming /
+                        // BroadcastToStreaming), deprecated Broadcasting,
+                        // existing UpdateOp, or guarded RequestUpdate /
+                        // BroadcastTo with has_update_op == true → legacy
+                        // path. Wildcard arm exists ONLY to satisfy
+                        // non-exhaustive matches against the slice-A
+                        // dispatch gate; do not expand.
+                        _ => {}
+                    }
+                }
+
                 let op_result = handle_op_request::<update::UpdateOp, _>(
                     &op_manager,
                     &mut conn_manager,
@@ -3521,6 +3605,103 @@ mod tests {
                 "Phase-3b bypass (try_forward_task_per_tx_reply) must appear \
                  BEFORE relay dispatch (start_relay_get) in the GET branch. \
                  Swapping order would break the client-driver terminal-reply fast path."
+            );
+        }
+
+        // ───────────────────────────────────────────────────────────
+        // Regression guards for the UPDATE branch of
+        // handle_pure_network_message_v1 added in #1454 phase 5
+        // follow-up (slice A: relay UPDATE task-per-tx).
+        //
+        // UPDATE is fire-and-forget end-to-end — there is no
+        // upstream reply to await, so there is no phase-3b bypass
+        // (no reply channel to forward into). Only relay dispatch
+        // is wired here.
+        // ───────────────────────────────────────────────────────────
+
+        #[test]
+        fn update_branch_dispatch_calls_relay_drivers() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            let anchor = "NetMessageV1::Update(ref op) => {";
+            let branch_start = SOURCE.find(anchor).expect(
+                "UPDATE branch of handle_pure_network_message_v1 not found; \
+                 the match arm has been renamed or moved — update this regression guard",
+            );
+
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<update::UpdateOp, _>")
+                .expect("UPDATE branch no longer calls handle_op_request — update guard")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+
+            assert!(
+                window.contains("start_relay_request_update("),
+                "UPDATE branch no longer calls start_relay_request_update for relay \
+                 dispatch. #1454 phase-5 relay UPDATE dispatch was removed — restore it."
+            );
+            assert!(
+                window.contains("start_relay_broadcast_to("),
+                "UPDATE branch no longer calls start_relay_broadcast_to for relay \
+                 dispatch. #1454 phase-5 relay UPDATE dispatch was removed — restore it."
+            );
+        }
+
+        #[test]
+        fn update_branch_dispatch_gates_on_source_and_existing_op() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            let anchor = "NetMessageV1::Update(ref op) => {";
+            let branch_start = SOURCE.find(anchor).expect("UPDATE branch not found");
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<update::UpdateOp, _>")
+                .expect("UPDATE branch no longer calls handle_op_request")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+
+            assert!(
+                window.contains("source_addr"),
+                "UPDATE relay dispatch must be gated on source_addr — \
+                 internal callers (source_addr.is_none()) must fall through to legacy."
+            );
+            assert!(
+                window.contains("has_update_op"),
+                "UPDATE relay dispatch must be guarded by has_update_op — \
+                 GC-spawned retries / pre-registered ops must fall through to legacy."
+            );
+        }
+
+        #[test]
+        fn update_branch_does_not_dispatch_streaming_or_broadcasting() {
+            const SOURCE: &str = include_str!("node.rs");
+
+            let anchor = "NetMessageV1::Update(ref op) => {";
+            let branch_start = SOURCE.find(anchor).expect("UPDATE branch not found");
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<update::UpdateOp, _>")
+                .expect("UPDATE branch no longer calls handle_op_request")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+
+            // Streaming + Broadcasting variants stay on legacy path in slice A.
+            // Drivers must not be invoked for them.
+            assert!(
+                !window.contains("RequestUpdateStreaming {")
+                    || window.contains("// Streaming variants"),
+                "UPDATE branch appears to dispatch RequestUpdateStreaming through \
+                 the relay driver. Slice A keeps streaming on the legacy path — \
+                 see docs/port-plans/relay-update-task-per-tx.md."
+            );
+            assert!(
+                !window.contains("BroadcastToStreaming {")
+                    || window.contains("// Streaming variants"),
+                "UPDATE branch appears to dispatch BroadcastToStreaming through \
+                 the relay driver. Slice A keeps streaming on the legacy path."
+            );
+            assert!(
+                !window.contains("UpdateMsg::Broadcasting {"),
+                "UPDATE branch dispatches deprecated Broadcasting variant through \
+                 the relay driver. Broadcasting must stay on the legacy path."
             );
         }
     }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -1023,7 +1023,6 @@ impl OpManager {
     /// inbound relay update (no existing op → spawn the task-per-tx driver)
     /// from a GC-spawned retry or `start_targeted_op`-style internal caller
     /// (existing op → fall through to the legacy `handle_op_request` path).
-    #[allow(dead_code)] // Wired in commit 2 of this slice.
     pub fn has_update_op(&self, id: &Transaction) -> bool {
         self.ops.update.contains_key(id)
     }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -339,6 +339,15 @@ pub(crate) struct OpManager {
     /// amplification observed in workflow run 24600634908 (6.8M spawns
     /// in 100s, 63GB RSS).
     pub(crate) active_relay_get_txs: Arc<DashSet<Transaction>>,
+    /// Set of transactions currently being driven by a relay UPDATE
+    /// task-per-tx driver on this node. Same role as
+    /// `active_relay_get_txs` but for UPDATE relay (#1454 phase 5
+    /// follow-up). UPDATE relay has no retry loop and no upstream
+    /// reply, so the amplification risk is structurally lower than GET
+    /// — the dedup gate exists primarily for robustness against
+    /// GC-spawned re-entries and routing-bloom false-positive
+    /// retransmissions.
+    pub(crate) active_relay_update_txs: Arc<DashSet<Transaction>>,
 }
 
 impl Clone for OpManager {
@@ -367,6 +376,7 @@ impl Clone for OpManager {
             configured_gateways: self.configured_gateways.clone(),
             pending_contract_fetches: self.pending_contract_fetches.clone(),
             active_relay_get_txs: self.active_relay_get_txs.clone(),
+            active_relay_update_txs: self.active_relay_update_txs.clone(),
         }
     }
 }
@@ -408,6 +418,7 @@ impl OpManager {
         let pending_contract_fetches: Arc<DashMap<ContractInstanceId, u64>> =
             Arc::new(DashMap::new());
         let active_relay_get_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
+        let active_relay_update_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
 
         task_monitor.register(
             "garbage_cleanup",
@@ -426,6 +437,7 @@ impl OpManager {
                     contract_waiters.clone(),
                     pending_contract_fetches.clone(),
                     active_relay_get_txs.clone(),
+                    active_relay_update_txs.clone(),
                 )
                 .instrument(garbage_span),
             ),
@@ -495,6 +507,7 @@ impl OpManager {
             ),
             pending_contract_fetches,
             active_relay_get_txs,
+            active_relay_update_txs,
         })
     }
 
@@ -1000,6 +1013,19 @@ impl OpManager {
     /// `pop` / `load_or_init`. This is a lightweight existence check only.
     pub fn has_get_op(&self, id: &Transaction) -> bool {
         self.ops.get.contains_key(id)
+    }
+
+    /// Returns `true` if an `UpdateOp` is currently registered for this
+    /// transaction in `OpManager.ops.update`.
+    ///
+    /// Same role as `has_get_op` but for the relay UPDATE dispatch gate
+    /// (#1454 phase 5 follow-up). Used by `node.rs` to distinguish a fresh
+    /// inbound relay update (no existing op → spawn the task-per-tx driver)
+    /// from a GC-spawned retry or `start_targeted_op`-style internal caller
+    /// (existing op → fall through to the legacy `handle_op_request` path).
+    #[allow(dead_code)] // Wired in commit 2 of this slice.
+    pub fn has_update_op(&self, id: &Transaction) -> bool {
+        self.ops.update.contains_key(id)
     }
 
     pub fn completed(&self, id: Transaction) {
@@ -1645,6 +1671,7 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
     >,
     pending_contract_fetches: Arc<DashMap<ContractInstanceId, u64>>,
     active_relay_get_txs: Arc<DashSet<Transaction>>,
+    active_relay_update_txs: Arc<DashSet<Transaction>>,
 ) {
     const CLEANUP_INTERVAL: Duration = Duration::from_secs(5);
     /// How often to clean up stale contract_waiters entries (every N ticks).
@@ -1695,6 +1722,19 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         crate::operations::get::op_ctx_task::RELAY_DEDUP_REJECTS
                             .load(Ordering::Relaxed);
                     let relay_active_txs = active_relay_get_txs.len();
+                    let relay_update_inflight =
+                        crate::operations::update::op_ctx_task::RELAY_UPDATE_INFLIGHT
+                            .load(Ordering::Relaxed);
+                    let relay_update_spawned =
+                        crate::operations::update::op_ctx_task::RELAY_UPDATE_SPAWNED_TOTAL
+                            .load(Ordering::Relaxed);
+                    let relay_update_completed =
+                        crate::operations::update::op_ctx_task::RELAY_UPDATE_COMPLETED_TOTAL
+                            .load(Ordering::Relaxed);
+                    let relay_update_dedup_rejects =
+                        crate::operations::update::op_ctx_task::RELAY_UPDATE_DEDUP_REJECTS
+                            .load(Ordering::Relaxed);
+                    let relay_update_active_txs = active_relay_update_txs.len();
                     tracing::info!(
                         target: "memory_stats",
                         tick = tick_count,
@@ -1717,6 +1757,11 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         relay_completed = relay_completed,
                         relay_dedup_rejects = relay_dedup_rejects,
                         relay_active_txs = relay_active_txs,
+                        relay_update_inflight = relay_update_inflight,
+                        relay_update_spawned = relay_update_spawned,
+                        relay_update_completed = relay_update_completed,
+                        relay_update_dedup_rejects = relay_update_dedup_rejects,
+                        relay_update_active_txs = relay_update_active_txs,
                         "memory stats"
                     );
                 }
@@ -3467,6 +3512,59 @@ mod tests {
         assert!(
             !ops.get.contains_key(&tx),
             "ops.get should not contain tx after removal"
+        );
+    }
+
+    // ── has_update_op unit tests ──────────────────────────────────────────
+    //
+    // Same shape as has_get_op tests above. `has_update_op` is a one-line
+    // wrapper over `self.ops.update.contains_key`, so we exercise the
+    // underlying map directly.
+
+    /// has_update_op returns false for an unknown transaction.
+    #[test]
+    fn has_update_op_returns_false_for_unknown_tx() {
+        let ops = Ops::default();
+        let tx = Transaction::new::<crate::operations::update::UpdateMsg>();
+        assert!(
+            !ops.update.contains_key(&tx),
+            "ops.update should not contain a never-inserted tx"
+        );
+    }
+
+    /// has_update_op returns true after an UpdateOp is inserted, and false
+    /// once removed.
+    #[test]
+    fn has_update_op_returns_true_after_insert_false_after_remove() {
+        use freenet_stdlib::prelude::{CodeHash, ContractInstanceId, ContractKey};
+
+        let ops = Ops::default();
+        let instance_id = ContractInstanceId::new([0u8; 32]);
+        let key = ContractKey::from_id_and_code(instance_id, CodeHash::new([1u8; 32]));
+        let update_op = crate::operations::update::start_op(
+            key,
+            freenet_stdlib::prelude::UpdateData::State(freenet_stdlib::prelude::State::from(vec![
+                1, 2, 3,
+            ])),
+            freenet_stdlib::prelude::RelatedContracts::default(),
+        );
+        let tx = update_op.id;
+
+        assert!(
+            !ops.update.contains_key(&tx),
+            "ops.update should not contain tx before insertion"
+        );
+
+        ops.update.insert(tx, update_op);
+        assert!(
+            ops.update.contains_key(&tx),
+            "ops.update should contain tx after insertion"
+        );
+
+        ops.update.remove(&tx);
+        assert!(
+            !ops.update.contains_key(&tx),
+            "ops.update should not contain tx after removal"
         );
     }
 }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -2173,7 +2173,7 @@ impl IsOperationCompleted for UpdateOp {
 ///
 /// Accepts the already-computed summary from `UpdateExecution` to avoid an
 /// extra WASM `summarize_state` call.
-async fn send_proactive_summary_notification(
+pub(crate) async fn send_proactive_summary_notification(
     op_manager: &OpManager,
     key: &ContractKey,
     sender_addr: SocketAddr,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -769,21 +769,14 @@ async fn drive_relay_request_update(
 
     // Forward downstream. We use the INCOMING tx (end-to-end preservation).
     //
-    // Slice A scope: this driver only handles inbound non-streaming
-    // `UpdateMsg::RequestUpdate` (the dispatch gate in node.rs filters
-    // out `RequestUpdateStreaming`). On the relay forward we re-emit
-    // non-streaming `RequestUpdate` regardless of payload size — the
-    // streaming-upgrade path on relay forward (legacy update.rs:518-535
-    // checks `should_use_streaming` before emitting `RequestUpdate` vs
-    // `RequestUpdateStreaming`) is deferred to slice B together with
-    // the streaming-variant migration. Tracked in
-    // docs/port-plans/relay-update-task-per-tx.md §3 / §9.
-    //
-    // Practical impact in slice A: large UPDATE payloads arriving as
-    // non-streaming `RequestUpdate` (which only happens if the upstream
-    // relay decided not to stream them) are forwarded as non-streaming
-    // — the same shape they arrived in. Slice B will add the size
-    // check + variant upgrade.
+    // Slice A scope: this driver only handles the inbound non-streaming
+    // wire variant (the dispatch gate in node.rs filters out the
+    // streaming sibling). On relay forward we re-emit the same
+    // non-streaming variant regardless of payload size — the size-based
+    // upgrade to the streaming sibling on forward (legacy
+    // update.rs:518-535 checks `should_use_streaming`) is deferred to
+    // slice B together with the streaming-variant migration. Tracked
+    // in docs/port-plans/relay-update-task-per-tx.md §3 / §9.
     let request = NetMessage::from(UpdateMsg::RequestUpdate {
         id: incoming_tx,
         key,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -397,7 +397,6 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
 /// Returns immediately after spawning. Driver publishes its own side
 /// effects (local merge → BroadcastStateChange via the executor, OR a
 /// single fire-and-forget downstream forward).
-#[allow(dead_code)] // Wired in commit 2 of this slice.
 pub(crate) async fn start_relay_request_update(
     op_manager: Arc<OpManager>,
     incoming_tx: Transaction,
@@ -447,7 +446,6 @@ pub(crate) async fn start_relay_request_update(
 /// `BroadcastStateChange` event fans out to other interested peers
 /// automatically — the driver itself never sends `BroadcastTo`
 /// downstream.
-#[allow(dead_code)] // Wired in commit 2 of this slice.
 pub(crate) async fn start_relay_broadcast_to(
     op_manager: Arc<OpManager>,
     incoming_tx: Transaction,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -20,6 +20,7 @@
 //! - Never pushes to `OpManager.ops.update` DashMap, eliminating stale
 //!   entry retention between completion and GC timeout.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use either::Either;
@@ -28,13 +29,42 @@ use freenet_stdlib::prelude::*;
 
 use crate::client_events::HostResult;
 use crate::config::GlobalExecutor;
-use crate::message::{NetMessage, Transaction};
+use crate::contract::{ContractHandlerEvent, StoreResponse};
+use crate::message::{DeltaOrFullState, InterestMessage, NetMessage, NodeEvent, Transaction};
 use crate::node::OpManager;
 use crate::operations::OpError;
 use crate::ring::{PeerKeyLocation, RingError};
-use crate::tracing::NetEventLog;
+use crate::tracing::{NetEventLog, OperationFailure, state_hash_full};
 
 use super::{UpdateExecution, UpdateMsg};
+
+/// Counter: number of times `start_relay_request_update` or
+/// `start_relay_broadcast_to` was invoked. Incremented under test/testing
+/// feature only — used by structural pin tests in #1454 phase 5
+/// follow-up to prove the dispatch gate routes fresh inbound traffic
+/// through the task-per-tx driver rather than legacy
+/// `handle_op_request`.
+#[cfg(any(test, feature = "testing"))]
+pub static RELAY_UPDATE_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: relay UPDATE drivers currently in flight. Decremented in the
+/// RAII guard on driver exit. Diagnostic for `FREENET_MEMORY_STATS`.
+pub static RELAY_UPDATE_INFLIGHT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: total relay UPDATE drivers ever spawned on this node.
+pub static RELAY_UPDATE_SPAWNED_TOTAL: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: total relay UPDATE drivers that exited (any path).
+pub static RELAY_UPDATE_COMPLETED_TOTAL: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: number of duplicate inbound `RequestUpdate` /
+/// `BroadcastTo` Requests rejected by the per-node dedup gate.
+pub static RELAY_UPDATE_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 /// Start a client-initiated UPDATE, returning as soon as the task has been
 /// spawned (mirrors legacy `request_update` timing).
@@ -325,6 +355,630 @@ fn deliver_outcome(op_manager: &OpManager, client_tx: Transaction, outcome: Driv
     op_manager.completed(client_tx);
 }
 
+// ── Relay UPDATE drivers (#1454 phase 5 follow-up — slice A) ────────────────
+//
+// UPDATE has no end-to-end response, so the relay drivers below are
+// strictly fire-and-forget: they apply state changes locally (or forward
+// once downstream) and exit.  No `send_and_await`, no
+// `pending_op_results` slot, no upstream reply.  This makes the relay
+// drivers immune to the four amplifiers that hit phase-5 GET (workflow
+// runs 24600168871 / 24600634908 / 24601267577 / 24601908758):
+//
+//   1. No retry loop at relay → no MAX_RELAY_RETRIES needed.
+//   2. No fresh `attempt_tx` → forwarding reuses `incoming_tx`.
+//   3. No `ForwardingAck` → never had one.
+//   4. Per-node dedup gate (`active_relay_update_txs`) drops duplicate
+//      inbound Requests for an in-flight tx, mirroring GET phase-5 even
+//      though the structural risk is lower.
+//
+// # Scope
+//
+// Migrated:
+//   - `UpdateMsg::RequestUpdate` (non-streaming relay arm:
+//      `update.rs::process_message`, lines 347–594).
+//   - `UpdateMsg::BroadcastTo`  (non-streaming relay arm:
+//      `update.rs::process_message`, lines 595–825).
+//
+// NOT migrated (stays on legacy path; see port plan §3 / §9):
+//   - `UpdateMsg::Broadcasting` (deprecated wire variant — legacy
+//      handler is a no-op).
+//   - `UpdateMsg::RequestUpdateStreaming` /
+//     `UpdateMsg::BroadcastToStreaming` (slice B follow-up — orphan
+//      stream claim + assembly).
+//   - GC-spawned retries / `start_targeted_op` UPDATE-triggered fetch
+//     (existing `UpdateOp` in `OpManager.ops.update` falls through to
+//     legacy via `has_update_op` dispatch gate).
+
+/// Spawn a relay driver for a fresh inbound `UpdateMsg::RequestUpdate`.
+///
+/// Caller-side gates (in `node.rs`): `source_addr.is_some()` AND no
+/// existing `UpdateOp` in `OpManager.ops.update` for `incoming_tx`.
+///
+/// Returns immediately after spawning. Driver publishes its own side
+/// effects (local merge → BroadcastStateChange via the executor, OR a
+/// single fire-and-forget downstream forward).
+#[allow(dead_code)] // Wired in commit 2 of this slice.
+pub(crate) async fn start_relay_request_update(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    related_contracts: RelatedContracts<'static>,
+    value: WrappedState,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError> {
+    #[cfg(any(test, feature = "testing"))]
+    RELAY_UPDATE_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    if !op_manager.active_relay_update_txs.insert(incoming_tx) {
+        RELAY_UPDATE_DEDUP_REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            %sender_addr,
+            phase = "relay_update_dedup_reject",
+            "UPDATE relay (task-per-tx): duplicate RequestUpdate for in-flight tx, dropping"
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        tx = %incoming_tx,
+        %key,
+        %sender_addr,
+        phase = "relay_update_request_start",
+        "UPDATE relay (task-per-tx): spawning RequestUpdate driver"
+    );
+
+    GlobalExecutor::spawn(run_relay_request_update(
+        op_manager,
+        incoming_tx,
+        key,
+        related_contracts,
+        value,
+        sender_addr,
+    ));
+    Ok(())
+}
+
+/// Spawn a relay driver for a fresh inbound `UpdateMsg::BroadcastTo`.
+///
+/// Same gates as `start_relay_request_update`. The driver applies the
+/// broadcast payload locally (after dedup) and the executor's
+/// `BroadcastStateChange` event fans out to other interested peers
+/// automatically — the driver itself never sends `BroadcastTo`
+/// downstream.
+#[allow(dead_code)] // Wired in commit 2 of this slice.
+pub(crate) async fn start_relay_broadcast_to(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    payload: DeltaOrFullState,
+    sender_summary_bytes: Vec<u8>,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError> {
+    #[cfg(any(test, feature = "testing"))]
+    RELAY_UPDATE_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    if !op_manager.active_relay_update_txs.insert(incoming_tx) {
+        RELAY_UPDATE_DEDUP_REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            %sender_addr,
+            phase = "relay_update_dedup_reject",
+            "UPDATE relay (task-per-tx): duplicate BroadcastTo for in-flight tx, dropping"
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        tx = %incoming_tx,
+        %key,
+        %sender_addr,
+        phase = "relay_update_broadcast_start",
+        "UPDATE relay (task-per-tx): spawning BroadcastTo driver"
+    );
+
+    GlobalExecutor::spawn(run_relay_broadcast_to(
+        op_manager,
+        incoming_tx,
+        key,
+        payload,
+        sender_summary_bytes,
+        sender_addr,
+    ));
+    Ok(())
+}
+
+/// RAII guard that decrements `RELAY_UPDATE_INFLIGHT`, bumps
+/// `RELAY_UPDATE_COMPLETED_TOTAL`, and removes the driver's
+/// `incoming_tx` from `active_relay_update_txs` on drop. Mirrors GET's
+/// `RelayInflightGuard` pattern.
+struct RelayUpdateInflightGuard {
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+}
+
+impl Drop for RelayUpdateInflightGuard {
+    fn drop(&mut self) {
+        self.op_manager
+            .active_relay_update_txs
+            .remove(&self.incoming_tx);
+        RELAY_UPDATE_INFLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        RELAY_UPDATE_COMPLETED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+async fn run_relay_request_update(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    related_contracts: RelatedContracts<'static>,
+    value: WrappedState,
+    sender_addr: SocketAddr,
+) {
+    RELAY_UPDATE_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RELAY_UPDATE_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let _guard = RelayUpdateInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
+    if let Err(err) = drive_relay_request_update(
+        &op_manager,
+        incoming_tx,
+        key,
+        related_contracts,
+        value,
+        sender_addr,
+    )
+    .await
+    {
+        tracing::warn!(
+            tx = %incoming_tx,
+            %key,
+            error = %err,
+            phase = "relay_update_request_error",
+            "UPDATE relay (task-per-tx): RequestUpdate driver returned error"
+        );
+    }
+}
+
+async fn run_relay_broadcast_to(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    payload: DeltaOrFullState,
+    sender_summary_bytes: Vec<u8>,
+    sender_addr: SocketAddr,
+) {
+    RELAY_UPDATE_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RELAY_UPDATE_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let _guard = RelayUpdateInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
+    if let Err(err) = drive_relay_broadcast_to(
+        &op_manager,
+        incoming_tx,
+        key,
+        payload,
+        sender_summary_bytes,
+        sender_addr,
+    )
+    .await
+    {
+        tracing::warn!(
+            tx = %incoming_tx,
+            %key,
+            error = %err,
+            phase = "relay_update_broadcast_error",
+            "UPDATE relay (task-per-tx): BroadcastTo driver returned error"
+        );
+    }
+}
+
+/// Inner driver for `RequestUpdate`. Mirrors `update.rs:347-594`.
+///
+/// Decision tree:
+///   - We host the contract → apply update locally; executor emits
+///     `BroadcastStateChange` automatically. No downstream forward.
+///   - We do NOT host the contract → forward `RequestUpdate` once to
+///     `closest_potentially_hosting`. No retry, no upstream reply.
+async fn drive_relay_request_update(
+    op_manager: &OpManager,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    related_contracts: RelatedContracts<'static>,
+    value: WrappedState,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError> {
+    let executing_addr = op_manager
+        .ring
+        .connection_manager
+        .own_location()
+        .socket_addr();
+    tracing::debug!(
+        tx = %incoming_tx,
+        %key,
+        executing_peer = ?executing_addr,
+        request_sender = %sender_addr,
+        "UPDATE relay (task-per-tx): processing RequestUpdate"
+    );
+
+    // ── Step 1: do we host the contract locally? ──────────────────────────
+    //
+    // Mirrors update.rs:371-389. There's a known TOCTOU between this lookup
+    // and the update_contract() call below — the legacy code accepts this
+    // for telemetry purposes and the driver matches that behavior.
+    let state_before = match op_manager
+        .notify_contract_handler(ContractHandlerEvent::GetQuery {
+            instance_id: *key.id(),
+            return_contract_code: false,
+        })
+        .await
+    {
+        Ok(ContractHandlerEvent::GetResponse {
+            response: Ok(StoreResponse { state: Some(s), .. }),
+            ..
+        }) => Some(s),
+        _ => None,
+    };
+
+    if state_before.is_some() {
+        // ── Local apply path ──────────────────────────────────────────────
+        let hash_before = state_before.as_ref().map(state_hash_full);
+
+        // Note: legacy comment at update.rs:402-406 — RequestUpdate sender
+        // should NOT be excluded from broadcast. Sender is REQUESTING the
+        // update and needs to receive the result via subscription.
+        let UpdateExecution {
+            value: updated_value,
+            summary: _,
+            changed,
+            ..
+        } = super::update_contract(
+            op_manager,
+            key,
+            UpdateData::State(State::from(value.clone())),
+            related_contracts.clone(),
+        )
+        .await?;
+
+        let hash_after = Some(state_hash_full(&updated_value));
+
+        // Telemetry: UPDATE succeeded at this peer (mirrors update.rs:428-444).
+        if let Some(requester_pkl) = op_manager
+            .ring
+            .connection_manager
+            .get_peer_by_addr(sender_addr)
+        {
+            if let Some(event) = NetEventLog::update_success(
+                &incoming_tx,
+                &op_manager.ring,
+                key,
+                requester_pkl,
+                hash_before,
+                hash_after,
+                Some(updated_value.len()),
+            ) {
+                op_manager.ring.register_events(Either::Left(event)).await;
+            }
+        }
+
+        if !changed {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %key,
+                "UPDATE relay (task-per-tx): yielded no state change, skipping broadcast"
+            );
+        } else {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %key,
+                "UPDATE relay (task-per-tx): RequestUpdate succeeded, state changed"
+            );
+        }
+        // No `Finished`/`ReceivedRequest` bookkeeping: relay driver owns
+        // its lifetime; BroadcastStateChange fans out automatically.
+        return Ok(());
+    }
+
+    // ── Forward path: contract not local ──────────────────────────────────
+    let self_addr = op_manager.ring.connection_manager.peer_addr()?;
+    let skip_list = vec![self_addr, sender_addr];
+
+    let next_target = op_manager
+        .ring
+        .closest_potentially_hosting(&key, skip_list.as_slice());
+
+    let forward_target = match next_target {
+        Some(t) => t,
+        None => {
+            // Mirrors update.rs:560-590: no peers + no local contract.
+            let candidates = op_manager
+                .ring
+                .k_closest_potentially_hosting(&key, skip_list.as_slice(), 5)
+                .into_iter()
+                .filter_map(|loc| loc.socket_addr())
+                .map(|addr| format!("{:.8}", addr))
+                .collect::<Vec<_>>();
+            let connection_count = op_manager.ring.connection_manager.num_connections();
+            tracing::error!(
+                tx = %incoming_tx,
+                contract = %key,
+                ?candidates,
+                connection_count,
+                peer_addr = %sender_addr,
+                phase = "error",
+                "UPDATE relay (task-per-tx): contract not local and no peers to forward to"
+            );
+            if let Some(event) = NetEventLog::update_failure(
+                &incoming_tx,
+                &op_manager.ring,
+                key,
+                OperationFailure::NoPeersAvailable,
+            ) {
+                op_manager.ring.register_events(Either::Left(event)).await;
+            }
+            return Err(OpError::RingError(RingError::NoHostingPeers(*key.id())));
+        }
+    };
+
+    let forward_addr = forward_target
+        .socket_addr()
+        .expect("forward target must have socket address");
+
+    tracing::debug!(
+        tx = %incoming_tx,
+        %key,
+        next_peer = %forward_addr,
+        "UPDATE relay (task-per-tx): forwarding to peer that might have contract"
+    );
+
+    // Telemetry: relay forwarding update request.
+    if let Some(event) =
+        NetEventLog::update_request(&incoming_tx, &op_manager.ring, key, forward_target.clone())
+    {
+        op_manager.ring.register_events(Either::Left(event)).await;
+    }
+
+    // Forward downstream. We use the INCOMING tx (end-to-end preservation).
+    // Streaming variants are handled on the legacy path in slice A; if the
+    // payload size triggers streaming, fall back to legacy by emitting the
+    // forward via legacy plumbing in commit 2's dispatch (TODO: confirm
+    // dispatch falls through to legacy when payload requires streaming —
+    // currently slice A only routes non-streaming RequestUpdate to the
+    // driver).
+    let request = NetMessage::from(UpdateMsg::RequestUpdate {
+        id: incoming_tx,
+        key,
+        related_contracts,
+        value,
+    });
+
+    let mut ctx = op_manager.op_ctx(incoming_tx);
+    if let Err(err) = ctx.send_fire_and_forget(forward_addr, request).await {
+        tracing::warn!(
+            tx = %incoming_tx,
+            %key,
+            target = %forward_addr,
+            error = %err,
+            "UPDATE relay (task-per-tx): forward send failed"
+        );
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+/// Inner driver for `BroadcastTo`. Mirrors `update.rs:595-825`.
+///
+/// 1. Update sender's cached summary in `interest_manager`.
+/// 2. Telemetry: `update_broadcast_received`.
+/// 3. Dedup cache check (skip merge if seen) — MUST run before WASM merge.
+/// 4. WASM merge via `update_contract`. On delta failure → ResyncRequest;
+///    on full-state failure → `try_auto_fetch_contract`.
+/// 5. Telemetry: `update_broadcast_applied`.
+/// 6. Spawn proactive summary notification background task.
+async fn drive_relay_broadcast_to(
+    op_manager: &OpManager,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    payload: DeltaOrFullState,
+    sender_summary_bytes: Vec<u8>,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError> {
+    let self_location = op_manager.ring.connection_manager.own_location();
+
+    let sender_summary = StateSummary::from(sender_summary_bytes);
+
+    // ── Step 1: update sender's cached summary ────────────────────────────
+    if let Some(sender_pkl) = op_manager
+        .ring
+        .connection_manager
+        .get_peer_by_addr(sender_addr)
+    {
+        let sender_key = crate::ring::PeerKey::from(sender_pkl.pub_key().clone());
+        op_manager
+            .interest_manager
+            .update_peer_summary(&key, &sender_key, Some(sender_summary));
+    }
+
+    let (update_data, payload_bytes) = match &payload {
+        DeltaOrFullState::Delta(bytes) => {
+            tracing::debug!(
+                contract = %key,
+                delta_size = bytes.len(),
+                "UPDATE relay (task-per-tx): received delta broadcast"
+            );
+            (
+                UpdateData::Delta(StateDelta::from(bytes.clone())),
+                bytes.clone(),
+            )
+        }
+        DeltaOrFullState::FullState(bytes) => {
+            tracing::debug!(
+                contract = %key,
+                state_size = bytes.len(),
+                "UPDATE relay (task-per-tx): received full state broadcast"
+            );
+            (UpdateData::State(State::from(bytes.clone())), bytes.clone())
+        }
+    };
+    let is_delta = matches!(payload, DeltaOrFullState::Delta(_));
+    let state_for_telemetry = WrappedState::from(payload_bytes.clone());
+
+    // ── Step 2: telemetry — broadcast received ─────────────────────────────
+    if let Some(requester_pkl) = op_manager
+        .ring
+        .connection_manager
+        .get_peer_by_addr(sender_addr)
+    {
+        if let Some(event) = NetEventLog::update_broadcast_received(
+            &incoming_tx,
+            &op_manager.ring,
+            key,
+            requester_pkl,
+            state_for_telemetry.clone(),
+        ) {
+            op_manager.ring.register_events(Either::Left(event)).await;
+        }
+    }
+
+    // ── Step 3: dedup cache (BEFORE merge) ────────────────────────────────
+    //
+    // Mirrors update.rs:670-694. MUST run before update_contract — a missed
+    // dedup re-runs WASM merge for every duplicate broadcast.
+    if op_manager.broadcast_dedup_cache.check_and_insert(
+        &key,
+        &payload_bytes,
+        is_delta,
+        op_manager.interest_manager.now(),
+    ) {
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            "UPDATE relay (task-per-tx): BroadcastTo skipped — duplicate payload (dedup hit)"
+        );
+        return Ok(());
+    }
+
+    // ── Step 4: apply broadcast via WASM merge ────────────────────────────
+    let update_result =
+        super::update_contract(op_manager, key, update_data, RelatedContracts::default()).await;
+
+    let UpdateExecution {
+        value: updated_value,
+        summary: update_summary,
+        changed,
+        ..
+    } = match update_result {
+        Ok(result) => result,
+        Err(err) => {
+            if is_delta {
+                // Delta application failed → send ResyncRequest. Mirrors
+                // update.rs:710-758.
+                tracing::warn!(
+                    tx = %incoming_tx,
+                    contract = %key,
+                    sender = %sender_addr,
+                    error = %err,
+                    event = "delta_apply_failed",
+                    "UPDATE relay (task-per-tx): delta apply failed, sending ResyncRequest"
+                );
+
+                if let Some(sender_pkl) = op_manager
+                    .ring
+                    .connection_manager
+                    .get_peer_by_addr(sender_addr)
+                {
+                    let sender_key = crate::ring::PeerKey::from(sender_pkl.pub_key().clone());
+                    op_manager
+                        .interest_manager
+                        .update_peer_summary(&key, &sender_key, None);
+                }
+
+                tracing::info!(
+                    tx = %incoming_tx,
+                    contract = %key,
+                    target = %sender_addr,
+                    event = "resync_request_sent",
+                    "UPDATE relay (task-per-tx): sending ResyncRequest after delta failure"
+                );
+                if let Err(e) = op_manager
+                    .notify_node_event(NodeEvent::SendInterestMessage {
+                        target: sender_addr,
+                        message: InterestMessage::ResyncRequest { key },
+                    })
+                    .await
+                {
+                    tracing::warn!(
+                        tx = %incoming_tx,
+                        error = %e,
+                        "UPDATE relay (task-per-tx): failed to send ResyncRequest"
+                    );
+                }
+            } else if !err.is_contract_exec_rejection() {
+                // Full state failed and the merge function did NOT reject it
+                // (so contract code is missing). Trigger self-healing GET.
+                op_manager.try_auto_fetch_contract(&key, sender_addr);
+            }
+            return Err(err);
+        }
+    };
+
+    tracing::debug!(
+        tx = %incoming_tx,
+        %key,
+        "UPDATE relay (task-per-tx): BroadcastTo applied"
+    );
+
+    // ── Step 5: telemetry — broadcast applied ─────────────────────────────
+    if let Some(event) = NetEventLog::update_broadcast_applied(
+        &incoming_tx,
+        &op_manager.ring,
+        key,
+        &state_for_telemetry,
+        &updated_value,
+        changed,
+    ) {
+        op_manager.ring.register_events(Either::Left(event)).await;
+    }
+
+    if !changed {
+        tracing::debug!(
+            tx = %incoming_tx,
+            %key,
+            "UPDATE relay (task-per-tx): BroadcastTo produced no change, ending propagation"
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        "UPDATE relay (task-per-tx): contract {} @ {:?} updated via BroadcastTo",
+        key,
+        self_location.location()
+    );
+
+    // ── Step 6: proactive summary notification ────────────────────────────
+    //
+    // Mirrors update.rs:806-819 — spawn a background task to notify
+    // interested peers our state changed. Unregistered with
+    // BackgroundTaskMonitor to match legacy timing semantics
+    // (per-broadcast spawn, dies when complete). Per-broadcast
+    // amplification is bounded by `should_send_summary_notification`'s
+    // 100ms-per-contract throttle inside the task.
+    let op_mgr = op_manager.clone();
+    let summary = update_summary.clone();
+    tokio::spawn(async move {
+        super::send_proactive_summary_notification(&op_mgr, &key, sender_addr, summary).await;
+    });
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     /// Guard: `client_events.rs` must call `start_client_update` for both the
@@ -418,6 +1072,274 @@ mod tests {
             src.contains("value: updated_value"),
             "RequestUpdate must use the post-merge updated_value, not the original \
              client update_data (mirrors legacy update.rs:2055)"
+        );
+    }
+
+    // ── Relay UPDATE driver structural pin tests (#1454 phase 5 follow-up,
+    // slice A scaffold). These pin the driver SOURCE against documented
+    // invariants; a future change that breaks any invariant should fail
+    // these before sim runs catch the consequence. Behavioral tests for
+    // the dispatch gate live in commit 2.
+
+    /// Pin: relay drivers must NOT call `send_and_await` anywhere. UPDATE
+    /// is fire-and-forget end-to-end; introducing a `send_and_await`
+    /// reintroduces the four-amplifier surface that hit phase-5 GET.
+    #[test]
+    fn relay_drivers_never_call_send_and_await() {
+        let src = include_str!("op_ctx_task.rs");
+        // Find the relay driver section (everything between the relay
+        // marker comment and the test module).
+        // Skip past the section header / module-level scope doc comment
+        // (which references variant names by design) by anchoring on the
+        // first relay entry-point fn.
+        let relay_start = src
+            .find("pub(crate) async fn start_relay_request_update(")
+            .expect("start_relay_request_update not found");
+        let relay_end = src
+            .find("#[cfg(test)]")
+            .expect("test module marker not found");
+        let relay_src = &src[relay_start..relay_end];
+        // Match call-site forms only (`.send_and_await(` /
+        // `send_and_await(`), so doc comments mentioning the symbol
+        // don't trip the lint.
+        assert!(
+            !relay_src.contains(".send_and_await("),
+            "Relay UPDATE drivers MUST NOT call send_and_await. UPDATE is \
+             fire-and-forget; introducing a wait reintroduces phase-5 GET's \
+             amplifier surface."
+        );
+    }
+
+    /// Pin: `RequestUpdate` driver must call `send_fire_and_forget` for
+    /// the forward path (single forward, no retry, no ack).
+    #[test]
+    fn relay_request_update_uses_fire_and_forget() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_request_update(")
+            .expect("drive_relay_request_update not found");
+        let driver_end_marker = src[driver_start..]
+            .find("\n}")
+            .expect("driver body end not found");
+        let driver_src = &src[driver_start..driver_start + driver_end_marker];
+        assert!(
+            driver_src.contains("send_fire_and_forget"),
+            "drive_relay_request_update must use send_fire_and_forget for the \
+             forward path"
+        );
+    }
+
+    /// Pin: `BroadcastTo` driver must check the dedup cache BEFORE calling
+    /// `update_contract`. If the order flips, duplicate broadcasts re-run
+    /// the WASM merge and amplify executor cost N-fold.
+    #[test]
+    fn broadcast_to_dedup_runs_before_merge() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_broadcast_to(")
+            .expect("drive_relay_broadcast_to not found");
+        let driver_end_marker = src[driver_start..]
+            .find("\n}")
+            .expect("driver body end not found");
+        let driver_src = &src[driver_start..driver_start + driver_end_marker];
+
+        let dedup_pos = driver_src
+            .find("broadcast_dedup_cache.check_and_insert")
+            .expect("dedup cache check missing in BroadcastTo driver");
+        let merge_pos = driver_src
+            .find("super::update_contract(")
+            .expect("update_contract call missing in BroadcastTo driver");
+        assert!(
+            dedup_pos < merge_pos,
+            "broadcast_dedup_cache.check_and_insert MUST appear before \
+             update_contract() in drive_relay_broadcast_to. If the order \
+             flips, duplicate broadcasts re-run WASM merge and amplify cost."
+        );
+    }
+
+    /// Pin: `BroadcastTo` driver must send `ResyncRequest` on delta apply
+    /// failure (before returning the error). Without this, peers stay out
+    /// of sync indefinitely on delta divergence.
+    #[test]
+    fn broadcast_to_sends_resync_on_delta_failure() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_broadcast_to(")
+            .expect("drive_relay_broadcast_to not found");
+        let driver_src = &src[driver_start..];
+        assert!(
+            driver_src.contains("InterestMessage::ResyncRequest"),
+            "drive_relay_broadcast_to must emit InterestMessage::ResyncRequest \
+             when a delta payload fails to apply (mirrors legacy update.rs:745-758)."
+        );
+    }
+
+    /// Pin: `BroadcastTo` driver must call `try_auto_fetch_contract` on
+    /// full-state failure that is NOT a contract execution rejection. This
+    /// is the self-healing recovery path for missing contract code.
+    #[test]
+    fn broadcast_to_triggers_auto_fetch_on_full_state_failure() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_broadcast_to(")
+            .expect("drive_relay_broadcast_to not found");
+        let driver_src = &src[driver_start..];
+        assert!(
+            driver_src.contains("try_auto_fetch_contract"),
+            "drive_relay_broadcast_to must call try_auto_fetch_contract on \
+             non-rejection full-state failures (mirrors legacy update.rs:764)."
+        );
+    }
+
+    /// Pin: `BroadcastTo` driver must spawn the proactive summary
+    /// notification background task on a successful state change. Skipping
+    /// it causes peers to repeatedly broadcast stale data.
+    #[test]
+    fn broadcast_to_spawns_proactive_summary() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_broadcast_to(")
+            .expect("drive_relay_broadcast_to not found");
+        let driver_src = &src[driver_start..];
+        assert!(
+            driver_src.contains("send_proactive_summary_notification"),
+            "drive_relay_broadcast_to must spawn send_proactive_summary_notification \
+             after a successful state change (mirrors legacy update.rs:806-819)."
+        );
+    }
+
+    /// Pin: both relay drivers MUST gate on `active_relay_update_txs` to
+    /// reject duplicate inbound messages for an in-flight tx (matches the
+    /// pattern that GET phase 5 needed to avoid amplification).
+    #[test]
+    fn relay_drivers_use_per_node_dedup_gate() {
+        let src = include_str!("op_ctx_task.rs");
+        let request_start = src
+            .find("pub(crate) async fn start_relay_request_update(")
+            .expect("start_relay_request_update not found");
+        let broadcast_start = src
+            .find("pub(crate) async fn start_relay_broadcast_to(")
+            .expect("start_relay_broadcast_to not found");
+
+        // Take ~1KB of body after each entry — enough to cover the dedup
+        // gate but not the rest of the file.
+        let req_body = &src[request_start..request_start + 1500];
+        let bc_body = &src[broadcast_start..broadcast_start + 1500];
+        assert!(
+            req_body.contains("active_relay_update_txs.insert"),
+            "start_relay_request_update must check active_relay_update_txs"
+        );
+        assert!(
+            bc_body.contains("active_relay_update_txs.insert"),
+            "start_relay_broadcast_to must check active_relay_update_txs"
+        );
+    }
+
+    /// Pin: dedup gate must increment `RELAY_UPDATE_DEDUP_REJECTS` when it
+    /// rejects a duplicate. Without the counter, the regression
+    /// signal is invisible to `FREENET_MEMORY_STATS` operators.
+    #[test]
+    fn dedup_rejection_increments_counter() {
+        let src = include_str!("op_ctx_task.rs");
+        // Restrict to the production driver section so the test source's
+        // own grep references don't enter the iteration.
+        let relay_start = src
+            .find("pub(crate) async fn start_relay_request_update(")
+            .expect("start_relay_request_update not found");
+        let relay_end = src
+            .find("#[cfg(test)]")
+            .expect("test module marker not found");
+        let relay_src = &src[relay_start..relay_end];
+
+        let sites: Vec<&str> = relay_src
+            .split("active_relay_update_txs.insert(incoming_tx)")
+            .skip(1)
+            .collect();
+        assert_eq!(
+            sites.len(),
+            2,
+            "expected exactly two dedup sites (RequestUpdate + BroadcastTo)"
+        );
+        for (idx, section) in sites.iter().enumerate() {
+            let window = &section[..500.min(section.len())];
+            assert!(
+                window.contains("RELAY_UPDATE_DEDUP_REJECTS.fetch_add"),
+                "dedup gate site #{idx} does not increment RELAY_UPDATE_DEDUP_REJECTS"
+            );
+        }
+    }
+
+    /// Pin: the RAII guard must remove from `active_relay_update_txs` on
+    /// drop. Without this, a panicking driver would permanently block
+    /// future drivers for the same tx.
+    #[test]
+    fn raii_guard_clears_dedup_set_on_drop() {
+        let src = include_str!("op_ctx_task.rs");
+        let drop_start = src
+            .find("impl Drop for RelayUpdateInflightGuard")
+            .expect("RelayUpdateInflightGuard Drop impl not found");
+        let drop_body = &src[drop_start..drop_start + 600];
+        assert!(
+            drop_body.contains("active_relay_update_txs"),
+            "RelayUpdateInflightGuard::drop must remove from active_relay_update_txs"
+        );
+        assert!(
+            drop_body.contains("RELAY_UPDATE_INFLIGHT.fetch_sub"),
+            "RelayUpdateInflightGuard::drop must decrement RELAY_UPDATE_INFLIGHT"
+        );
+        assert!(
+            drop_body.contains("RELAY_UPDATE_COMPLETED_TOTAL.fetch_add"),
+            "RelayUpdateInflightGuard::drop must increment RELAY_UPDATE_COMPLETED_TOTAL"
+        );
+    }
+
+    /// Pin: streaming variants MUST NOT be touched by the driver in slice A.
+    /// They stay on the legacy path until slice B. Reference the variant
+    /// names by their wire-message identifiers.
+    #[test]
+    fn slice_a_does_not_touch_streaming_variants() {
+        let src = include_str!("op_ctx_task.rs");
+        // Skip past the section header / module-level scope doc comment
+        // (which references variant names by design) by anchoring on the
+        // first relay entry-point fn.
+        let relay_start = src
+            .find("pub(crate) async fn start_relay_request_update(")
+            .expect("start_relay_request_update not found");
+        let relay_end = src
+            .find("#[cfg(test)]")
+            .expect("test module marker not found");
+        let relay_src = &src[relay_start..relay_end];
+        assert!(
+            !relay_src.contains("RequestUpdateStreaming"),
+            "slice A must not handle RequestUpdateStreaming (deferred to slice B)"
+        );
+        assert!(
+            !relay_src.contains("BroadcastToStreaming"),
+            "slice A must not handle BroadcastToStreaming (deferred to slice B)"
+        );
+    }
+
+    /// Pin: `Broadcasting` (deprecated) must not be migrated. Legacy
+    /// handler treats it as a no-op; driver should never reference it.
+    #[test]
+    fn deprecated_broadcasting_variant_stays_legacy() {
+        let src = include_str!("op_ctx_task.rs");
+        // Skip past the section header / module-level scope doc comment
+        // (which references variant names by design) by anchoring on the
+        // first relay entry-point fn.
+        let relay_start = src
+            .find("pub(crate) async fn start_relay_request_update(")
+            .expect("start_relay_request_update not found");
+        let relay_end = src
+            .find("#[cfg(test)]")
+            .expect("test module marker not found");
+        let relay_src = &src[relay_start..relay_end];
+        // Match the variant constructor (UpdateMsg::Broadcasting), not
+        // arbitrary substrings (e.g. "Broadcasting" in a doc comment).
+        assert!(
+            !relay_src.contains("UpdateMsg::Broadcasting"),
+            "Driver must not handle UpdateMsg::Broadcasting — deprecated wire \
+             variant; legacy no-op handler stays in place."
         );
     }
 }

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -740,9 +740,18 @@ async fn drive_relay_request_update(
         }
     };
 
-    let forward_addr = forward_target
-        .socket_addr()
-        .expect("forward target must have socket address");
+    let forward_addr = match forward_target.socket_addr() {
+        Some(addr) => addr,
+        None => {
+            tracing::error!(
+                tx = %incoming_tx,
+                %key,
+                target_pub_key = %forward_target.pub_key(),
+                "UPDATE relay (task-per-tx): forward target has no socket address"
+            );
+            return Err(OpError::RingError(RingError::NoHostingPeers(*key.id())));
+        }
+    };
 
     tracing::debug!(
         tx = %incoming_tx,

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -428,7 +428,21 @@ pub(crate) async fn start_relay_request_update(
         "UPDATE relay (task-per-tx): spawning RequestUpdate driver"
     );
 
+    // Construct guard + bump counters BEFORE spawn so the dedup-set
+    // entry is paired with a Drop even if the spawned future is dropped
+    // before its first poll (executor shutdown, scheduling panic).
+    // Without this, a pre-poll drop would permanently leak the
+    // `active_relay_update_txs` entry — no TTL → permanent dedup
+    // blind-spot for that tx.
+    RELAY_UPDATE_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RELAY_UPDATE_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let guard = RelayUpdateInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
     GlobalExecutor::spawn(run_relay_request_update(
+        guard,
         op_manager,
         incoming_tx,
         key,
@@ -477,7 +491,17 @@ pub(crate) async fn start_relay_broadcast_to(
         "UPDATE relay (task-per-tx): spawning BroadcastTo driver"
     );
 
+    // See `start_relay_request_update` — guard pre-spawn closes the
+    // pre-poll dedup-leak window.
+    RELAY_UPDATE_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RELAY_UPDATE_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let guard = RelayUpdateInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
     GlobalExecutor::spawn(run_relay_broadcast_to(
+        guard,
         op_manager,
         incoming_tx,
         key,
@@ -508,6 +532,7 @@ impl Drop for RelayUpdateInflightGuard {
 }
 
 async fn run_relay_request_update(
+    guard: RelayUpdateInflightGuard,
     op_manager: Arc<OpManager>,
     incoming_tx: Transaction,
     key: ContractKey,
@@ -515,12 +540,7 @@ async fn run_relay_request_update(
     value: WrappedState,
     sender_addr: SocketAddr,
 ) {
-    RELAY_UPDATE_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    RELAY_UPDATE_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let _guard = RelayUpdateInflightGuard {
-        op_manager: op_manager.clone(),
-        incoming_tx,
-    };
+    let _guard = guard;
 
     if let Err(err) = drive_relay_request_update(
         &op_manager,
@@ -543,6 +563,7 @@ async fn run_relay_request_update(
 }
 
 async fn run_relay_broadcast_to(
+    guard: RelayUpdateInflightGuard,
     op_manager: Arc<OpManager>,
     incoming_tx: Transaction,
     key: ContractKey,
@@ -550,12 +571,7 @@ async fn run_relay_broadcast_to(
     sender_summary_bytes: Vec<u8>,
     sender_addr: SocketAddr,
 ) {
-    RELAY_UPDATE_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    RELAY_UPDATE_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let _guard = RelayUpdateInflightGuard {
-        op_manager: op_manager.clone(),
-        incoming_tx,
-    };
+    let _guard = guard;
 
     if let Err(err) = drive_relay_broadcast_to(
         &op_manager,
@@ -970,7 +986,7 @@ async fn drive_relay_broadcast_to(
     // 100ms-per-contract throttle inside the task.
     let op_mgr = op_manager.clone();
     let summary = update_summary.clone();
-    tokio::spawn(async move {
+    GlobalExecutor::spawn(async move {
         super::send_proactive_summary_notification(&op_mgr, &key, sender_addr, summary).await;
     });
 

--- a/crates/core/src/operations/update/op_ctx_task.rs
+++ b/crates/core/src/operations/update/op_ctx_task.rs
@@ -759,12 +759,22 @@ async fn drive_relay_request_update(
     }
 
     // Forward downstream. We use the INCOMING tx (end-to-end preservation).
-    // Streaming variants are handled on the legacy path in slice A; if the
-    // payload size triggers streaming, fall back to legacy by emitting the
-    // forward via legacy plumbing in commit 2's dispatch (TODO: confirm
-    // dispatch falls through to legacy when payload requires streaming —
-    // currently slice A only routes non-streaming RequestUpdate to the
-    // driver).
+    //
+    // Slice A scope: this driver only handles inbound non-streaming
+    // `UpdateMsg::RequestUpdate` (the dispatch gate in node.rs filters
+    // out `RequestUpdateStreaming`). On the relay forward we re-emit
+    // non-streaming `RequestUpdate` regardless of payload size — the
+    // streaming-upgrade path on relay forward (legacy update.rs:518-535
+    // checks `should_use_streaming` before emitting `RequestUpdate` vs
+    // `RequestUpdateStreaming`) is deferred to slice B together with
+    // the streaming-variant migration. Tracked in
+    // docs/port-plans/relay-update-task-per-tx.md §3 / §9.
+    //
+    // Practical impact in slice A: large UPDATE payloads arriving as
+    // non-streaming `RequestUpdate` (which only happens if the upstream
+    // relay decided not to stream them) are forwarded as non-streaming
+    // — the same shape they arrived in. Slice B will add the size
+    // check + variant upgrade.
     let request = NetMessage::from(UpdateMsg::RequestUpdate {
         id: incoming_tx,
         key,

--- a/docs/port-plans/relay-update-task-per-tx.md
+++ b/docs/port-plans/relay-update-task-per-tx.md
@@ -1,0 +1,307 @@
+# Relay UPDATE → task-per-tx port plan (#1454 phase 5 follow-up)
+
+**Branch:** `phase-5-relay-update`
+**Baseline:** main @ `bc8ee9d` (PR #3896 — relay GET task-per-tx) merged.
+**Predecessor patterns:** PR #3806 (SUBSCRIBE 2b), #3843 (PUT 3a), #3884 (GET 3b),
+#3891 (UPDATE 4 client-init), #3896 (relay GET phase 5).
+
+## 1. Problem statement
+
+Today the **client-initiated** UPDATE at an originator runs through
+`operations/update/op_ctx_task.rs::start_client_update` (Phase 4). But every
+**relay hop** that receives any of the five `UpdateMsg` wire variants still
+hits the legacy `process_message` re-entry loop:
+
+```
+node.rs:1191  NetMessageV1::Update
+  → handle_op_request::<update::UpdateOp, _>
+    → UpdateOp::process_message
+      → match UpdateMsg { RequestUpdate
+                        | BroadcastTo
+                        | Broadcasting (deprecated)
+                        | RequestUpdateStreaming
+                        | BroadcastToStreaming }
+```
+
+Relay state lives in an `UpdateOp` stored in `OpManager.ops.update` indexed
+by tx, mutated by each incoming message. Same state-machine pattern the
+task-per-tx refactor is eliminating.
+
+**Scope of this port:** migrate the relay-hop side of UPDATE to a task-per-tx
+driver so a relay receiving `UpdateMsg::RequestUpdate` or
+`UpdateMsg::BroadcastTo` spawns a driver that owns the local-apply +
+forward-or-broadcast decision in task locals, with **no `UpdateOp` in
+`OpManager.ops.update` for any relay hop**.
+
+## 2. Architectural map (UPDATE differs from GET)
+
+UPDATE is **not** request/response. There is no upstream reply on success
+or failure for `RequestUpdate` or `BroadcastTo`. Relay state transitions
+are terminal (`Finished` or `None`). The op survives only because GC needs
+something to time-out for telemetry.
+
+Wire variants and their relay roles:
+
+| Variant | Relay role | Reply? | Side effects |
+|---|---|---|---|
+| `RequestUpdate` | Forward inbound update toward closest peer that hosts contract | None | If has-contract: apply locally → BroadcastStateChange (automatic). If not: forward downstream once. |
+| `BroadcastTo` | Apply broadcast payload locally; auto-fanout via BroadcastStateChange | None | Dedup cache check, WASM merge, ResyncRequest on delta failure, try_auto_fetch_contract on missing-params, proactive summary notify. |
+| `Broadcasting` | DEPRECATED no-op | None | None (logging only). |
+| `RequestUpdateStreaming` | Same as RequestUpdate but assembles streamed value first | None | Stream claim, assemble, deserialize, then RequestUpdate logic. |
+| `BroadcastToStreaming` | Same as BroadcastTo but streamed | None | Stream claim, assemble, then BroadcastTo logic. |
+
+**Loop-back consideration:** Phase 4's client driver does NOT call
+`send_to_and_await(target=None)` like GET does. It calls
+`send_fire_and_forget(target_addr, msg)` for the remote case and never
+loops back through pure-network-message handler. So **no loop-back path
+to preserve** for UPDATE — this is simpler than GET.
+
+**Per-node dedup:** GET relay added `active_relay_get_txs` to drop
+duplicate inbound Requests. UPDATE needs a similar gate but the
+amplification risk is lower because there's no retry loop and no waited
+response. Still add `active_relay_update_txs` for parity + safety against
+GC-spawned re-entries.
+
+## 3. Scope decision: which variants migrate
+
+**This PR — slice A:**
+- ✅ `RequestUpdate` (non-streaming)
+- ✅ `BroadcastTo` (non-streaming)
+- ✅ `Broadcasting` (deprecated — fall through to legacy no-op handler;
+   not worth migrating)
+
+**Deferred — slice B (follow-up PR):**
+- ⏳ `RequestUpdateStreaming`
+- ⏳ `BroadcastToStreaming`
+
+Streaming variants share the same orphan-stream infrastructure as GET's
+deferred slice 4. Migrate both ops' streaming together so the orphan-claim
++ assembly pattern lands once.
+
+**Slice C (cleanup):**
+- ⏳ Remove relay branches from `update.rs::process_message` once both
+  slices A + B above prove stable.
+
+## 4. Code map
+
+### 4.1 Legacy relay regions to bypass (slice A)
+
+| Region | Lines | Role |
+|---|---|---|
+| `UpdateMsg::RequestUpdate` arm | 347-594 | Local apply or forward to next hop |
+| `UpdateMsg::BroadcastTo` arm | 595-825 | Apply broadcast, dedup, ResyncRequest, auto-fetch |
+| `UpdateMsg::Broadcasting` arm | 826-844 | Deprecated logging-only |
+
+Streaming branches (847-1054 and beyond) stay legacy in slice A.
+
+### 4.2 New driver entry points — `operations/update/op_ctx_task.rs`
+
+```rust
+pub(crate) async fn start_relay_request_update(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    related_contracts: RelatedContracts<'static>,
+    value: WrappedState,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError>;
+
+pub(crate) async fn start_relay_broadcast_to(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    key: ContractKey,
+    payload: DeltaOrFullState,
+    sender_summary_bytes: Vec<u8>,
+    sender_addr: SocketAddr,
+) -> Result<(), OpError>;
+```
+
+Driver bodies mirror legacy `process_message` arms but:
+- No `OpManager.ops.update` push.
+- No `return_msg` / `new_state` bookkeeping.
+- All side effects (dedup cache, WASM merge, ResyncRequest, auto-fetch,
+  proactive summary) reproduced verbatim.
+- Forward-downstream uses `OpCtx::send_fire_and_forget` (no
+  `send_to_and_await` — UPDATE has no reply to await).
+- Per-node dedup via `OpManager::active_relay_update_txs` (DashSet).
+
+### 4.3 Dispatch wiring — `node.rs::NetMessageV1::Update` branch
+
+Replaces `handle_op_request::<update::UpdateOp, _>` for fresh inbound
+`RequestUpdate` / `BroadcastTo` with `source_addr.is_some()` and no
+existing `UpdateOp`. All other paths fall through to legacy:
+
+- `RequestUpdateStreaming` / `BroadcastToStreaming` → legacy (slice B).
+- `Broadcasting` → legacy (deprecated no-op).
+- Existing `UpdateOp` (GC-spawned retries, originator loop-back) → legacy.
+
+Add `OpManager::has_update_op(tx) -> bool` mirroring `has_get_op`.
+
+### 4.4 Telemetry parity
+
+Each relay arm emits NetEventLog events (`update_request`,
+`update_success`, `update_broadcast_received`, `update_broadcast_applied`,
+`update_failure`). Driver replicates every emission point with same
+arguments and ordering.
+
+## 5. Tricky cases
+
+### 5.1 BroadcastTo dedup cache (#5: amplification risk)
+
+`broadcast_dedup_cache.check_and_insert` MUST fire BEFORE the WASM
+merge. If we skip dedup and run merge for every duplicate broadcast, a
+gossiping fanout multiplies WASM cost N-fold. Driver inserts the dedup
+check at the same point legacy does (after telemetry, before merge).
+
+### 5.2 ResyncRequest on delta-merge failure
+
+Legacy `update.rs:759-758` sends `InterestMessage::ResyncRequest` via
+`notify_node_event` when delta application fails. Driver MUST replicate
+this — it's the primary recovery path for state divergence between peers.
+
+### 5.3 try_auto_fetch_contract on missing params
+
+`update.rs:764` triggers self-healing GET when full-state update fails
+with non-rejection error. Replicate in driver.
+
+### 5.4 Proactive summary notification
+
+`update.rs:806-819` spawns background task to notify interested peers
+when state changes (so they can update their cached summary of us).
+Driver MUST also spawn this — without it, peers re-broadcast stale data
+to us repeatedly.
+
+### 5.5 No upstream reply
+
+UPDATE relay never sends a response back to upstream. The originator's
+client driver completes IMMEDIATELY after `send_fire_and_forget`
+returns (Phase 4 design). So the new relay driver:
+- Does NOT call `send_and_await` anywhere.
+- Does NOT install a `pending_op_results` slot.
+- Does NOT need any reply-routing bypass in `node.rs`.
+
+This is simpler than GET relay and means **no per-node dedup
+amplification risk** of the kind that hit phase 5 GET. We still add
+the dedup gate for tx-collision robustness against GC-spawned retries.
+
+### 5.6 Originator loopback non-issue
+
+Phase 4 client driver (`update/op_ctx_task.rs:264-273`) builds
+`UpdateMsg::RequestUpdate` and sends via `send_fire_and_forget` to a
+remote peer. It never sends to itself. There's no Phase-4-equivalent of
+GET's `send_and_await(target=None)` loop-back. So we don't need a
+`source_addr.is_none()` legacy fall-through for Phase 4 compatibility.
+
+The dispatch gate still gates on `source_addr.is_some()` defensively —
+internal callers (e.g. `start_op_with_id` from `start_targeted_op`)
+that pre-register an `UpdateOp` will be caught by `has_update_op(tx)
+-> true`.
+
+### 5.7 Apply-amplification-fixes preemptively
+
+Mitigate the four amplifiers from PR #3896 even though most don't
+apply to UPDATE:
+1. ✅ No retry loop at relay (UPDATE forwards once unconditionally).
+2. ✅ No fresh attempt_tx (UPDATE uses incoming_tx directly).
+3. ✅ No ForwardingAck (UPDATE never had one).
+4. ✅ Per-node dedup via `active_relay_update_txs` DashSet.
+
+## 6. Commit split
+
+1. **`refactor(ops): add relay UPDATE task-per-tx driver scaffold`**
+   Add `start_relay_request_update` + `start_relay_broadcast_to` +
+   helpers to `operations/update/op_ctx_task.rs`. Add
+   `OpManager::has_update_op` + `active_relay_update_txs` field.
+   `#[allow(dead_code)]` on driver — not yet wired. Unit tests for:
+   - Dispatch decision tree (has-contract vs no-contract for RequestUpdate)
+   - Dedup cache hit on duplicate BroadcastTo
+   - ResyncRequest emission on delta failure
+   - try_auto_fetch_contract emission on full-state failure
+   - Per-node dedup gate rejects duplicate tx
+   `cargo test -p freenet --lib` green.
+
+2. **`refactor(ops): route relay UPDATE through task-per-tx driver`**
+   Switch dispatch in `node.rs::NetMessageV1::Update` branch to call
+   `start_relay_request_update` / `start_relay_broadcast_to` for fresh
+   inbound non-streaming variants with `source_addr.is_some()` and no
+   existing `UpdateOp`. Lift `dead_code` allows. Add structural pin
+   tests + behavioral invariants:
+   - T1: dispatch routes RequestUpdate to driver
+   - T2: dispatch routes BroadcastTo to driver
+   - T3: dispatch falls through for Streaming variants
+   - T4: dispatch falls through for Broadcasting (deprecated)
+   - T5: dispatch falls through when has_update_op returns true
+   - T6: dispatch falls through when source_addr is None
+   - T7: counter increments on driver entry
+   - T8: relay driver does NOT call send_and_await
+   - T9: relay driver MUST call dedup cache before merge
+
+3. **`refactor(ops): remove unreachable relay arms from update.rs`**
+   Delete the `RequestUpdate` and `BroadcastTo` arms of
+   `process_message` once tests confirm they're unreachable for fresh
+   inbound traffic. Keep streaming arms (slice B). Verify with grep.
+
+## 7. Validation gates
+
+### 7.1 Per-commit
+
+```
+cargo fmt
+cargo clippy -- -D warnings
+cargo test -p freenet --lib
+```
+
+### 7.2 Commit 2 (behavior flip)
+
+Sim integration tests on Linux via `/linux-test`:
+- `test_update_basic_propagation`
+- `test_update_two_node`
+- `test_update_three_node`
+- `test_update_propagates_through_relay`
+- `test_update_fanout`
+- `test_update_subscribe_after_update_propagates`
+- `test_concurrent_updates_from_multiple_clients`
+- `test_update_delta_merge_recovery`
+- `test_update_resync_on_delta_failure`
+- `test_update_streaming_large_payload` (must stay green — slice A doesn't
+  touch streaming, but verify dispatch fallthrough works)
+
+### 7.3 Memory regression watch
+
+Run `simulation-debug.yml` ci-fault-loss workflow with RSS sampler.
+Compare against post-#3896 baseline (2.6 GB peak). Driver has no retry
+loop and no `send_and_await` — expected RSS impact: minimal. Any
+regression is suspicious.
+
+## 8. Risks
+
+- **Dedup cache consistency:** if driver misses the dedup check, a
+  duplicate BroadcastTo runs WASM merge twice, doubling executor cost.
+  Mitigation: T9 structural test pins the call order.
+
+- **ResyncRequest semantics:** if the driver doesn't clear cached peer
+  summary before sending ResyncRequest, the peer sends back the same
+  delta and the loop continues. Mitigation: replicate clear-then-send
+  ordering exactly.
+
+- **Auto-fetch contract:** `try_auto_fetch_contract` spawns a GET
+  internally via `start_targeted_op`. Verify spawn succeeds and the
+  fetched contract is properly stored.
+
+- **Proactive summary task:** `tokio::spawn`ed background task. Per
+  `code-style.md` rule "no fire-and-forget for critical tasks" — but
+  this matches legacy. Replicate without registering with
+  `BackgroundTaskMonitor` to preserve parity. Document why in driver
+  comment.
+
+- **Telemetry coverage gaps:** if any `NetEventLog::*` emission is
+  dropped, downstream observability tooling sees gaps in update
+  traces. T-series structural tests grep for each emission name in
+  driver source.
+
+## 9. Out of scope (slice B + slice C follow-ups)
+
+- `RequestUpdateStreaming` / `BroadcastToStreaming` migration.
+- Removal of `UpdateOp::process_message` relay arms.
+- `Broadcasting` (deprecated) handler removal.
+- Final `OpManager.ops.update` DashMap deletion (Phase 5 close-out).


### PR DESCRIPTION
## Problem

Phase 5 of #1454 migrated relay GET to the task-per-tx pattern (PR #3896 / `bc8ee9d`). Relay UPDATE still ran on the legacy `OpManager.ops.update` DashMap state machine. UPDATE relays inherit the same amplifier classes that broke GET (per-tx GC blind spots, dedup-set leakage, virtual-time TTL collapse) — keeping UPDATE on legacy blocks the eventual deletion of `OpManager.ops` + `process_message` + `OperationResult` planned for Phase 5 close-out.

## Solution

Slice A (this PR) ports the non-streaming UPDATE relay variants — `RequestUpdate` and `BroadcastTo` — to the task-per-tx driver pattern. Slice B (streaming variants) and slice C (cleanup of unreachable arms in `update.rs::process_message`) follow.

Key insight: UPDATE is fire-and-forget end-to-end (no upstream reply, no retry loop), so the relay driver is structurally simpler than GET — no `ForwardingAck`, no loop-back to preserve. Still adds the per-node dedup gate (`active_relay_update_txs` DashSet + `RelayUpdateInflightGuard` RAII cleanup) to suppress GC-spawned re-entries for the same tx.

Dispatch in `node.rs::handle_pure_network_message_v1` UPDATE branch is gated on:
- `source_addr.is_some()` (true relay; internal callers fall through to legacy)
- `!op_manager.has_update_op(id)` (no pre-registered op; GC retries / `start_targeted_op` fall through)
- non-streaming variants only (`RequestUpdate`, `BroadcastTo`)

`drive_relay_request_update`: have-contract → `update_contract` + telemetry; no-contract → single `send_fire_and_forget` forward; no peers → error + telemetry.

`drive_relay_broadcast_to`: sender summary update → telemetry → `BroadcastDedupCache` BEFORE `update_contract` (to prevent amplification) → on delta failure send `InterestMessage::ResyncRequest` → on full-state failure with missing code call `try_auto_fetch_contract` → on success spawn `send_proactive_summary_notification`.

Streaming variants (`RequestUpdateStreaming`, `BroadcastToStreaming`) and the deprecated `Broadcasting` wire variant stay on the legacy path in slice A — see `docs/port-plans/relay-update-task-per-tx.md` §3.

## Testing

**Unit / structural pin tests** (in `op_ctx_task.rs::tests` and `node.rs::tests`):
- 11 source-literal pins for the relay drivers (dedup-before-merge ordering, ResyncRequest on delta failure, auto-fetch on full-state failure, fire-and-forget for RequestUpdate, no `send_and_await`, slice-A boundary against streaming/Broadcasting)
- 3 dispatch-branch pins (`update_branch_dispatch_calls_relay_drivers`, `update_branch_dispatch_gates_on_source_and_existing_op`, `update_branch_does_not_dispatch_streaming_or_broadcasting`)
- `has_update_op` smoke tests (insert/remove)

**Integration / simulation tests on Linux** (Docker `freenet-test-runner`):
| Test | Result |
|------|--------|
| `test_update_contract` | PASS |
| `test_update_no_change_notification` | PASS |
| `test_update_broadcast_propagation_issue_2301` | PASS |
| `test_concurrent_updates_convergence` | PASS |
| `test_concurrent_updates_from_n_sources` | PASS |
| `test_auto_fetch_from_update_sender` | PASS |
| `test_streaming_update_broadcast` | PASS (slice-A keeps streaming on legacy — verifies no regression) |

Full lib test suite: 2401 passed, 16 ignored.

## Fixes

Refs #1454 (phase 5 follow-up). Does NOT close — slice B (streaming) + slice C (cleanup) + PUT/SUBSCRIBE relay migrations remain.