### PR TITLE
fix(tray,update): address review findings and add macOS DMG-swap auto-update

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -259,7 +259,7 @@ jobs:
         run: |
           # Decode the .p12 into a file that `security import` can read.
           CERT_PATH="$RUNNER_TEMP/cert.p12"
-          echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
+          echo "$P12_BASE64" | base64 -d > "$CERT_PATH"
 
           # Stand up an ephemeral keychain for this job.
           KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
@@ -287,7 +287,7 @@ jobs:
         run: |
           # notarytool reads the key from a file path at submit time.
           KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
-          echo "$P8_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "$P8_BASE64" | base64 -d > "$KEY_PATH"
           chmod 600 "$KEY_PATH"
           echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 

--- a/.github/workflows/macos-dmg-test.yml
+++ b/.github/workflows/macos-dmg-test.yml
@@ -75,7 +75,7 @@ jobs:
           P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
         run: |
           CERT_PATH="$RUNNER_TEMP/cert.p12"
-          echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
+          echo "$P12_BASE64" | base64 -d > "$CERT_PATH"
           KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
           KEYCHAIN_PASSWORD="$(uuidgen)"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
@@ -95,7 +95,7 @@ jobs:
           P8_BASE64: ${{ secrets.APPLE_ASC_API_KEY_P8_BASE64 }}
         run: |
           KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
