### PR TITLE
fix(operations/update): downgrade benign WASM merge rejections to INFO

### DIFF
--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -177,7 +177,7 @@ impl ExecutorError {
         }
     }
 
-    fn request(error: impl Into<RequestError>) -> Self {
+    pub(crate) fn request(error: impl Into<RequestError>) -> Self {
         Self {
             inner: Either::Left(Box::new(error.into())),
             fatal: false,

--- a/crates/core/src/contract/executor.rs
+++ b/crates/core/src/contract/executor.rs
@@ -177,7 +177,7 @@ impl ExecutorError {
         }
     }
 
-    pub(crate) fn request(error: impl Into<RequestError>) -> Self {
+    fn request(error: impl Into<RequestError>) -> Self {
         Self {
             inner: Either::Left(Box::new(error.into())),
             fatal: false,
@@ -236,7 +236,15 @@ impl ExecutorError {
 
     /// Returns true if this error indicates the contract's WASM merge function
     /// ran and rejected the update (e.g., stale version). This means the contract
-    /// code IS present locally — no auto-fetch is needed.
+    /// code IS present locally, so no auto-fetch is needed.
+    ///
+    /// This is BROADER than `is_invalid_update_rejection`: it ALSO returns true
+    /// for runtime failures like out-of-gas, max-compute-time, traps, etc.,
+    /// because those still mean the contract code is present : only the
+    /// execution itself failed. Use this for auto-fetch decisions, NOT for log
+    /// severity (a contract that runs out of gas is a real bug operators must
+    /// see at ERROR level : see `is_invalid_update_rejection` for the
+    /// log-severity discriminator).
     ///
     /// Only matches errors created via `StdContractError::update_exec_error()`
     /// (cause starts with "execution error:"), NOT other `Update` variants like
@@ -247,6 +255,36 @@ impl ExecutorError {
                 req_err.as_ref(),
                 RequestError::ContractError(StdContractError::Update { cause, .. })
                     if cause.starts_with("execution error")
+            ),
+            Either::Right(_) => false,
+        }
+    }
+
+    /// Returns true ONLY when the contract WASM merge function ran to completion
+    /// and returned a typed `InvalidUpdate` / `InvalidUpdateWithInfo` rejection
+    /// (e.g., "New state version N must be higher than current version N"). This
+    /// is the precise case that production gateways hit on every re-broadcast
+    /// missed by the dedup cache (issue #3914) and the only case where ERROR-
+    /// level logging is operationally noise.
+    ///
+    /// Excluded by design (these remain real failures and keep their ERROR/WARN
+    /// log levels):
+    /// - Out-of-gas / max-compute-time-exceeded
+    /// - WASM traps (stack overflow, division by zero, etc.)
+    /// - Compilation errors, instantiation errors, internal runtime errors
+    /// - Other contract-side `ContractError` variants (`Deser`, `InvalidState`,
+    ///   `InvalidDelta`, `Other`, `DoublePut`, `InvalidArrayLength`, etc.)
+    ///
+    /// Discriminator: stdlib's `ContractError::InvalidUpdate{,WithInfo}` Display
+    /// impls produce strings beginning with "invalid contract update", which
+    /// `update_exec_error` then prefixes with "execution error: ". Any other
+    /// flavor of execution error has a different prefix and falls through.
+    pub fn is_invalid_update_rejection(&self) -> bool {
+        match &self.inner {
+            Either::Left(req_err) => matches!(
+                req_err.as_ref(),
+                RequestError::ContractError(StdContractError::Update { cause, .. })
+                    if cause.starts_with("execution error: invalid contract update")
             ),
             Either::Right(_) => false,
         }
@@ -1283,6 +1321,88 @@ mod tests {
             assert!(
                 !err.is_contract_exec_rejection(),
                 "Non-request errors should NOT be recognized as exec rejections"
+            );
+        }
+
+        // Tests for `is_invalid_update_rejection` : the tighter predicate that
+        // gates log severity (issue #3914). It must match ONLY the contract's
+        // typed `InvalidUpdate{,WithInfo}` rejections, NOT runtime failures
+        // like OOG/timeout/traps even though those flow through the same
+        // `update_exec_error` wrapper.
+
+        #[test]
+        fn test_invalid_update_rejection_for_invalid_update() {
+            let key = test_fixtures::make_contract_key();
+            // Production cause string from issue #3914.
+            let err = ExecutorError::request(StdContractError::update_exec_error(
+                key,
+                "invalid contract update, reason: New state version 100 must be higher than current version 100",
+            ));
+            assert!(
+                err.is_invalid_update_rejection(),
+                "Contract InvalidUpdateWithInfo rejection MUST be recognized as benign"
+            );
+            assert!(
+                err.is_contract_exec_rejection(),
+                "The benign case must also satisfy the broader predicate (auto-fetch gate)"
+            );
+        }
+
+        #[test]
+        fn test_invalid_update_rejection_false_for_out_of_gas() {
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::update_exec_error(
+                key,
+                "The operation ran out of gas. This might be caused by an infinite loop or an inefficient computation.",
+            ));
+            assert!(
+                !err.is_invalid_update_rejection(),
+                "Out-of-gas MUST NOT be classified as a benign invalid-update rejection (it's a real WASM fault)"
+            );
+            assert!(
+                err.is_contract_exec_rejection(),
+                "Out-of-gas IS a contract-exec error (broader predicate matches), so auto-fetch is correctly skipped"
+            );
+        }
+
+        #[test]
+        fn test_invalid_update_rejection_false_for_max_compute_time() {
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::update_exec_error(
+                key,
+                "The operation exceeded the maximum allowed compute time",
+            ));
+            assert!(
+                !err.is_invalid_update_rejection(),
+                "Max-compute-time MUST NOT be classified as a benign invalid-update rejection"
+            );
+        }
+
+        #[test]
+        fn test_invalid_update_rejection_false_for_double_put() {
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::update_exec_error(
+                key,
+                format!(
+                    "Attempted to perform a put for an already put contract ({key}), use update instead"
+                ),
+            ));
+            assert!(
+                !err.is_invalid_update_rejection(),
+                "DoublePut MUST NOT be classified as a benign invalid-update rejection"
+            );
+        }
+
+        #[test]
+        fn test_invalid_update_rejection_false_for_missing_parameters() {
+            let key = test_fixtures::make_contract_key();
+            let err = ExecutorError::request(StdContractError::Update {
+                key,
+                cause: "missing contract parameters".into(),
+            });
+            assert!(
+                !err.is_invalid_update_rejection(),
+                "Missing parameters is a real failure, not a benign rejection"
             );
         }
 

--- a/crates/core/src/operations.rs
+++ b/crates/core/src/operations.rs
@@ -493,8 +493,21 @@ impl OpError {
     /// Returns true if this error indicates a contract's WASM merge function
     /// ran and rejected the update. When true, the contract code is present
     /// locally and auto-fetching would be unnecessary.
+    ///
+    /// BROADER than `is_invalid_update_rejection` : includes runtime failures
+    /// like OOG/timeout/traps. Use this for auto-fetch decisions, NOT for log
+    /// severity. See `ExecutorError::is_contract_exec_rejection`.
     pub fn is_contract_exec_rejection(&self) -> bool {
         matches!(self, Self::ExecutorError(e) if e.is_contract_exec_rejection())
+    }
+
+    /// Returns true ONLY when the contract WASM merge function rejected the
+    /// update with a typed `InvalidUpdate{,WithInfo}` error (the benign
+    /// stale-state case from issue #3914). Use this for log-severity
+    /// decisions: real WASM faults (OOG, traps, timeouts) return false here
+    /// and stay at ERROR/WARN. See `ExecutorError::is_invalid_update_rejection`.
+    pub fn is_invalid_update_rejection(&self) -> bool {
+        matches!(self, Self::ExecutorError(e) if e.is_invalid_update_rejection())
     }
 }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -1310,11 +1310,9 @@ impl Operation for UpdateOp {
                             }
                         }
                         Err(err) => {
-                            // Two distinct cases (see issue #3914):
-                            //   1. Contract WASM merge rejected the incoming state
-                            //      (e.g., stale version) — benign, log INFO, no auto-fetch.
-                            //   2. Other failure (missing parameters after restart, etc.) —
-                            //      contract not ready locally; log WARN and self-heal.
+                            // See issue #3914 and `log_broadcast_to_streaming_failure`
+                            // for the classification. The bool return is `true` when
+                            // self-heal is needed (real failure, not a benign rejection).
                             if log_broadcast_to_streaming_failure(id, key, &err) {
                                 op_manager.try_auto_fetch_contract(key, sender_addr);
                             }
@@ -1623,23 +1621,29 @@ fn build_op_result(
     })
 }
 
