### PR TITLE
ci: add macos-dmg-test workflow + packaging script

### DIFF
--- a/.github/workflows/macos-dmg-test.yml
+++ b/.github/workflows/macos-dmg-test.yml
@@ -1,0 +1,117 @@
+name: Build Freenet.dmg (smoke-test)
+
+# Fast-iteration path for the macOS packaging pipeline. Downloads the
+# Mac binaries from an existing GitHub release and runs the same
+# package-macos.sh script that the real release pipeline uses, without
+# waiting for a 30-minute-per-arch cargo rebuild.
+#
+# Use the real pipeline (cross-compile.yml build-macos-dmg job) on actual
+# release tags. This workflow exists purely for validating the DMG
+# packaging logic itself.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag whose Mac tarballs to repackage (e.g. v0.2.48 or "latest")'
+        required: false
+        type: string
+        default: latest
+
+jobs:
+  build-dmg:
+    name: Repackage existing Mac binaries into a signed Freenet.dmg
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve release tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [[ "$INPUT_TAG" == "latest" || -z "$INPUT_TAG" ]]; then
+            TAG=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+          else
+            TAG="$INPUT_TAG"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Using tag: $TAG"
+
+      - name: Download Mac binaries from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          mkdir -p download
+          gh release download "$TAG" --repo "${{ github.repository }}" \
+            --pattern 'freenet-aarch64-apple-darwin.tar.gz' \
+            --pattern 'freenet-x86_64-apple-darwin.tar.gz' \
+            --dir download
+          mkdir -p bin-arm64 bin-x86_64
+          tar -xzf download/freenet-aarch64-apple-darwin.tar.gz -C bin-arm64
+          tar -xzf download/freenet-x86_64-apple-darwin.tar.gz  -C bin-x86_64
+          chmod +x bin-arm64/freenet bin-x86_64/freenet
+          file bin-arm64/freenet bin-x86_64/freenet
+
+      - name: Install packaging dependencies
+        run: brew install create-dmg
+
+      - name: Import Developer ID signing certificate
+        env:
+          P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+          echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" \
+            -P "$P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | tr -d '"')
+          rm "$CERT_PATH"
+
+      - name: Decode App Store Connect API key
+        env:
+          P8_BASE64: ${{ secrets.APPLE_ASC_API_KEY_P8_BASE64 }}
+        run: |
+          KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          echo "$P8_BASE64" | base64 --decode > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Build signed + notarized DMG
+        env:
+          VERSION: ${{ steps.tag.outputs.tag }}
+          FREENET_ARM64_BIN: bin-arm64/freenet
+          FREENET_X86_BIN: bin-x86_64/freenet
+          CODESIGN_IDENTITY: "Developer ID Application: Ian CLARKE (R55ZESJCXG)"
+          ASC_API_KEY_ID: ${{ secrets.APPLE_ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.APPLE_ASC_API_KEY_ISSUER_ID }}
+        run: |
+          # Strip leading "v" so the DMG filename reads "Freenet-0.2.48.dmg"
+          # rather than "Freenet-v0.2.48.dmg".
+          export VERSION="${VERSION#v}"
+          ./scripts/package-macos.sh
+
+      - name: Clean up secrets from runner
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/AuthKey.p8" || true
+          security delete-keychain "$RUNNER_TEMP/build.keychain-db" 2>/dev/null || true
+
+      - name: Upload DMG as workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: freenet-macos-universal-dmg-smoketest
+          path: dist/macos/Freenet-*.dmg