-          echo "$P8_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "$P8_BASE64" | base64 -d > "$KEY_PATH"
           chmod 600 "$KEY_PATH"
           echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -349,8 +349,11 @@ fn is_launch_at_login_enabled_at(plist: &Path) -> bool {
 /// If `exe` lives inside a macOS `.app` bundle, return that bundle's
 /// absolute path. Walks up the parent directories until a path segment
 /// ending in `.app` is found, or the filesystem root is reached.
+///
+/// Exposed at `pub(super)` so `update.rs` can detect bundle context for
+/// its DMG-swap auto-update path.
 #[allow(dead_code)]
-fn macos_app_bundle_path(exe: &Path) -> Option<PathBuf> {
+pub(super) fn macos_app_bundle_path(exe: &Path) -> Option<PathBuf> {
     for ancestor in exe.ancestors() {
         if ancestor
             .file_name()
@@ -1327,10 +1330,27 @@ fn run_wrapper_loop(
                                     if spawn_new_wrapper(&exe_path, log_dir) {
                                         return Ok(());
                                     }
-                                    // Spawn failed — fall through to relaunch child
+                                    // Spawn failed. Fall through to relaunch child
                                     // with the current (old) wrapper rather than
                                     // leaving no node running.
                                     break SENTINEL_RESTART;
+                                }
+                                Ok(s)
+                                    if s.code()
+                                        == Some(super::update::EXIT_CODE_BUNDLE_UPDATE_STAGED) =>
+                                {
+                                    // macOS DMG-swap: the detached updater
+                                    // will swap /Applications/Freenet.app
+                                    // after this process exits and relaunch
+                                    // the new bundle. Do NOT re-exec.
+                                    log_wrapper_event(
+                                        log_dir,
+                                        "Bundle update staged; exiting for updater to take over",
+                                    );
+                                    status_tx.send(WrapperStatus::UpdatedRestarting).ok();
+                                    drop(child.kill());
+                                    drop(child.wait());
+                                    return Ok(());
                                 }
                                 Ok(_) => {
                                     // Exit code 2 = already up to date, or other
@@ -1395,9 +1415,22 @@ fn run_wrapper_loop(
                                         if spawn_new_wrapper(&exe_path, log_dir) {
                                             return Ok(());
                                         }
-                                        // Spawn failed — exit stopped state and
+                                        // Spawn failed. Exit stopped state and
                                         // relaunch child with the current wrapper.
                                         break;
+                                    }
+                                    Ok(s)
+                                        if s.code()
+                                            == Some(
+                                                super::update::EXIT_CODE_BUNDLE_UPDATE_STAGED,
+                                            ) =>
+                                    {
+                                        log_wrapper_event(
+                                            log_dir,
+                                            "Bundle update staged while stopped; exiting for updater",
+                                        );
+                                        status_tx.send(WrapperStatus::UpdatedRestarting).ok();
+                                        return Ok(());
                                     }
                                     Ok(_) => {
                                         log_wrapper_event(log_dir, "No update available");
@@ -1443,9 +1476,26 @@ fn run_wrapper_loop(
                 status_tx.send(WrapperStatus::Updating).ok();
             }
 
-            let ok = spawn_update_command(&exe_path)
-                .map(|s| s.success())
-                .unwrap_or(false);
+            let result = spawn_update_command(&exe_path);
+            // macOS DMG-swap: if the update subprocess exits with the
+            // bundle-staged code, the detached updater takes over after
+            // this process exits. We must not re-exec or retry; just
+            // return Ok so the wrapper exits cleanly and the updater can
+            // swap /Applications/Freenet.app.
+            if let Ok(ref s) = result {
+                if s.code() == Some(super::update::EXIT_CODE_BUNDLE_UPDATE_STAGED) {
+                    log_wrapper_event(
+                        log_dir,
+                        "Bundle update staged during auto-update; exiting for updater",
+                    );
+                    #[cfg(any(target_os = "windows", target_os = "macos"))]
+                    if let Some((_, status_tx)) = tray {
+                        status_tx.send(WrapperStatus::UpdatedRestarting).ok();
+                    }
+                    return Ok(());
+                }
+            }
+            let ok = result.map(|s| s.success()).unwrap_or(false);
 
             if ok {
                 log_wrapper_event(log_dir, "Update successful, restarting...");
@@ -1552,9 +1602,22 @@ fn run_wrapper_loop(
                                         if spawn_new_wrapper(&exe_path, log_dir) {
                                             return Ok(());
                                         }
-                                        // Spawn failed — relaunch with current wrapper
+                                        // Spawn failed. Relaunch with current wrapper.
                                         state.consecutive_failures = 0;
                                         break;
+                                    }
+                                    Ok(s)
+                                        if s.code()
+                                            == Some(
+                                                super::update::EXIT_CODE_BUNDLE_UPDATE_STAGED,
+                                            ) =>
+                                    {
+                                        log_wrapper_event(
+                                            log_dir,
+                                            "Bundle update staged during backoff; exiting for updater",
+                                        );
+                                        status_tx.send(WrapperStatus::UpdatedRestarting).ok();
+                                        return Ok(());
                                     }
                                     Ok(_) => {
                                         log_wrapper_event(log_dir, "No update available");

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -252,7 +252,7 @@ fn open_url_in_browser(url: &str) {
 //
 // On first launch of the tray wrapper we open the local dashboard in the
 // user's default browser so a new user can actually see Freenet doing
-// something. Subsequent launches are silent — this matches Mac menu-bar
+// something. Subsequent launches are silent, matching Mac menu-bar
 // conventions (Docker Desktop, Dropbox, Rectangle, etc.: guide the user
 // on first install, stay out of the way afterwards).
 //
@@ -302,31 +302,42 @@ static FIRST_RUN_OPENER_SPAWNED: std::sync::atomic::AtomicBool =
 // ── Launch at Login (macOS) ──
 //
 // On macOS, the DMG-installed Freenet.app does not auto-start on login by
-// itself — the .app bundle is just a folder in /Applications. To match
+// itself: the .app bundle is just a folder in /Applications. To match
 // the Windows-installer experience (service registers with the OS and
 // starts on boot) we write a user LaunchAgent plist that points at the
-// .app bundle's executable and sets `RunAtLoad=true`.
+// .app bundle's CFBundleExecutable shell wrapper and sets RunAtLoad=true.
 //
 // The presence/absence of the plist file is the single source of truth
-// for the user's preference: plist exists ⇒ launch at login enabled.
+// for the user's preference: plist exists means launch at login enabled.
 // The tray menu's Launch at Login check item reads this state.
 //
-// Implementation uses the modern `launchctl bootstrap gui/$UID` path,
-// which loads the agent into the current GUI session and honours
-// RunAtLoad on future logins. Falls back to legacy `launchctl load` if
-// bootstrap fails (older macOS, unusual session state).
+// Implementation uses `launchctl bootstrap gui/$UID <plist>`, which loads
+// the agent into the current GUI session and honours RunAtLoad on future
+// logins. launchctl exit status is logged via tracing::warn for diagnosis
+// but not propagated to callers; the plist is the authoritative preference.
 
 /// Identifier that also serves as the plist filename and launchd label.
 #[allow(dead_code)]
 const LAUNCH_AT_LOGIN_LABEL: &str = "org.freenet.Freenet";
 
+/// Legacy plist label written by the old `install.sh` / `freenet service
+/// install` path. We log a warning when we detect it so users know to
+/// clean up the duplicate before it races for port 7509.
+#[allow(dead_code)]
+const LEGACY_SERVICE_LAUNCHD_LABEL: &str = "org.freenet.node";
+
 /// Absolute path of the user LaunchAgent plist, if `$HOME` is resolvable.
 #[allow(dead_code)]
 fn launch_agent_plist_path() -> Option<PathBuf> {
+    launch_agent_plist_path_for(LAUNCH_AT_LOGIN_LABEL)
+}
+
+#[allow(dead_code)]
+fn launch_agent_plist_path_for(label: &str) -> Option<PathBuf> {
     dirs::home_dir().map(|h| {
         h.join("Library")
             .join("LaunchAgents")
-            .join(format!("{LAUNCH_AT_LOGIN_LABEL}.plist"))
+            .join(format!("{label}.plist"))
     })
 }
 
@@ -335,23 +346,84 @@ fn is_launch_at_login_enabled_at(plist: &Path) -> bool {
     plist.exists()
 }
 
-/// Build the plist XML for the user LaunchAgent. Split out so it's unit-
-/// testable without touching the filesystem or launchctl.
+/// If `exe` lives inside a macOS `.app` bundle, return that bundle's
+/// absolute path. Walks up the parent directories until a path segment
+/// ending in `.app` is found, or the filesystem root is reached.
 #[allow(dead_code)]
-fn launch_agent_plist_contents(executable: &Path) -> String {
-    // The path could contain characters that aren't valid in a plist <string>
-    // (e.g. `&`, `<`), so we XML-escape defensively even though macOS
-    // installer paths almost never need it.
-    let mut escaped = String::with_capacity(executable.as_os_str().len());
-    for ch in executable.to_string_lossy().chars() {
-        match ch {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            '"' => escaped.push_str("&quot;"),
-            '\'' => escaped.push_str("&apos;"),
-            c => escaped.push(c),
+fn macos_app_bundle_path(exe: &Path) -> Option<PathBuf> {
+    for ancestor in exe.ancestors() {
+        if ancestor
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with(".app"))
+        {
+            return Some(ancestor.to_path_buf());
         }
+    }
+    None
+}
+
+/// The path to a `.app` bundle's CFBundleExecutable shell wrapper, by our
+/// packaging convention. See `scripts/package-macos.sh` for how this
+/// wrapper is produced: it execs the inner `freenet-bin` with the
+/// `service run-wrapper` subcommand.
+#[allow(dead_code)]
+fn macos_app_bundle_wrapper(bundle: &Path) -> PathBuf {
+    bundle.join("Contents").join("MacOS").join("Freenet")
+}
+
+/// Compute the ProgramArguments array for the user LaunchAgent. If we're
+/// running from inside an `.app` bundle, launchd should relaunch the
+/// bundle's CFBundleExecutable shell wrapper (which in turn execs
+/// `freenet-bin service run-wrapper`, entering the tray path). Otherwise
+/// (cargo-run, raw binary install, dev build) launchd needs to invoke
+/// the binary with the explicit `service run-wrapper` subcommand or it
+/// would default to `Network` mode and skip the tray entirely.
+#[allow(dead_code)]
+fn launch_agent_program_arguments(exe: &Path) -> Vec<String> {
+    match macos_app_bundle_path(exe) {
+        Some(bundle) => vec![
+            macos_app_bundle_wrapper(&bundle)
+                .to_string_lossy()
+                .into_owned(),
+        ],
+        None => vec![
+            exe.to_string_lossy().into_owned(),
+            "service".to_string(),
+            "run-wrapper".to_string(),
+        ],
+    }
+}
+
+fn xml_escape(s: &str) -> String {
+    // XML 1.0 predefined entities. Filesystem paths very rarely contain
+    // these, but launchd silently fails to load a malformed plist, so
+    // defensive escaping avoids a hard-to-diagnose "Launch at Login
+    // silently does nothing" for pathological paths.
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Build the plist XML for the user LaunchAgent given explicit
+/// ProgramArguments. Pure function so the output format is unit-testable
+/// without touching the filesystem or launchctl.
+#[allow(dead_code)]
+fn launch_agent_plist_contents(program_arguments: &[String]) -> String {
+    let mut args_xml = String::new();
+    for arg in program_arguments {
+        args_xml.push_str("        <string>");
+        args_xml.push_str(&xml_escape(arg));
+        args_xml.push_str("</string>\n");
     }
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -362,8 +434,7 @@ fn launch_agent_plist_contents(executable: &Path) -> String {
     <string>{LAUNCH_AT_LOGIN_LABEL}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>{escaped}</string>
-    </array>
+{args_xml}    </array>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
@@ -377,14 +448,14 @@ fn launch_agent_plist_contents(executable: &Path) -> String {
 }
 
 /// Write the plist to disk, creating `~/Library/LaunchAgents` if needed.
-/// Does NOT activate the agent with launchctl — that's the caller's job
+/// Does NOT activate the agent with launchctl: that's the caller's job
 /// (separated so the filesystem half is unit-testable on Linux).
 #[allow(dead_code)]
-fn write_launch_agent_plist_at(plist: &Path, executable: &Path) -> std::io::Result<()> {
+fn write_launch_agent_plist_at(plist: &Path, program_arguments: &[String]) -> std::io::Result<()> {
     if let Some(parent) = plist.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(plist, launch_agent_plist_contents(executable))
+    std::fs::write(plist, launch_agent_plist_contents(program_arguments))
 }
 
 /// Remove the plist. Idempotent: returns Ok if the file was already gone.
@@ -397,29 +468,79 @@ fn remove_launch_agent_plist_at(plist: &Path) -> std::io::Result<()> {
     }
 }
 
-/// Activate or deactivate the agent via `launchctl`. macOS-only; a no-op
-/// on other platforms so callers don't have to cfg-gate.
+/// Returns true if the on-disk plist already contains the expected
+/// leading ProgramArguments path, false otherwise (including on read
+/// error). Used for the self-heal check at wrapper startup so the
+/// plist gets rewritten after the user moves or replaces the .app.
+#[allow(dead_code)]
+fn launch_agent_plist_has_expected_leader(plist: &Path, expected_leader: &str) -> bool {
+    let escaped = format!("<string>{}</string>", xml_escape(expected_leader));
+    match std::fs::read_to_string(plist) {
+        Ok(contents) => contents.contains(&escaped),
+        Err(_) => false,
+    }
+}
+
+/// Call `launchctl bootstrap gui/$UID <plist>`. Logs non-zero exit
+/// (with stderr) via tracing::warn so silent "plist written but launchd
+/// never loaded it" breakages are diagnosable after the fact.
 #[cfg(target_os = "macos")]
 fn launchctl_bootstrap(plist: &Path) {
     let uid = unsafe { libc::getuid() };
     let target = format!("gui/{uid}");
-    // Bootstrap the agent into the GUI session. Ignore errors: if the
-    // agent is already loaded (e.g. from a previous run), bootstrap
-    // returns non-zero but that's fine.
-    let _ = std::process::Command::new("launchctl")
+    match std::process::Command::new("launchctl")
         .args(["bootstrap", &target])
         .arg(plist)
-        .output();
+        .output()
+    {
+        Ok(o) if !o.status.success() => {
+            tracing::warn!(
+                "launchctl bootstrap {} returned {}: {}",
+                plist.display(),
+                o.status,
+                String::from_utf8_lossy(&o.stderr).trim()
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                "launchctl bootstrap {} failed to spawn: {}",
+                plist.display(),
+                e
+            );
+        }
+        _ => {}
+    }
 }
 
 #[cfg(target_os = "macos")]
 fn launchctl_bootout(plist: &Path) {
     let uid = unsafe { libc::getuid() };
     let target = format!("gui/{uid}");
-    let _ = std::process::Command::new("launchctl")
+    match std::process::Command::new("launchctl")
         .args(["bootout", &target])
         .arg(plist)
-        .output();
+        .output()
+    {
+        Ok(o) if !o.status.success() => {
+            // bootout returns non-zero when the agent isn't currently
+            // loaded, which is expected when we're disabling after a
+            // previous session already exited. Log at debug, not warn.
+            tracing::debug!(
+                "launchctl bootout {} returned {}: {}",
+                plist.display(),
+                o.status,
+                String::from_utf8_lossy(&o.stderr).trim()
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                "launchctl bootout {} failed to spawn: {}",
+                plist.display(),
+                e
+            );
+        }
+        _ => {}
+    }
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -439,13 +560,14 @@ pub(super) fn enable_launch_at_login(executable: &Path) -> std::io::Result<()> {
             "could not resolve home directory for launch agent path",
         ));
     };
+    let args = launch_agent_program_arguments(executable);
     // If an older plist is already loaded, bootout first so bootstrap
     // picks up any change to the executable path (e.g. user moved the
     // .app from /Applications to ~/Applications between launches).
     if plist.exists() {
         launchctl_bootout(&plist);
     }
-    write_launch_agent_plist_at(&plist, executable)?;
+    write_launch_agent_plist_at(&plist, &args)?;
     launchctl_bootstrap(&plist);
     Ok(())
 }
@@ -466,6 +588,164 @@ pub(super) fn is_launch_at_login_enabled() -> bool {
         .map(|p| is_launch_at_login_enabled_at(&p))
         .unwrap_or(false)
 }
+
+/// Decision outcome for first-run Launch at Login registration. Pure so
+/// the decision logic can be unit-tested independently of filesystem or
+/// launchctl side-effects, per the deployment-rule pattern established
+/// earlier in this PR.
+#[derive(Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(super) enum FirstRunLaunchAtLoginAction {
+    /// User hasn't launched before and Launch at Login is disabled: enable it.
+    Register,
+    /// User hasn't launched before but Launch at Login is already enabled
+    /// (e.g. from the legacy install.sh path). Leave as-is.
+    AlreadyEnabled,
+    /// Not a first-run invocation.
+    NotFirstRun,
+}
+
+#[allow(dead_code)]
+pub(super) fn first_run_launch_at_login_action(
+    is_first_run: bool,
+    already_enabled: bool,
+) -> FirstRunLaunchAtLoginAction {
+    if !is_first_run {
+        FirstRunLaunchAtLoginAction::NotFirstRun
+    } else if already_enabled {
+        FirstRunLaunchAtLoginAction::AlreadyEnabled
+    } else {
+        FirstRunLaunchAtLoginAction::Register
+    }
+}
+
+/// Decision outcome for a user-initiated Launch at Login toggle (click
+/// on the tray menu check item). Pure function, same testability
+/// rationale as `first_run_launch_at_login_action`.
+#[derive(Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(super) enum ToggleLaunchAtLoginOutcome {
+    Enable,
+    Disable,
+}
+
+#[allow(dead_code)]
+pub(super) fn toggle_launch_at_login_outcome(
+    currently_enabled: bool,
+) -> ToggleLaunchAtLoginOutcome {
+    if currently_enabled {
+        ToggleLaunchAtLoginOutcome::Disable
+    } else {
+        ToggleLaunchAtLoginOutcome::Enable
+    }
+}
+
+/// Startup self-heal: if Launch at Login is enabled but the plist points
+/// somewhere other than where we'd write it now (user moved the .app,
+/// upgraded via a new DMG install location, etc.), rewrite it. Idempotent:
+/// no-op when the plist is already current, or when Launch at Login is
+/// disabled, or when we can't figure out the expected location.
+#[allow(dead_code)]
+pub(super) fn refresh_launch_at_login_plist_if_stale() {
+    if !is_launch_at_login_enabled() {
+        return;
+    }
+    let Some(plist) = launch_agent_plist_path() else {
+        return;
+    };
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let args = launch_agent_program_arguments(&exe);
+    let Some(leader) = args.first() else {
+        return;
+    };
+    if launch_agent_plist_has_expected_leader(&plist, leader) {
+        return;
+    }
+    tracing::info!(
+        "Refreshing stale Launch at Login plist (was pointing elsewhere, now {})",
+        leader
+    );
+    if let Err(e) = enable_launch_at_login(&exe) {
+        tracing::warn!("Failed to refresh Launch at Login plist: {}", e);
+    }
+}
+
+/// Returns true if the legacy `org.freenet.node` LaunchAgent plist
+/// exists. Used to warn users migrating from `install.sh` that they
+/// have two auto-starts racing for the same ports.
+#[allow(dead_code)]
+pub(super) fn legacy_launchd_agent_present() -> bool {
+    launch_agent_plist_path_for(LEGACY_SERVICE_LAUNCHD_LABEL)
+        .map(|p| p.exists())
+        .unwrap_or(false)
+}
+
+/// Run all the macOS-only Launch-at-Login housekeeping that must happen
+/// before the tray is built. Specifically:
+///
+/// - On first wrapper launch, register a user LaunchAgent so Freenet
+///   auto-starts on future logins (Windows-parity auto-start).
+/// - On every subsequent launch, if the user had previously enabled
+///   Launch at Login but the plist's embedded executable path no longer
+///   matches the current one (user moved the .app, upgraded via a new
+///   DMG installed elsewhere, etc.), rewrite it.
+/// - If the legacy `org.freenet.node` LaunchAgent from the install.sh
+///   era is still present, log a prominent warning so migrating users
+///   know to clean it up before the two agents race for port 7509.
+///
+/// Called synchronously (not from the wrapper thread) so the tray's
+/// Launch-at-Login check item reads the final filesystem state when
+/// `TrayState::new` consults it. Previously the first-run registration
+/// lived inside `run_wrapper_loop`, which ran on a background thread
+/// AFTER the tray was built, so the menu item shipped stale-unchecked
+/// on first launch even though Launch at Login had been enabled.
+#[cfg(target_os = "macos")]
+pub(super) fn macos_launch_at_login_startup(log_dir: &Path) {
+    // Legacy-agent warning: fire once per startup regardless of first-run.
+    if legacy_launchd_agent_present() {
+        log_wrapper_event(
+            log_dir,
+            "Legacy launchd agent ~/Library/LaunchAgents/org.freenet.node.plist \
+             detected. Two agents will race for port 7509; remove the legacy one \
+             with: launchctl bootout gui/$UID ~/Library/LaunchAgents/org.freenet.node.plist \
+             && rm ~/Library/LaunchAgents/org.freenet.node.plist",
+        );
+    }
+
+    // First-run auto-register.
+    let Some(marker) = first_run_marker_path() else {
+        return;
+    };
+    let already_enabled = is_launch_at_login_enabled();
+    match first_run_launch_at_login_action(is_first_run_at(&marker), already_enabled) {
+        FirstRunLaunchAtLoginAction::Register => match std::env::current_exe() {
+            Ok(exe) => match enable_launch_at_login(&exe) {
+                Ok(()) => log_wrapper_event(log_dir, "First-run: registered Launch at Login agent"),
+                Err(e) => log_wrapper_event(
+                    log_dir,
+                    &format!("First-run Launch at Login registration failed: {e}"),
+                ),
+            },
+            Err(e) => log_wrapper_event(
+                log_dir,
+                &format!("First-run Launch at Login: could not resolve current exe: {e}"),
+            ),
+        },
+        FirstRunLaunchAtLoginAction::AlreadyEnabled => {
+            // Nothing to do for first-run, but the plist may still be stale.
+            refresh_launch_at_login_plist_if_stale();
+        }
+        FirstRunLaunchAtLoginAction::NotFirstRun => {
+            refresh_launch_at_login_plist_if_stale();
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
+pub(super) fn macos_launch_at_login_startup(_log_dir: &Path) {}
 
 /// Spawn a short-lived thread that waits for the dashboard HTTP server to
 /// come up, then opens it in the browser and writes the first-run marker.
@@ -700,6 +980,16 @@ fn run_wrapper(version: &str) -> Result<()> {
         let version_owned = version.to_string();
         let log_dir_clone = log_dir.clone();
 
+        // macOS: handle Launch at Login state BEFORE building the tray so
+        // the menu item's check state reads the final filesystem truth.
+        // Previously this ran on the wrapper thread, after the tray was
+        // already built, so first-run users saw a stale-unchecked box
+        // despite the agent being registered. Also rewrites a stale plist
+        // when the user moved the .app, and warns if the legacy install.sh
+        // launchd agent is still present.
+        #[cfg(target_os = "macos")]
+        macos_launch_at_login_startup(&log_dir);
+
         // Wrapper loop runs on a background thread
         let loop_handle = std::thread::spawn(move || {
             let result = run_wrapper_loop(&log_dir_clone, Some((&action_rx, &status_tx)));
@@ -917,7 +1207,7 @@ fn run_wrapper_loop(
     // First-run onboarding: if this user has never launched the tray wrapper
     // before, open the dashboard in their browser once the HTTP server comes
     // up, and (on macOS) register the app for launch-at-login so Freenet
-    // behaves like the Windows-installed service — always on, starts at
+    // behaves like the Windows-installed service: always on, starts at
     // boot, no extra action required from the user. Runs the dashboard
     // opener in a background thread so it doesn't delay the main loop.
     // `FIRST_RUN_OPENER_SPAWNED` ensures at most one opener thread per
@@ -930,33 +1220,6 @@ fn run_wrapper_loop(
             && !FIRST_RUN_OPENER_SPAWNED.swap(true, std::sync::atomic::Ordering::SeqCst)
         {
             spawn_first_run_dashboard_opener(log_dir);
-
-            // Default Launch at Login to on for new users (macOS only;
-            // Windows installs as a service). The user can uncheck the
-            // menu item to disable. On failure, log and continue — the
-            // user can still enable manually via the menu item.
-            #[cfg(target_os = "macos")]
-            if !is_launch_at_login_enabled() {
-                match std::env::current_exe() {
-                    Ok(exe) => {
-                        if let Err(e) = enable_launch_at_login(&exe) {
-                            log_wrapper_event(
-                                log_dir,
-                                &format!("First-run Launch at Login registration failed: {e}"),
-                            );
-                        } else {
-                            log_wrapper_event(
-                                log_dir,
-                                "First-run: registered Launch at Login agent",
-                            );
-                        }
-                    }
-                    Err(e) => log_wrapper_event(
-                        log_dir,
-                        &format!("First-run Launch at Login: could not resolve current exe: {e}"),
-                    ),
-                }
-            }
         }
     }
 
@@ -2871,27 +3134,30 @@ mod tests {
     }
 
     #[test]
-    fn launch_agent_plist_contents_escapes_and_embeds_executable_path() {
-        let exe = PathBuf::from("/Applications/Freenet.app/Contents/MacOS/Freenet");
-        let xml = launch_agent_plist_contents(&exe);
+    fn launch_agent_plist_contents_embeds_all_program_arguments() {
+        let args = vec![
+            "/usr/local/bin/freenet".to_string(),
+            "service".to_string(),
+            "run-wrapper".to_string(),
+        ];
+        let xml = launch_agent_plist_contents(&args);
         assert!(xml.starts_with("<?xml version=\"1.0\""));
         assert!(xml.contains("<key>Label</key>"));
         assert!(xml.contains("org.freenet.Freenet"));
         assert!(xml.contains("<key>RunAtLoad</key>"));
         assert!(xml.contains("<true/>"));
-        assert!(
-            xml.contains("/Applications/Freenet.app/Contents/MacOS/Freenet"),
-            "plist must embed the concrete executable path"
-        );
+        assert!(xml.contains("<string>/usr/local/bin/freenet</string>"));
+        assert!(xml.contains("<string>service</string>"));
+        assert!(xml.contains("<string>run-wrapper</string>"));
     }
 
     #[test]
     fn launch_agent_plist_contents_xml_escapes_unusual_paths() {
-        // Unusual but legal filesystem path characters must be XML-escaped,
-        // otherwise launchd fails to parse the plist at load time and the
-        // user's Launch at Login setting silently does nothing.
-        let exe = PathBuf::from("/tmp/has <angles> & \"quotes\"/Freenet");
-        let xml = launch_agent_plist_contents(&exe);
+        // Unusual but legal filesystem path characters must be XML-escaped
+        // or launchd fails to parse the plist at load time and the user's
+        // Launch at Login setting silently does nothing.
+        let args = vec!["/tmp/has <angles> & \"quotes\"/Freenet".to_string()];
+        let xml = launch_agent_plist_contents(&args);
         assert!(xml.contains("&lt;angles&gt;"));
         assert!(xml.contains("&amp;"));
         assert!(xml.contains("&quot;quotes&quot;"));
@@ -2900,22 +3166,142 @@ mod tests {
     }
 
     #[test]
+    fn launch_agent_program_arguments_for_bundle_points_at_wrapper() {
+        // Inside a .app bundle, ProgramArguments must be the CFBundleExecutable
+        // shell wrapper (Contents/MacOS/Freenet). Launching it re-enters the
+        // tray path via the `exec freenet-bin service run-wrapper` line in
+        // scripts/package-macos.sh. If this regresses and ProgramArguments
+        // becomes just `freenet-bin`, launchd runs bare freenet which
+        // defaults to Network mode and the tray never appears: the exact
+        // shipping bug that Codex P2 and the code-first/big-picture reviews
+        // flagged on the first round of this commit.
+        let exe = PathBuf::from("/Applications/Freenet.app/Contents/MacOS/freenet-bin");
+        let args = launch_agent_program_arguments(&exe);
+        assert_eq!(
+            args,
+            vec!["/Applications/Freenet.app/Contents/MacOS/Freenet".to_string()]
+        );
+    }
+
+    #[test]
+    fn launch_agent_program_arguments_for_nested_bundle_path() {
+        // User dragged Freenet.app into a subfolder.
+        let exe = PathBuf::from(
+            "/Users/someone/Applications/Tools/Freenet.app/Contents/MacOS/freenet-bin",
+        );
+        let args = launch_agent_program_arguments(&exe);
+        assert_eq!(
+            args,
+            vec![
+                "/Users/someone/Applications/Tools/Freenet.app/Contents/MacOS/Freenet".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn launch_agent_program_arguments_for_non_bundle_binary_includes_subcommand() {
+        // Non-bundle path (cargo run, raw binary install, dev build): the
+        // plist must explicitly pass `service run-wrapper` so launchd
+        // doesn't default the binary to Network mode.
+        let exe = PathBuf::from("/usr/local/bin/freenet");
+        let args = launch_agent_program_arguments(&exe);
+        assert_eq!(
+            args,
+            vec![
+                "/usr/local/bin/freenet".to_string(),
+                "service".to_string(),
+                "run-wrapper".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn macos_app_bundle_path_finds_bundle_from_inner_binary() {
+        let exe = PathBuf::from("/Applications/Freenet.app/Contents/MacOS/freenet-bin");
+        assert_eq!(
+            macos_app_bundle_path(&exe).as_deref(),
+            Some(Path::new("/Applications/Freenet.app"))
+        );
+    }
+
+    #[test]
+    fn macos_app_bundle_path_returns_none_for_non_bundle_path() {
+        assert_eq!(
+            macos_app_bundle_path(Path::new("/usr/local/bin/freenet")),
+            None
+        );
+        assert_eq!(macos_app_bundle_path(Path::new("/tmp/freenet")), None);
+    }
+
+    #[test]
+    fn first_run_launch_at_login_action_covers_all_cases() {
+        assert_eq!(
+            first_run_launch_at_login_action(true, false),
+            FirstRunLaunchAtLoginAction::Register
+        );
+        assert_eq!(
+            first_run_launch_at_login_action(true, true),
+            FirstRunLaunchAtLoginAction::AlreadyEnabled
+        );
+        assert_eq!(
+            first_run_launch_at_login_action(false, false),
+            FirstRunLaunchAtLoginAction::NotFirstRun
+        );
+        assert_eq!(
+            first_run_launch_at_login_action(false, true),
+            FirstRunLaunchAtLoginAction::NotFirstRun
+        );
+    }
+
+    #[test]
+    fn toggle_launch_at_login_outcome_inverts_current_state() {
+        assert_eq!(
+            toggle_launch_at_login_outcome(false),
+            ToggleLaunchAtLoginOutcome::Enable
+        );
+        assert_eq!(
+            toggle_launch_at_login_outcome(true),
+            ToggleLaunchAtLoginOutcome::Disable
+        );
+    }
+
+    #[test]
     fn launch_at_login_plist_roundtrips() {
         let tmp = tempfile::tempdir().unwrap();
         let plist = tmp
             .path()
             .join("nested/Library/LaunchAgents/org.freenet.Freenet.plist");
-        let exe = PathBuf::from("/Applications/Freenet.app/Contents/MacOS/Freenet");
+        let args = vec!["/Applications/Freenet.app/Contents/MacOS/Freenet".to_string()];
 
         assert!(!is_launch_at_login_enabled_at(&plist));
 
         // Writing creates parent dirs and flips the state.
-        write_launch_agent_plist_at(&plist, &exe).unwrap();
+        write_launch_agent_plist_at(&plist, &args).unwrap();
         assert!(is_launch_at_login_enabled_at(&plist));
         let body = std::fs::read_to_string(&plist).unwrap();
         assert!(body.contains("/Applications/Freenet.app/Contents/MacOS/Freenet"));
 
-        // Removing flips it back. Idempotent: removing when already gone is Ok.
+        // Self-heal detection: happy-path match, then mismatch after a
+        // subsequent write with a different leader (simulates the user
+        // moving the .app).
+        assert!(launch_agent_plist_has_expected_leader(
+            &plist,
+            "/Applications/Freenet.app/Contents/MacOS/Freenet"
+        ));
+        assert!(!launch_agent_plist_has_expected_leader(
+            &plist,
+            "/Users/someone/Applications/Freenet.app/Contents/MacOS/Freenet"
+        ));
+
+        let moved =
+            vec!["/Users/someone/Applications/Freenet.app/Contents/MacOS/Freenet".to_string()];
+        write_launch_agent_plist_at(&plist, &moved).unwrap();
+        assert!(launch_agent_plist_has_expected_leader(
+            &plist,
+            "/Users/someone/Applications/Freenet.app/Contents/MacOS/Freenet"
+        ));
+
+        // Removing flips it back. Idempotent on repeat.
         remove_launch_agent_plist_at(&plist).unwrap();
         assert!(!is_launch_at_login_enabled_at(&plist));
         remove_launch_agent_plist_at(&plist).unwrap();

--- a/crates/core/src/bin/commands/tray.rs
+++ b/crates/core/src/bin/commands/tray.rs
@@ -299,7 +299,7 @@ mod platform {
         fn new(version: String) -> Result<Self, String> {
             let menu = Menu::new();
 
-            // App header — disabled item at the top of the menu that
+            // App header: disabled item at the top of the menu that
             // identifies the app and shows its version. Serves the same
             // role as the bold app-name entry at the top of standard
             // macOS app menus; keeps the menu bar status item itself
@@ -423,7 +423,7 @@ mod platform {
         status_rx: std_mpsc::Receiver<WrapperStatus>,
         _cleanup_done_rx: std_mpsc::Receiver<()>,
     ) {
-        // Windows doesn't need the cleanup signal — the Win32 message pump
+        // Windows doesn't need the cleanup signal: the Win32 message pump
         // returns control to the caller normally, so `run_wrapper` can join
         // the wrapper thread afterwards. The parameter exists for signature
         // parity with the macOS path.
@@ -439,7 +439,7 @@ mod platform {
                 match dispatch_menu_event(event.id.as_ref()) {
                     MenuDispatch::OpenDashboard => open_url(DASHBOARD_URL),
                     MenuDispatch::ToggleLaunchAtLogin => {
-                        // Windows installs as a service — the tray doesn't
+                        // Windows installs as a service, so the tray doesn't
                         // expose a Launch at Login item, so this arm is
                         // unreachable here. Noop for future-proofing.
                     }
@@ -472,7 +472,7 @@ mod platform {
     // On macOS a menu bar status item is only rendered and interactive
     // while an NSApplication event loop is pumping on the main thread.
     // The `tray-icon` crate registers the `NSStatusItem` but does *not*
-    // drive the run loop — the host application has to. We use
+    // drive the run loop; the host application has to. We use
     // `tao::EventLoop`, which wraps `NSApplication.run()` correctly and
     // matches tray-icon's own published examples. Status updates from the
     // wrapper thread are forwarded in as user events so they land on the
@@ -516,8 +516,8 @@ mod platform {
 
         event_loop.run(move |event, _window, control_flow| {
             // Wake at least every 100ms to poll muda's menu event channel
-            // — muda delivers menu events on its own channel rather than
-            // via tao's event stream, so we can't rely on Poll/Wait alone.
+            // (muda delivers menu events on its own channel rather than
+            // via tao's event stream, so we can't rely on Poll/Wait alone).
             *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::from_millis(100));
 
             // Drain menu events.
@@ -525,21 +525,28 @@ mod platform {
                 match dispatch_menu_event(menu_event.id.as_ref()) {
                     MenuDispatch::OpenDashboard => open_url(DASHBOARD_URL),
                     MenuDispatch::ToggleLaunchAtLogin => {
-                        // Flip the user preference by consulting the
-                        // current state and inverting it. Log failures but
-                        // don't propagate — the menu item's check-state
-                        // will refresh from the filesystem either way.
-                        let exe = std::env::current_exe();
-                        let result = if super::super::service::is_launch_at_login_enabled() {
-                            super::super::service::disable_launch_at_login()
-                        } else {
-                            match exe {
-                                Ok(p) => super::super::service::enable_launch_at_login(&p),
-                                Err(e) => Err(e),
+                        // Flip the user preference. The decision is a pure
+                        // function so it's unit-testable on Linux CI; the
+                        // side-effects (plist write + launchctl) live in
+                        // the service module. On any failure we log and
+                        // refresh the check-state from the filesystem so
+                        // the UI reflects reality rather than intent.
+                        let outcome = super::super::service::toggle_launch_at_login_outcome(
+                            super::super::service::is_launch_at_login_enabled(),
+                        );
+                        let result = match outcome {
+                            super::super::service::ToggleLaunchAtLoginOutcome::Enable => {
+                                match std::env::current_exe() {
+                                    Ok(p) => super::super::service::enable_launch_at_login(&p),
+                                    Err(e) => Err(e),
+                                }
+                            }
+                            super::super::service::ToggleLaunchAtLoginOutcome::Disable => {
+                                super::super::service::disable_launch_at_login()
                             }
                         };
                         if let Err(e) = result {
-                            eprintln!("Failed to toggle Launch at Login: {e}");
+                            tracing::warn!("Failed to toggle Launch at Login: {}", e);
                         }
                         state.refresh_launch_at_login_state();
                     }
@@ -583,7 +590,7 @@ mod platform {
     }
 
     /// Run the tray icon event loop on the current thread (must be the main
-    /// thread — both Windows and macOS require UI work on the main thread).
+    /// thread: both Windows and macOS require UI work on the main thread).
     ///
     /// `action_tx` sends user menu actions to the wrapper loop running on
     /// another thread. `status_rx` receives status updates from the wrapper

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -19,6 +19,13 @@ const GITHUB_API_URL: &str = "https://api.github.com/repos/freenet/freenet-core/
 /// Used by the service wrapper to avoid unnecessary restarts.
 pub const EXIT_CODE_ALREADY_UP_TO_DATE: i32 = 2;
 
+/// Exit code returned when a macOS DMG-swap update has been staged and the
+/// detached updater script is ready to take over. The wrapper MUST NOT
+/// re-exec itself on this code (the current .app bundle is about to be
+/// replaced out from under us); instead it should exit cleanly so the
+/// updater can complete the swap and relaunch.
+pub const EXIT_CODE_BUNDLE_UPDATE_STAGED: i32 = 3;
+
 #[derive(Args, Debug, Clone)]
 pub struct UpdateCommand {
     /// Only check if an update is available without installing
@@ -85,6 +92,37 @@ impl UpdateCommand {
     }
 
     async fn download_and_install(&self, release: &Release) -> Result<()> {
+        // macOS DMG-swap path: when running from inside a .app bundle,
+        // in-place binary replacement would invalidate the bundle's code
+        // signature and Gatekeeper would refuse to launch the result on
+        // next login. Instead we download the signed+notarized DMG and
+        // hand off to a detached updater script that swaps the whole
+        // bundle once this process exits. See fn maybe_perform_bundle_update.
+        #[cfg(target_os = "macos")]
+        {
+            match self.maybe_perform_bundle_update(release).await {
+                Ok(true) => {
+                    if !self.quiet {
+                        println!("Bundle update staged. Freenet will relaunch shortly.");
+                    }
+                    std::process::exit(EXIT_CODE_BUNDLE_UPDATE_STAGED);
+                }
+                Ok(false) => {
+                    // Not running inside a .app bundle (cargo run, raw
+                    // binary install, dev build): fall through to the
+                    // standard in-place binary replacement path below.
+                }
+                Err(e) => {
+                    if !self.quiet {
+                        eprintln!(
+                            "Bundle update failed ({}). Falling back to in-place binary replacement.",
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
         let target = get_target_triple();
         let extension = get_archive_extension();
         let freenet_asset_name = format!("freenet-{}.{}", target, extension);
@@ -388,6 +426,103 @@ impl UpdateCommand {
         } else if !self.quiet {
             println!("Successfully updated fdev.");
         }
+    }
+
+    /// macOS DMG-swap update. Invoked from `download_and_install` when we
+    /// detect we're running inside a .app bundle. Downloads the new
+    /// `Freenet-<version>.dmg`, verifies its checksum against
+    /// SHA256SUMS.txt, mounts it, stages the new bundle in
+    /// `~/Library/Caches/Freenet/staging/Freenet.app`, and spawns the
+    /// detached `macos-bundle-updater.sh` script which waits for the
+    /// running process to exit and then swaps the bundle.
+    ///
+    /// Returns:
+    ///   Ok(true)  update was staged; caller should exit with
+    ///             EXIT_CODE_BUNDLE_UPDATE_STAGED
+    ///   Ok(false) not running in a bundle; caller should use the
+    ///             standard binary-replacement flow instead
+    ///   Err       failed; caller may fall back to binary replacement
+    #[cfg(target_os = "macos")]
+    async fn maybe_perform_bundle_update(&self, release: &Release) -> Result<bool> {
+        let current_exe = std::env::current_exe()
+            .context("Failed to resolve current executable for bundle-update check")?;
+        let Some(bundle_path) = super::service::macos_app_bundle_path(&current_exe) else {
+            return Ok(false);
+        };
+
+        let version = release.tag_name.trim_start_matches('v');
+        let dmg_asset_name = format!("Freenet-{version}.dmg");
+        let dmg_asset = release
+            .assets
+            .iter()
+            .find(|a| a.name == dmg_asset_name)
+            .ok_or_else(|| anyhow::anyhow!("No DMG asset named {} in release", dmg_asset_name))?;
+
+        let checksums = match release.assets.iter().find(|a| a.name == "SHA256SUMS.txt") {
+            Some(a) => download_checksums(&a.browser_download_url).await.ok(),
+            None => None,
+        };
+
+        let scratch = tempfile::tempdir().context("Failed to create temp directory")?;
+        let dmg_path = scratch.path().join(&dmg_asset_name);
+        download_file(&dmg_asset.browser_download_url, &dmg_path, self.quiet).await?;
+
+        if let Some(checksums) = &checksums {
+            if let Some(expected) = checksums.get(&dmg_asset_name) {
+                verify_checksum(&dmg_path, expected)?;
+            } else if !self.quiet {
+                eprintln!(
+                    "Warning: no checksum for {dmg_asset_name}. Continuing without verification."
+                );
+            }
+        }
+
+        let mount_point = scratch.path().join("mount");
+        std::fs::create_dir_all(&mount_point)?;
+        hdiutil_attach(&dmg_path, &mount_point)?;
+
+        let mounted_app = mount_point.join("Freenet.app");
+        if !mounted_app.exists() {
+            let _ = hdiutil_detach(&mount_point);
+            anyhow::bail!(
+                "DMG mounted at {} does not contain Freenet.app",
+                mount_point.display()
+            );
+        }
+
+        // Stage into a persistent location outside `scratch` (which is
+        // deleted as soon as this function returns). The updater script
+        // reads the staged bundle AFTER we exit, so it must survive.
+        let staging = staging_dir()?;
+        std::fs::create_dir_all(&staging)?;
+        let staged_app = staging.join("Freenet.app");
+        if staged_app.exists() {
+            std::fs::remove_dir_all(&staged_app)
+                .context("Failed to clean previous staging directory")?;
+        }
+
+        // `ditto` preserves HFS+/APFS metadata and extended attributes
+        // (including the code-signature bits and stapled notarization).
+        // A plain `cp -R` would strip quarantine/notarization attrs and
+        // Gatekeeper would then reject the bundle on next launch.
+        let ditto = std::process::Command::new("/usr/bin/ditto")
+            .arg(&mounted_app)
+            .arg(&staged_app)
+            .output()
+            .context("Failed to spawn /usr/bin/ditto")?;
+        let _ = hdiutil_detach(&mount_point);
+        if !ditto.status.success() {
+            anyhow::bail!(
+                "ditto copy failed ({}): {}",
+                ditto.status,
+                String::from_utf8_lossy(&ditto.stderr).trim()
+            );
+        }
+
+        let script_path = write_updater_script()?;
+        spawn_detached_updater(&script_path, &bundle_path, &staged_app)?;
+
+        Ok(true)
     }
 }
 
@@ -1104,4 +1239,110 @@ fn is_windows_wrapper_running() -> bool {
             stdout.matches("freenet.exe").count() > 1
         })
         .unwrap_or(false)
+}
+
+// ── macOS DMG-swap update support ──
+
+/// Cache directory for staged bundles and the updater script. Separate
+/// sub-paths live under this root. Uses `dirs::cache_dir()` which on
+/// macOS resolves to `~/Library/Caches`.
+#[cfg(target_os = "macos")]
+fn bundle_updater_cache_root() -> Result<PathBuf> {
+    dirs::cache_dir()
+        .map(|d| d.join("Freenet"))
+        .context("Could not resolve user cache directory")
+}
+
+#[cfg(target_os = "macos")]
+fn staging_dir() -> Result<PathBuf> {
+    Ok(bundle_updater_cache_root()?.join("staging"))
+}
+
+#[cfg(target_os = "macos")]
+fn updater_runtime_dir() -> Result<PathBuf> {
+    Ok(bundle_updater_cache_root()?.join("updater"))
+}
+
+#[cfg(target_os = "macos")]
+fn hdiutil_attach(dmg: &Path, mount_point: &Path) -> Result<()> {
+    let output = std::process::Command::new("hdiutil")
+        .args(["attach", "-nobrowse", "-readonly", "-mountpoint"])
+        .arg(mount_point)
+        .arg(dmg)
+        .output()
+        .context("Failed to spawn hdiutil")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "hdiutil attach failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn hdiutil_detach(mount_point: &Path) -> Result<()> {
+    // `-force` so a stuck unmount from a prior crashed run doesn't pin
+    // us indefinitely. Attach is read-only, so there's no data at risk.
+    let output = std::process::Command::new("hdiutil")
+        .args(["detach", "-force"])
+        .arg(mount_point)
+        .output()
+        .context("Failed to spawn hdiutil")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "hdiutil detach failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Materialize the macOS bundle updater script onto disk. We ship it as
+/// an embedded `include_str!` so the Freenet binary is self-contained
+/// even when installed from crates.io without the `scripts/` directory.
+#[cfg(target_os = "macos")]
+fn write_updater_script() -> Result<PathBuf> {
+    const SCRIPT: &str = include_str!("../../../../../scripts/macos-bundle-updater.sh");
+    let dir = updater_runtime_dir()?;
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join("macos-bundle-updater.sh");
+    std::fs::write(&path, SCRIPT)?;
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms)?;
+    Ok(path)
+}
+
+/// Spawn the bundle updater in a detached process group so it survives
+/// when the current process exits (which it is about to, so the bundle
+/// can be swapped).
+#[cfg(target_os = "macos")]
+fn spawn_detached_updater(script: &Path, current_app: &Path, staged_app: &Path) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+    let log_path = updater_runtime_dir()?.join("updater.log");
+    let mut cmd = Command::new("/bin/bash");
+    cmd.arg(script)
+        .arg(current_app)
+        .arg(staged_app)
+        .arg(&log_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // Put the updater in its own process group so the shell that spawned
+    // Freenet (or our own process-exit signal) can't accidentally sweep
+    // it up as a child. `setsid` is unavailable on macOS but `setpgid(0, 0)`
+    // via `before_exec` works.
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setpgid(0, 0);
+            Ok(())
+        });
+    }
+    cmd.spawn().context("Failed to spawn detached updater")?;
+    Ok(())
 }

--- a/scripts/macos-bundle-updater.sh
+++ b/scripts/macos-bundle-updater.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# macOS DMG-swap updater. Launched detached by `freenet update` when the
+# running process is inside a .app bundle. Waits for the running Freenet
+# to exit (so /Applications/Freenet.app is no longer in use), atomically
+# swaps the bundle with the staged copy, then relaunches the new bundle.
+#
+# Usage (called from Rust):
+#   /bin/bash macos-bundle-updater.sh <current_app> <staged_app> <log_file>
+#
+# where:
+#   current_app: absolute path of the installed bundle
+#                (e.g. /Applications/Freenet.app)
+#   staged_app:  absolute path of the newly-downloaded bundle
+#                (e.g. ~/Library/Caches/Freenet/staging/Freenet.app)
+#   log_file:    absolute path of a file to append diagnostic log lines
+#                to (e.g. ~/Library/Caches/Freenet/updater/updater.log)
+#
+# Exit codes:
+#   0  swap + relaunch succeeded
+#   1  swap failed; bundle has been restored from backup
+#   2  swap failed AND restore failed (user's install may be broken)
+
+set -u
+
+CURRENT_APP="${1:-}"
+STAGED_APP="${2:-}"
+LOG_FILE="${3:-/tmp/freenet-macos-updater.log}"
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+if [[ -z "$CURRENT_APP" || -z "$STAGED_APP" ]]; then
+    log "ERROR: usage: $0 <current_app> <staged_app> [log_file]"
+    exit 1
+fi
+
+log "Updater started: CURRENT_APP=$CURRENT_APP STAGED_APP=$STAGED_APP"
+
+# Wait for every freenet process whose executable lives under CURRENT_APP
+# to exit. Bounded deadline so a stuck child doesn't freeze the update
+# indefinitely. The regex matches both the shell wrapper CFBundleExecutable
+# (/.../Freenet.app/Contents/MacOS/Freenet) and the inner binary
+# (/.../Freenet.app/Contents/MacOS/freenet-bin), but NOT unrelated binaries
+# that happen to contain "Freenet" in their path.
+deadline=$(( $(date +%s) + 120 ))
+while (( $(date +%s) < deadline )); do
+    if ! pgrep -f "^${CURRENT_APP}/Contents/MacOS/" > /dev/null 2>&1; then
+        log "All Freenet processes under $CURRENT_APP have exited"
+        break
+    fi
+    sleep 1
+done
+
+if pgrep -f "^${CURRENT_APP}/Contents/MacOS/" > /dev/null 2>&1; then
+    log "WARNING: timeout waiting for Freenet to exit; proceeding with swap anyway"
+fi
+
+if [[ ! -d "$STAGED_APP" ]]; then
+    log "ERROR: staged bundle not found at $STAGED_APP; aborting"
+    exit 1
+fi
+
+# Move the old bundle aside (atomic rename within the same filesystem).
+# Name includes a timestamp so concurrent updates don't collide, though
+# we expect at most one updater at a time.
+BACKUP="${CURRENT_APP}.oldupdate.$$"
+if [[ -e "$CURRENT_APP" ]]; then
+    if ! mv "$CURRENT_APP" "$BACKUP" 2>>"$LOG_FILE"; then
+        log "ERROR: failed to move current bundle aside; aborting"
+        exit 1
+    fi
+fi
+
+# Move the staged bundle into place.
+if ! mv "$STAGED_APP" "$CURRENT_APP" 2>>"$LOG_FILE"; then
+    log "ERROR: failed to move staged bundle into place; attempting rollback"
+    if [[ -d "$BACKUP" ]]; then
+        if ! mv "$BACKUP" "$CURRENT_APP" 2>>"$LOG_FILE"; then
+            log "CRITICAL: failed to restore backup; bundle is at $BACKUP"
+            exit 2
+        fi
+    fi
+    exit 1
+fi
+
+# Success. Remove the backup.
+if [[ -d "$BACKUP" ]]; then
+    rm -rf "$BACKUP" 2>>"$LOG_FILE" || true
+fi
+
+log "Bundle swap complete. Launching new bundle: $CURRENT_APP"
+
+# `open` re-enters LaunchServices bundle resolution: icon, quarantine-
+# approval check, Gatekeeper re-scan of the stapled notarization, NSApp
+# setup, and (for LSUIElement apps) menu-bar status item registration.
+# This is why we can't just exec the inner binary directly.
+/usr/bin/open "$CURRENT_APP" 2>>"$LOG_FILE"
+
+log "Updater complete"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -200,14 +200,24 @@ if [ "$OS" = "linux" ]; then
        (or: sudo systemctl disable --now freenet && sudo rm /etc/systemd/system/freenet.service)"
     fi
 elif [ "$OS" = "macos" ]; then
-    PLIST="${HOME}/Library/LaunchAgents/org.freenet.node.plist"
-    if [ -f "$PLIST" ]; then
-        info "Unloading launchd agent..."
-        launchctl unload "$PLIST" >/dev/null 2>&1 || true
-        rm -f "$PLIST"
-        info "Removed ${PLIST}"
-        removed_service="launchd"
-    fi
+    # Legacy install.sh / `freenet service install` plist (pre-DMG):
+    LEGACY_PLIST="${HOME}/Library/LaunchAgents/org.freenet.node.plist"
+    # DMG-installed Freenet.app's Launch-at-Login plist:
+    DMG_PLIST="${HOME}/Library/LaunchAgents/org.freenet.Freenet.plist"
+    UID_VALUE="$(id -u 2>/dev/null || echo 501)"
+    for PLIST in "$LEGACY_PLIST" "$DMG_PLIST"; do
+        if [ -f "$PLIST" ]; then
+            info "Unloading launchd agent at $PLIST"
+            # Try modern bootout first (macOS 11+), fall back to legacy
+            # unload for older systems. Either may fail non-fatally if
+            # the agent was never actually loaded in this session.
+            launchctl bootout "gui/${UID_VALUE}" "$PLIST" >/dev/null 2>&1 || \
+                launchctl unload "$PLIST" >/dev/null 2>&1 || true
+            rm -f "$PLIST"
+            info "Removed ${PLIST}"
+            removed_service="launchd"
+        fi
+    done
 fi
 
 # --- Step 2: remove binaries from every known install location ------------


### PR DESCRIPTION
Follow-up to #3928. Splits into two commits for reviewability.

## Commit 1 — fix(tray): address launch-at-login review findings

All four internal reviewers plus Codex converged on the same set of bugs in #3928's Launch-at-Login commit. Addresses every "Must-fix" finding:

- **Plist pointed at wrong executable** (code-first Discrepancy #1, skeptical M2, Codex P2, big-picture). `std::env::current_exe()` inside a .app bundle resolves to `Contents/MacOS/freenet-bin`, not the `Freenet` shell wrapper, and ProgramArguments had no `service run-wrapper` args. On next login launchd would exec bare `freenet-bin` which defaults to Network mode, silently breaking the stated Windows-parity goal. **Fix:** new pure `launch_agent_program_arguments(exe)` that returns the wrapper path for bundle installs or `[exe, "service", "run-wrapper"]` for non-bundle. Three new tests including a regression test for the specific inner-binary path.
- **UI state drift** (skeptical H1). First-run registration ran AFTER the tray built and read `is_launch_at_login_enabled()`, so first-time users saw an unchecked box despite the agent being registered. **Fix:** extracted `macos_launch_at_login_startup()` and called it synchronously from `run_wrapper` BEFORE spawning the wrapper thread and BEFORE building the tray.
- **Stale plist after app relocation** (skeptical M1). `refresh_launch_at_login_plist_if_stale()` now runs on every startup; if the embedded path no longer matches the current one, the plist is rewritten.
- **Wrong comment about `launchctl load` fallback** (code-first, big-picture). Deleted.
- **launchctl stderr silently swallowed** (code-first C2). Now captured and logged via `tracing::warn` / `tracing::debug`.
- **First-run and toggle decisions inlined rather than extracted** (testing review gap #1/#2, big-picture). Now pure functions `first_run_launch_at_login_action()` and `toggle_launch_at_login_outcome()` with exhaustive unit tests.
- **Collision with legacy install.sh LaunchAgent** (big-picture). `legacy_launchd_agent_present()` detects the old `org.freenet.node.plist` and logs a prominent warning with cleanup commands.
- **`uninstall.sh` only knew about the legacy plist** (big-picture). Now removes both plists using modern `launchctl bootout` with legacy `launchctl unload` fallback.
- **`base64 --decode` portability** (Codex P1). Switched to `base64 -d` in both workflows.
- **Em-dashes in new comments** (big-picture). Scrubbed.

## Commit 2 — feat(update): DMG-swap auto-update for macOS .app installs

Closes the auto-update gap for macOS bundle installs. Silent, matching Linux/Windows.

When `freenet update --quiet` runs inside a .app bundle:

1. Download `Freenet-<version>.dmg` from the release assets (the workflow added in #3928).
2. Verify checksum against `SHA256SUMS.txt`.
3. Mount read-only via `hdiutil attach -readonly -nobrowse`.
4. Copy out the new `.app` to `~/Library/Caches/Freenet/staging/Freenet.app` using `ditto` so the notarization ticket and code-signature extended attributes are preserved.
5. Unmount.
6. Materialize the embedded `scripts/macos-bundle-updater.sh` and spawn it detached (new process group via `setpgid(0,0)`).
7. Exit with new `EXIT_CODE_BUNDLE_UPDATE_STAGED = 3`.

The wrapper handles exit 3 at all four existing `spawn_update_command` sites by exiting cleanly without re-exec. The updater script waits up to 120s for freenet processes under `CURRENT_APP` to exit, atomically swaps the bundle (`mv` aside + `mv` in + cleanup backup, with rollback on failure), then `/usr/bin/open` the new bundle to re-enter LaunchServices (icon, Gatekeeper re-scan, LSUIElement registration).

Non-bundle installs (cargo, raw binary) fall through to the existing in-place binary replacement path.

## Testing

- 60 unit tests, all passing (was 53 on the landed #3928 base, +7 new here).
- `cargo fmt` + `cargo clippy -- -D warnings` clean.
- Manual verification still requires a macOS install with a release that contains both `Freenet-X.dmg` and `Freenet-Y.dmg` (Y > X). Plan is to smoke-test end-to-end on 0.2.49 → 0.2.50 once we cut those.

## Related

- Completes the signed-DMG-with-auto-update story from #3928.
- Fixes the production bug identified post-merge by multiple reviewers.

[AI-assisted - Claude]