-/// Distinguishes a contract WASM merge rejection (benign — the contract
-/// correctly refused a stale or otherwise invalid incoming state) from a
-/// real failure (missing contract code, storage error, internal bug).
+/// Logs the failure outcome of `update_contract`.
 ///
-/// Mirrors the runtime layer's classification at
-/// `contract::executor::runtime::merge_state_and_validate` (logs the same
-/// rejection at INFO with `event="merge_rejected_valid_local"`). Without
-/// this distinction, every benign re-broadcast that misses the dedup
-/// window produced an ERROR-level log, drowning real alerts on production
-/// gateways. See issue #3914.
+/// Splits into two cases (issue #3914):
+///
+/// 1. The contract WASM merge function rejected the incoming state with a
+///    typed `InvalidUpdate{,WithInfo}` error (e.g. "New state version 100
+///    must be higher than current version 100"). On production gateways
+///    this fires on every re-broadcast that misses the 60s dedup cache,
+///    generating 80-130 ERROR/hr per gateway with no actionable signal.
+///    Logged at INFO with `event="merge_rejected_invalid_update"`.
+///
+/// 2. Anything else (missing contract code, storage error, OOG, WASM trap,
+///    timeout, internal bug) keeps the original ERROR level. The
+///    discriminator is `is_invalid_update_rejection`, which matches the
+///    contract-side `InvalidUpdate{,WithInfo}` cause string EXCLUSIVELY,
+///    so runtime failures like OOG remain visible to operators.
 fn log_update_contract_failure(key: &ContractKey, err: &ExecutorError) {
-    if err.is_contract_exec_rejection() {
+    if err.is_invalid_update_rejection() {
         tracing::info!(
             contract = %key,
             error = %err,
-            event = "merge_rejected_stale",
-            "Update rejected by contract — incoming state stale, keeping local"
+            event = "merge_rejected_invalid_update",
+            "Update rejected by contract: incoming state invalid (likely stale rebroadcast), keeping local"
         );
     } else {
         tracing::error!(
@@ -1651,30 +1655,52 @@ fn log_update_contract_failure(key: &ContractKey, err: &ExecutorError) {
     }
 }
 
-/// Logs the failure of a `BroadcastToStreaming` relay attempt and returns
-/// whether the caller should trigger a self-healing GET. A benign WASM
-/// rejection (stale incoming state) is logged at INFO and returns `false`
-/// — the contract is present locally and no fetch is needed. Any other
-/// failure is logged at WARN and returns `true`. See issue #3914.
+/// Logs the failure outcome of a `BroadcastToStreaming` relay attempt and
+/// returns whether the caller should trigger a self-healing GET.
+///
+/// The two decisions (log severity, auto-fetch) use DIFFERENT predicates
+/// because they answer different questions:
+///
+/// - Log severity uses `is_invalid_update_rejection` (narrow): only the
+///   contract WASM's typed "invalid contract update" rejection counts as
+///   benign. Out-of-gas, traps, timeouts stay at WARN even though the
+///   contract code is present.
+///
+/// - Auto-fetch uses `is_contract_exec_rejection` (broad): any time the
+///   contract code DID execute (whether successfully rejecting a stale
+///   state or running out of gas), the code is present locally and a
+///   self-heal GET would be wasted. Auto-fetch only fires for failures
+///   where the contract is actually missing (e.g., missing parameters
+///   after restart, storage error).
+///
+/// Returning `true` means "fetch missing contract code"; returning `false`
+/// means "contract is present, skip auto-fetch".
+///
+/// Note: this helper takes `&OpError` while `log_update_contract_failure`
+/// takes `&ExecutorError` because the two call sites have different error
+/// types in scope (the streaming branch operates on the OpError already
+/// produced by `update_contract`'s `Err(err.into())`).
 fn log_broadcast_to_streaming_failure(tx: &Transaction, key: &ContractKey, err: &OpError) -> bool {
-    if err.is_contract_exec_rejection() {
+    if err.is_invalid_update_rejection() {
         tracing::info!(
             tx = %tx,
             %key,
             error = %err,
-            event = "merge_rejected_stale",
-            "BroadcastToStreaming merge rejected — incoming state stale, keeping local"
+            event = "merge_rejected_invalid_update",
+            "BroadcastToStreaming merge rejected: incoming state invalid (likely stale rebroadcast), keeping local"
         );
-        false
     } else {
         tracing::warn!(
             tx = %tx,
             %key,
             error = %err,
-            "BroadcastToStreaming update skipped — contract not ready locally"
+            "BroadcastToStreaming update skipped: contract not ready locally"
         );
-        true
     }
+    // Preserves the pre-#3914 auto-fetch behavior: skip the self-heal
+    // GET whenever the contract code is present (broader check than the
+    // log-severity decision above).
+    !err.is_contract_exec_rejection()
 }
 
 /// Apply an update to a contract.
@@ -2847,52 +2873,76 @@ mod tests {
     /// Regression tests for issue #3914: misleading ERROR/WARN log noise from
     /// benign WASM rejections of stale broadcast UPDATEs. The contract correctly
     /// rejects an incoming state at a version we already hold (a re-broadcast
-    /// the dedup cache missed). On production gateways this generated 80–130
-    /// ERROR-level lines per hour per gateway; tests below pin the new INFO
-    /// classification so the regression cannot reappear.
+    /// the dedup cache missed). On production gateways this generated 80-130
+    /// ERROR-level lines per hour per gateway. The tests below pin both that
+    /// the benign case is now INFO AND that real WASM failures (out-of-gas,
+    /// max-compute-time, traps) stay at ERROR/WARN, so the predicate cannot
+    /// silently broaden and hide real failures.
     mod log_severity {
         use super::*;
         use crate::contract::ExecutorError;
         use crate::test_utils::TestLogger;
-        use freenet_stdlib::client_api::ContractError as StdContractError;
+        use freenet_stdlib::client_api::{ContractError as StdContractError, RequestError};
 
-        fn stale_state_rejection() -> ExecutorError {
-            // Mirrors the production message exactly:
-            // "execution error: invalid contract update, reason: New state
-            //  version N must be higher than current version N"
-            ExecutorError::request(StdContractError::update_exec_error(
+        // Constructors use `From<RequestError> for ExecutorError` (a public
+        // impl) rather than the module-private `ExecutorError::request`, so
+        // these helpers don't require widening any visibility for tests.
+        fn invalid_update_rejection() -> ExecutorError {
+            // Mirrors the production cause string exactly: stdlib's
+            // `update_exec_error` prefixes "execution error: " and the
+            // contract WASM's `InvalidUpdateWithInfo` Display produces
+            // "invalid contract update, reason: ...".
+            let req: RequestError = StdContractError::update_exec_error(
                 make_contract_key(1),
                 "invalid contract update, reason: New state version 100 must be higher than current version 100",
-            ))
+            )
+            .into();
+            req.into()
+        }
+
+        fn out_of_gas_failure() -> ExecutorError {
+            // Real WASM fault: contract ran out of gas. Same `update_exec_error`
+            // wrapper as the benign case (so the loose `is_contract_exec_rejection`
+            // predicate matches both), but the cause string starts with
+            // "execution error: The operation ran out of gas..." which the
+            // tighter `is_invalid_update_rejection` predicate must REJECT.
+            let req: RequestError = StdContractError::update_exec_error(
+                make_contract_key(1),
+                "The operation ran out of gas. This might be caused by an infinite loop or an inefficient computation.",
+            )
+            .into();
+            req.into()
         }
 
         fn missing_parameters_failure() -> ExecutorError {
             // Real failure case: contract not ready locally, auto-fetch needed.
-            ExecutorError::request(StdContractError::Update {
+            let req: RequestError = StdContractError::Update {
                 key: make_contract_key(2),
                 cause: "missing contract parameters".into(),
-            })
+            }
+            .into();
+            req.into()
         }
 
         #[test]
-        fn update_contract_failure_logs_info_for_stale_state_rejection() {
+        fn update_contract_failure_logs_info_for_invalid_update_rejection() {
             let logger = TestLogger::new().capture_logs().with_level("info").init();
 
-            log_update_contract_failure(&make_contract_key(1), &stale_state_rejection());
+            log_update_contract_failure(&make_contract_key(1), &invalid_update_rejection());
 
             assert!(
-                logger.contains("merge_rejected_stale"),
-                "expected event=merge_rejected_stale in logs, got: {:?}",
+                logger.contains("merge_rejected_invalid_update"),
+                "expected event=merge_rejected_invalid_update in logs, got: {:?}",
                 logger.logs()
             );
             assert!(
                 logger.contains("INFO"),
-                "expected INFO-level log for stale state rejection, got: {:?}",
+                "expected INFO-level log for invalid-update rejection, got: {:?}",
                 logger.logs()
             );
             assert!(
                 !logger.logs().iter().any(|l| l.contains("ERROR")),
-                "stale state rejection must not produce ERROR-level logs, got: {:?}",
+                "invalid-update rejection must not produce ERROR-level logs, got: {:?}",
                 logger.logs()
             );
         }
@@ -2915,27 +2965,54 @@ mod tests {
             );
         }
 
+        /// CRITICAL: out-of-gas comes through the same `update_exec_error`
+        /// wrapper as the benign rejection, so the loose
+        /// `is_contract_exec_rejection` predicate matches it (used for the
+        /// auto-fetch gate, where this is correct: contract code IS present).
+        /// But for log severity, OOG is a real bug operators must see and
+        /// MUST stay at ERROR. This test pins that.
         #[test]
-        fn broadcast_to_streaming_failure_logs_info_and_skips_auto_fetch_for_stale() {
+        fn update_contract_failure_logs_error_for_out_of_gas() {
+            let logger = TestLogger::new().capture_logs().with_level("info").init();
+
+            log_update_contract_failure(&make_contract_key(1), &out_of_gas_failure());
+
+            assert!(
+                logger.contains("ERROR"),
+                "out-of-gas must remain ERROR-level (real WASM fault), got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger
+                    .logs()
+                    .iter()
+                    .any(|l| l.contains("merge_rejected_invalid_update")),
+                "out-of-gas must NOT be classified as a benign rejection, got: {:?}",
+                logger.logs()
+            );
+        }
+
+        #[test]
+        fn broadcast_to_streaming_failure_logs_info_and_skips_auto_fetch_for_invalid_update() {
             let logger = TestLogger::new().capture_logs().with_level("info").init();
             let tx = Transaction::new::<UpdateMsg>();
-            let err: OpError = stale_state_rejection().into();
+            let err: OpError = invalid_update_rejection().into();
 
             let needs_auto_fetch =
                 log_broadcast_to_streaming_failure(&tx, &make_contract_key(1), &err);
 
             assert!(
                 !needs_auto_fetch,
-                "stale state rejection must NOT trigger self-heal auto-fetch (contract code is present)"
+                "invalid-update rejection must NOT trigger self-heal auto-fetch (contract code is present)"
             );
             assert!(
-                logger.contains("merge_rejected_stale"),
-                "expected event=merge_rejected_stale in logs, got: {:?}",
+                logger.contains("merge_rejected_invalid_update"),
+                "expected event=merge_rejected_invalid_update in logs, got: {:?}",
                 logger.logs()
             );
             assert!(
                 !logger.logs().iter().any(|l| l.contains("WARN")),
-                "stale state rejection must not produce WARN-level logs (the old misleading 'contract not ready locally' line), got: {:?}",
+                "invalid-update rejection must not produce WARN-level logs (the old misleading 'contract not ready locally' line), got: {:?}",
                 logger.logs()
             );
             assert!(
@@ -2943,7 +3020,7 @@ mod tests {
                     .logs()
                     .iter()
                     .any(|l| l.contains("contract not ready locally")),
-                "the misleading 'contract not ready locally' message must not appear for stale rejections, got: {:?}",
+                "the misleading 'contract not ready locally' message must not appear for invalid-update rejections, got: {:?}",
                 logger.logs()
             );
         }
@@ -2970,6 +3047,39 @@ mod tests {
                 logger.contains("contract not ready locally"),
                 "expected the WARN message text for real failure, got: {:?}",
                 logger.logs()
+            );
+        }
+
+        /// Mirror of `update_contract_failure_logs_error_for_out_of_gas` for
+        /// the streaming branch: OOG must stay at WARN, AND auto-fetch must
+        /// be SKIPPED because the contract code is present (broader predicate
+        /// `is_contract_exec_rejection` correctly catches this case). The two
+        /// decisions are deliberately decoupled by the helper.
+        #[test]
+        fn broadcast_to_streaming_failure_logs_warn_and_skips_auto_fetch_for_out_of_gas() {
+            let logger = TestLogger::new().capture_logs().with_level("info").init();
+            let tx = Transaction::new::<UpdateMsg>();
+            let err: OpError = out_of_gas_failure().into();
+
+            let needs_auto_fetch =
+                log_broadcast_to_streaming_failure(&tx, &make_contract_key(1), &err);
+
+            assert!(
+                logger.contains("WARN"),
+                "out-of-gas must remain WARN-level for the streaming branch, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger
+                    .logs()
+                    .iter()
+                    .any(|l| l.contains("merge_rejected_invalid_update")),
+                "out-of-gas must NOT be classified as a benign rejection, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !needs_auto_fetch,
+                "out-of-gas must NOT trigger self-heal auto-fetch (contract code is present locally; the broader is_contract_exec_rejection predicate catches this case independently of log severity)"
             );
         }
     }

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -8,7 +8,7 @@ pub(crate) use self::messages::{BroadcastStreamingPayload, UpdateMsg, UpdateStre
 use super::{
     OpEnum, OpError, OpInitialization, OpOutcome, Operation, OperationResult, should_use_streaming,
 };
-use crate::contract::{ContractHandlerEvent, StoreResponse};
+use crate::contract::{ContractHandlerEvent, ExecutorError, StoreResponse};
 use crate::message::{InnerMessage, NetMessage, NodeEvent, Transaction};
 use crate::node::IsOperationCompleted;
 use crate::ring::{Location, PeerKeyLocation, RingError};
@@ -1310,19 +1310,12 @@ impl Operation for UpdateOp {
                             }
                         }
                         Err(err) => {
-                            // Broadcast updates are best-effort: if we can't apply the update
-                            // (e.g., missing contract parameters after restart), log and skip.
-                            tracing::warn!(
-                                tx = %id,
-                                %key,
-                                error = %err,
-                                "BroadcastToStreaming update skipped — contract not ready locally"
-                            );
-                            if !err.is_contract_exec_rejection() {
-                                // Self-heal: trigger a background GET to fetch the missing
-                                // contract code and parameters from the network.
-                                // Skip if the merge function ran and rejected the update
-                                // (e.g., stale version) — the contract code is present.
+                            // Two distinct cases (see issue #3914):
+                            //   1. Contract WASM merge rejected the incoming state
+                            //      (e.g., stale version) — benign, log INFO, no auto-fetch.
+                            //   2. Other failure (missing parameters after restart, etc.) —
+                            //      contract not ready locally; log WARN and self-heal.
+                            if log_broadcast_to_streaming_failure(id, key, &err) {
                                 op_manager.try_auto_fetch_contract(key, sender_addr);
                             }
                         }
@@ -1630,6 +1623,60 @@ fn build_op_result(
     })
 }
 
+/// Distinguishes a contract WASM merge rejection (benign — the contract
+/// correctly refused a stale or otherwise invalid incoming state) from a
+/// real failure (missing contract code, storage error, internal bug).
+///
+/// Mirrors the runtime layer's classification at
+/// `contract::executor::runtime::merge_state_and_validate` (logs the same
+/// rejection at INFO with `event="merge_rejected_valid_local"`). Without
+/// this distinction, every benign re-broadcast that misses the dedup
+/// window produced an ERROR-level log, drowning real alerts on production
+/// gateways. See issue #3914.
+fn log_update_contract_failure(key: &ContractKey, err: &ExecutorError) {
+    if err.is_contract_exec_rejection() {
+        tracing::info!(
+            contract = %key,
+            error = %err,
+            event = "merge_rejected_stale",
+            "Update rejected by contract — incoming state stale, keeping local"
+        );
+    } else {
+        tracing::error!(
+            contract = %key,
+            error = %err,
+            phase = "error",
+            "Failed to update contract value"
+        );
+    }
+}
+
+/// Logs the failure of a `BroadcastToStreaming` relay attempt and returns
+/// whether the caller should trigger a self-healing GET. A benign WASM
+/// rejection (stale incoming state) is logged at INFO and returns `false`
+/// — the contract is present locally and no fetch is needed. Any other
+/// failure is logged at WARN and returns `true`. See issue #3914.
+fn log_broadcast_to_streaming_failure(tx: &Transaction, key: &ContractKey, err: &OpError) -> bool {
+    if err.is_contract_exec_rejection() {
+        tracing::info!(
+            tx = %tx,
+            %key,
+            error = %err,
+            event = "merge_rejected_stale",
+            "BroadcastToStreaming merge rejected — incoming state stale, keeping local"
+        );
+        false
+    } else {
+        tracing::warn!(
+            tx = %tx,
+            %key,
+            error = %err,
+            "BroadcastToStreaming update skipped — contract not ready locally"
+        );
+        true
+    }
+}
+
 /// Apply an update to a contract.
 ///
 /// This function:
@@ -1698,7 +1745,7 @@ pub(crate) async fn update_contract(
             new_value: Err(err),
             ..
         }) => {
-            tracing::error!(contract = %key, error = %err, phase = "error", "Failed to update contract value");
+            log_update_contract_failure(&key, &err);
             Err(err.into())
         }
         Ok(ContractHandlerEvent::UpdateNoChange { .. }) => {
@@ -2795,5 +2842,135 @@ mod tests {
         let (peer, loc) = op.failure_routing_info().expect("should have routing info");
         assert_eq!(peer, target);
         assert_eq!(loc, contract_location);
+    }
+
+    /// Regression tests for issue #3914: misleading ERROR/WARN log noise from
+    /// benign WASM rejections of stale broadcast UPDATEs. The contract correctly
+    /// rejects an incoming state at a version we already hold (a re-broadcast
+    /// the dedup cache missed). On production gateways this generated 80–130
+    /// ERROR-level lines per hour per gateway; tests below pin the new INFO
+    /// classification so the regression cannot reappear.
+    mod log_severity {
+        use super::*;
+        use crate::contract::ExecutorError;
+        use crate::test_utils::TestLogger;
+        use freenet_stdlib::client_api::ContractError as StdContractError;
+
+        fn stale_state_rejection() -> ExecutorError {
+            // Mirrors the production message exactly:
+            // "execution error: invalid contract update, reason: New state
+            //  version N must be higher than current version N"
+            ExecutorError::request(StdContractError::update_exec_error(
+                make_contract_key(1),
+                "invalid contract update, reason: New state version 100 must be higher than current version 100",
+            ))
+        }
+
+        fn missing_parameters_failure() -> ExecutorError {
+            // Real failure case: contract not ready locally, auto-fetch needed.
+            ExecutorError::request(StdContractError::Update {
+                key: make_contract_key(2),
+                cause: "missing contract parameters".into(),
+            })
+        }
+
+        #[test]
+        fn update_contract_failure_logs_info_for_stale_state_rejection() {
+            let logger = TestLogger::new().capture_logs().with_level("info").init();
+
+            log_update_contract_failure(&make_contract_key(1), &stale_state_rejection());
+
+            assert!(
+                logger.contains("merge_rejected_stale"),
+                "expected event=merge_rejected_stale in logs, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                logger.contains("INFO"),
+                "expected INFO-level log for stale state rejection, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger.logs().iter().any(|l| l.contains("ERROR")),
+                "stale state rejection must not produce ERROR-level logs, got: {:?}",
+                logger.logs()
+            );
+        }
+
+        #[test]
+        fn update_contract_failure_logs_error_for_real_failure() {
+            let logger = TestLogger::new().capture_logs().with_level("info").init();
+
+            log_update_contract_failure(&make_contract_key(2), &missing_parameters_failure());
+
+            assert!(
+                logger.contains("ERROR"),
+                "real failures must remain ERROR-level, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                logger.contains("Failed to update contract value"),
+                "expected ERROR message text, got: {:?}",
+                logger.logs()
+            );
+        }
+
+        #[test]
+        fn broadcast_to_streaming_failure_logs_info_and_skips_auto_fetch_for_stale() {
+            let logger = TestLogger::new().capture_logs().with_level("info").init();
+            let tx = Transaction::new::<UpdateMsg>();
+            let err: OpError = stale_state_rejection().into();
+
+            let needs_auto_fetch =
+                log_broadcast_to_streaming_failure(&tx, &make_contract_key(1), &err);
+
+            assert!(
+                !needs_auto_fetch,
+                "stale state rejection must NOT trigger self-heal auto-fetch (contract code is present)"
+            );
+            assert!(
+                logger.contains("merge_rejected_stale"),
+                "expected event=merge_rejected_stale in logs, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger.logs().iter().any(|l| l.contains("WARN")),
+                "stale state rejection must not produce WARN-level logs (the old misleading 'contract not ready locally' line), got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                !logger
+                    .logs()
+                    .iter()
+                    .any(|l| l.contains("contract not ready locally")),
+                "the misleading 'contract not ready locally' message must not appear for stale rejections, got: {:?}",
+                logger.logs()
+            );
+        }
+
+        #[test]
+        fn broadcast_to_streaming_failure_logs_warn_and_triggers_auto_fetch_for_real_failure() {
+            let logger = TestLogger::new().capture_logs().with_level("info").init();
+            let tx = Transaction::new::<UpdateMsg>();
+            let err: OpError = missing_parameters_failure().into();
+
+            let needs_auto_fetch =
+                log_broadcast_to_streaming_failure(&tx, &make_contract_key(2), &err);
+
+            assert!(
+                needs_auto_fetch,
+                "real failures must trigger self-heal auto-fetch"
+            );
+            assert!(
+                logger.contains("WARN"),
+                "real failures remain WARN-level for the streaming branch, got: {:?}",
+                logger.logs()
+            );
+            assert!(
+                logger.contains("contract not ready locally"),
+                "expected the WARN message text for real failure, got: {:?}",
+                logger.logs()
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

On production gateways (nova, vega) we logged ~80–130 ERROR-level lines per hour per gateway from `freenet::operations::update`:

```
ERROR network_event_listener{...}:process_network_message{... tx_type=update}:
  freenet::operations::update: Failed to update contract value
  contract=<key>
  reason: execution error: invalid contract update,
          reason: New state version <N> must be higher than current version <N>
```

These are **not failures**. The contract WASM is correctly rejecting an incoming broadcast UPDATE whose state is at the same version we already hold (typically a re-broadcast that the 60s `BroadcastDedupCache` TTL missed). The runtime layer one level down already understands this is benign and logs it at INFO with `event="merge_rejected_valid_local"`.

The op layer above logged the same event at ERROR (`update.rs:1701`), and the streaming relay path added a WARN with the misleading message `"BroadcastToStreaming update skipped — contract not ready locally"` (`update.rs:1315–1319`). The contract IS ready locally — the merge ran and the WASM rejected the stale state. The line right below already used `err.is_contract_exec_rejection()` to skip auto-fetch in this case, but the log message above didn't follow the same distinction.

A representative burst (one tx, three log lines, microseconds apart):

```
22:03:58.708616 INFO   contract_handling:upsert_contract_state:
                       event="merge_rejected_valid_local"
                       local_state_size=612752 incoming_state_size=612752
22:03:58.708901 ERROR  freenet::operations::update: Failed to update contract value
22:03:58.709059 WARN   freenet::operations::update:
                       BroadcastToStreaming update skipped — contract not ready locally
```

Anyone alerting on ERROR-level logs from `freenet::operations::update` got a constant false-positive baseline that drowns real failures.

## Solution

Both log sites now branch on `err.is_contract_exec_rejection()` (the classifier already used to skip auto-fetch for these errors) and emit INFO with `event=\"merge_rejected_stale\"` when the rejection is benign. Real failures (missing contract code, missing parameters, internal bugs) keep their ERROR/WARN levels and unchanged messages.

The decision was extracted into two small helpers — `log_update_contract_failure` and `log_broadcast_to_streaming_failure` — so the level dispatch is unit-testable in isolation:

- `log_update_contract_failure(&key, &err)` — INFO if contract-exec rejection, otherwise ERROR.
- `log_broadcast_to_streaming_failure(&tx, key, &err) -> bool` — INFO + return `false` (no auto-fetch) if rejection, otherwise WARN + return `true`. The boolean replaces the inline `if !err.is_contract_exec_rejection()` guard at the auto-fetch call site.

`ExecutorError::request` was widened from private to `pub(crate)` so the test helpers can construct the specific `RequestError::ContractError::Update` variants `is_contract_exec_rejection()` matches against. No external API surface change.

## Testing

Four new regression tests in `operations::update::tests::log_severity`, each capturing actual `tracing` output via `TestLogger`:

- `update_contract_failure_logs_info_for_stale_state_rejection` — stale-state rejection produces INFO with `event=\"merge_rejected_stale\"` and zero ERROR lines.
- `update_contract_failure_logs_error_for_real_failure` — \"missing contract parameters\" still produces ERROR with the original message.
- `broadcast_to_streaming_failure_logs_info_and_skips_auto_fetch_for_stale` — stale rejection produces INFO, returns `false` (no self-heal), and the misleading \"contract not ready locally\" line does NOT appear.
- `broadcast_to_streaming_failure_logs_warn_and_triggers_auto_fetch_for_real_failure` — real failure still produces WARN with the original message and returns `true` to trigger self-heal.

Each test would have failed before this PR — they assert both the captured log level (INFO vs ERROR/WARN) and the `event` field, so the regression cannot reappear silently.

All 36 `operations::update` tests pass; all 138 `contract::executor` tests pass; `cargo clippy --all-targets -- -D warnings` clean.

## Out of Scope

The upstream cause — why peers periodically broadcast a full state that's identical (in version, often in size) to what the receiver already has — is worth understanding separately. Each rejected merge runs a WASM `update_state` + a WASM `validate_state` (the `local_valid` check) on a 600 KB state, so there's a real (small) CPU cost. Tracking that down is a separate investigation; this PR is purely the logging-noise fix.

## Fixes

Closes #3914

[AI-assisted - Claude]