--- a/scripts/macos-entitlements.plist
+++ b/scripts/macos-entitlements.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      Freenet uses wasmtime to execute contract and delegate WASM. wasmtime
+      JIT-compiles code at runtime, which the Hardened Runtime (required
+      for notarization) blocks by default. These entitlements allow the
+      JIT path while keeping every other Hardened Runtime protection in
+      place.
+    -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Build a signed and notarized Freenet.app + Freenet.dmg from cross-
+# compiled macOS binaries.
+#
+# Runs on macOS. Expects the following environment variables:
+#
+#   Required:
+#     FREENET_ARM64_BIN   Path to aarch64-apple-darwin freenet binary
+#     FREENET_X86_BIN     Path to x86_64-apple-darwin freenet binary
+#     VERSION             Version string for the bundle (e.g. 0.2.48)
+#
+#   Optional (all three must be set together, or none, to enable signing):
+#     CODESIGN_IDENTITY   "Developer ID Application: Ian CLARKE (R55ZESJCXG)"
+#     ASC_API_KEY_PATH    Path to the App Store Connect API .p8 file
+#     ASC_API_KEY_ID      10-char key ID (e.g. HZLB6C37WG)
+#     ASC_API_ISSUER_ID   Issuer UUID from App Store Connect
+#
+#   Other optional:
+#     OUTPUT_DIR          Where to place artifacts (default: dist/macos)
+#     ICON_ICNS           Path to a .icns file (default: generic app icon)
+#     CREATE_DMG          "true" to produce a .dmg; "false" to stop at .app
+#                         (default: true)
+#
+# Produces:
+#   $OUTPUT_DIR/Freenet.app        (signed + notarized if credentials set)
+#   $OUTPUT_DIR/Freenet-$VERSION.dmg  (signed + notarized, if CREATE_DMG)
+#
+# Local smoke-test:
+#   VERSION=0.2.48 \
+#   FREENET_ARM64_BIN=target/aarch64-apple-darwin/release/freenet \
+#   FREENET_X86_BIN=target/x86_64-apple-darwin/release/freenet \
+#   ./scripts/package-macos.sh
+#
+# (No CODESIGN_IDENTITY = unsigned build; the .app still runs locally
+# via right-click-Open but will fail Gatekeeper on a fresh download.)
+
+set -euo pipefail
+
+: "${FREENET_ARM64_BIN:?FREENET_ARM64_BIN is required}"
+: "${FREENET_X86_BIN:?FREENET_X86_BIN is required}"
+: "${VERSION:?VERSION is required}"
+OUTPUT_DIR="${OUTPUT_DIR:-dist/macos}"
+CREATE_DMG="${CREATE_DMG:-true}"
+ICON_ICNS="${ICON_ICNS:-}"
+
+# Sanity: refuse to run on non-macOS. Some of the tools below (codesign,
+# xcrun notarytool, lipo, hdiutil, create-dmg) are macOS-only.
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "package-macos.sh: this script requires macOS (found $(uname -s))" >&2
+    exit 1
+fi
+
+# Validate that signing env vars are all set or all unset.
+sign_vars_set=0
+for v in CODESIGN_IDENTITY ASC_API_KEY_PATH ASC_API_KEY_ID ASC_API_ISSUER_ID; do
+    if [[ -n "${!v:-}" ]]; then
+        sign_vars_set=$((sign_vars_set + 1))
+    fi
+done
+if [[ "$sign_vars_set" -ne 0 && "$sign_vars_set" -ne 4 ]]; then
+    echo "package-macos.sh: signing env vars must all be set or all unset" >&2
+    echo "  CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-<unset>}" >&2
+    echo "  ASC_API_KEY_PATH=${ASC_API_KEY_PATH:-<unset>}" >&2
+    echo "  ASC_API_KEY_ID=${ASC_API_KEY_ID:-<unset>}" >&2
+    echo "  ASC_API_ISSUER_ID=${ASC_API_ISSUER_ID:-<unset>}" >&2
+    exit 1
+fi
+SIGNING_ENABLED=$([[ "$sign_vars_set" -eq 4 ]] && echo true || echo false)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTITLEMENTS="$SCRIPT_DIR/macos-entitlements.plist"
+if [[ ! -f "$ENTITLEMENTS" ]]; then
+    echo "package-macos.sh: missing $ENTITLEMENTS" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+APP_DIR="$OUTPUT_DIR/Freenet.app"
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Resources"
+
+echo ">> Building universal binary"
+lipo -create -output "$APP_DIR/Contents/MacOS/freenet-bin" \
+    "$FREENET_ARM64_BIN" "$FREENET_X86_BIN"
+chmod +x "$APP_DIR/Contents/MacOS/freenet-bin"
+
+echo ">> Writing shell wrapper as CFBundleExecutable"
+# When the user opens Freenet.app, macOS runs Contents/MacOS/Freenet (the
+# value of CFBundleExecutable). That script execs the real freenet binary
+# with "service run-wrapper" so the tray path is activated.
+cat > "$APP_DIR/Contents/MacOS/Freenet" <<'SH'
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$DIR/freenet-bin" service run-wrapper
+SH
+chmod +x "$APP_DIR/Contents/MacOS/Freenet"
+
+echo ">> Writing Info.plist"
+cat > "$APP_DIR/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>Freenet</string>
+    <key>CFBundleDisplayName</key><string>Freenet</string>
+    <key>CFBundleIdentifier</key><string>org.freenet.Freenet</string>
+    <key>CFBundleVersion</key><string>$VERSION</string>
+    <key>CFBundleShortVersionString</key><string>$VERSION</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleExecutable</key><string>Freenet</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>LSUIElement</key><true/>
+    <key>LSMinimumSystemVersion</key><string>11.0</string>
+    <key>NSPrincipalClass</key><string>NSApplication</string>
+    <key>NSHighResolutionCapable</key><true/>
+$(if [[ -n "$ICON_ICNS" ]]; then echo "    <key>CFBundleIconFile</key><string>Freenet</string>"; fi)
+</dict>
+</plist>
+PLIST
+
+echo -n "APPL????" > "$APP_DIR/Contents/PkgInfo"
+
+if [[ -n "$ICON_ICNS" ]]; then
+    if [[ ! -f "$ICON_ICNS" ]]; then
+        echo "package-macos.sh: ICON_ICNS=$ICON_ICNS not found" >&2
+        exit 1
+    fi
+    cp "$ICON_ICNS" "$APP_DIR/Contents/Resources/Freenet.icns"
+fi
+
+if [[ "$SIGNING_ENABLED" == "true" ]]; then
+    echo ">> Signing Freenet.app with $CODESIGN_IDENTITY"
+    # --deep signs nested content; --options runtime enables Hardened
+    # Runtime (required by notarization); --timestamp is mandatory for
+    # Developer ID signatures.
+    codesign --deep --force \
+        --options runtime \
+        --entitlements "$ENTITLEMENTS" \
+        --sign "$CODESIGN_IDENTITY" \
+        --timestamp \
+        "$APP_DIR"
+    codesign --verify --deep --strict --verbose=2 "$APP_DIR"
+
+    echo ">> Notarizing Freenet.app"
+    # Notarization requires submitting a zip (or dmg/pkg). We zip the .app
+    # for submission, wait for the result, then staple the ticket to the
+    # original .app bundle so offline Gatekeeper sees approval immediately.
+    NOTARIZE_ZIP="$OUTPUT_DIR/Freenet-app-for-notarization.zip"
+    ditto -c -k --keepParent "$APP_DIR" "$NOTARIZE_ZIP"
+    xcrun notarytool submit "$NOTARIZE_ZIP" \
+        --key "$ASC_API_KEY_PATH" \
+        --key-id "$ASC_API_KEY_ID" \
+        --issuer "$ASC_API_ISSUER_ID" \
+        --wait
+    rm "$NOTARIZE_ZIP"
+    xcrun stapler staple "$APP_DIR"
+    xcrun stapler validate "$APP_DIR"
+else
+    echo ">> Skipping signing + notarization (credentials not provided)"
+fi
+
+if [[ "$CREATE_DMG" == "true" ]]; then
+    echo ">> Creating Freenet-$VERSION.dmg"
+    DMG_PATH="$OUTPUT_DIR/Freenet-$VERSION.dmg"
+    rm -f "$DMG_PATH"
+    if ! command -v create-dmg >/dev/null 2>&1; then
+        echo "package-macos.sh: create-dmg not found (brew install create-dmg)" >&2
+        exit 1
+    fi
+    create-dmg \
+        --volname "Freenet $VERSION" \
+        --window-pos 200 120 \
+        --window-size 600 400 \
+        --icon-size 100 \
+        --icon "Freenet.app" 150 190 \
+        --app-drop-link 450 190 \
+        --hide-extension "Freenet.app" \
+        "$DMG_PATH" \
+        "$APP_DIR"
+
+    if [[ "$SIGNING_ENABLED" == "true" ]]; then
+        echo ">> Signing + notarizing Freenet-$VERSION.dmg"
+        codesign --force --sign "$CODESIGN_IDENTITY" --timestamp "$DMG_PATH"
+        xcrun notarytool submit "$DMG_PATH" \
+            --key "$ASC_API_KEY_PATH" \
+            --key-id "$ASC_API_KEY_ID" \
+            --issuer "$ASC_API_ISSUER_ID" \
+            --wait
+        xcrun stapler staple "$DMG_PATH"
+        xcrun stapler validate "$DMG_PATH"
+    fi
+
+    echo ">> $DMG_PATH"
+fi
+
+echo ">> Done. Artifacts in $OUTPUT_DIR"
+ls -la "$OUTPUT_DIR"


### PR DESCRIPTION
## Problem

Testing changes to the macOS DMG packaging flow currently requires waiting for the full release build (~30 min per arch of cargo build --release on freenet-core). That's overkill for validating just the bundle → sign → notarize → dmg logic.

## Solution

Land a separate, manual-dispatch-only workflow that downloads the Mac binaries from an existing GitHub release (default: latest) and runs the same packaging script that the real release pipeline uses. Produces a signed + notarized DMG in under ten minutes.

This PR only adds:
- \`.github/workflows/macos-dmg-test.yml\` — manual-dispatch workflow
- \`scripts/package-macos.sh\` — packaging script (also used by the real release path in #3928)
- \`scripts/macos-entitlements.plist\` — Hardened Runtime entitlements

No behaviour change to any existing workflow. The new workflow is gated on \`workflow_dispatch\` only; it won't run on pushes or PRs.

## Why separate from #3928

GitHub's \`workflow_dispatch\` endpoint only resolves workflow names on the default branch. Merging \`macos-dmg-test.yml\` here lets us smoke-test the packaging flow on any branch (including #3928) without cutting a release.

## Testing

After merge: run \`gh workflow run macos-dmg-test.yml --ref <branch>\` to produce a DMG artifact. Artifact can be downloaded and installed on macOS for validation.

The real release path (build-macos-dmg in cross-compile.yml) is added in #3928.

[AI-assisted - Claude]