### PR TITLE
fix(update): address DMG-swap review findings from #3930

### DIFF
--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -707,21 +707,31 @@ pub(super) fn legacy_launchd_agent_present() -> bool {
 #[cfg(target_os = "macos")]
 pub(super) fn macos_launch_at_login_startup(log_dir: &Path) {
     // Legacy-agent warning: fire once per startup regardless of first-run.
-    if legacy_launchd_agent_present() {
+    // If users see this, they have an auto-start from the old install.sh
+    // flow still configured; if we also write our own plist below, both
+    // agents race for port 7509 on every login. To avoid that race we
+    // treat the legacy plist's presence as "already enabled" for the
+    // first-run decision, so we don't layer a second auto-start on top.
+    // User is still instructed to clean up the legacy one manually.
+    let legacy_present = legacy_launchd_agent_present();
+    if legacy_present {
         log_wrapper_event(
             log_dir,
             "Legacy launchd agent ~/Library/LaunchAgents/org.freenet.node.plist \
-             detected. Two agents will race for port 7509; remove the legacy one \
-             with: launchctl bootout gui/$UID ~/Library/LaunchAgents/org.freenet.node.plist \
-             && rm ~/Library/LaunchAgents/org.freenet.node.plist",
+             detected. Freenet is already configured to auto-start via that \
+             agent; the new DMG install will NOT create a duplicate agent. \
+             To clean up the legacy one when convenient: launchctl bootout \
+             gui/$UID ~/Library/LaunchAgents/org.freenet.node.plist && rm \
+             ~/Library/LaunchAgents/org.freenet.node.plist",
         );
     }
 
-    // First-run auto-register.
+    // First-run auto-register. Treat the legacy plist as already-enabled
+    // so migrating users don't end up with two plists (Codex P2).
     let Some(marker) = first_run_marker_path() else {
         return;
     };
-    let already_enabled = is_launch_at_login_enabled();
+    let already_enabled = is_launch_at_login_enabled() || legacy_present;
     match first_run_launch_at_login_action(is_first_run_at(&marker), already_enabled) {
         FirstRunLaunchAtLoginAction::Register => match std::env::current_exe() {
             Ok(exe) => match enable_launch_at_login(&exe) {
@@ -738,10 +748,16 @@ pub(super) fn macos_launch_at_login_startup(log_dir: &Path) {
         },
         FirstRunLaunchAtLoginAction::AlreadyEnabled => {
             // Nothing to do for first-run, but the plist may still be stale.
-            refresh_launch_at_login_plist_if_stale();
+            // Only refresh if our OWN plist is present — don't resurrect
+            // a rewrite cycle on a legacy-only install.
+            if is_launch_at_login_enabled() {
+                refresh_launch_at_login_plist_if_stale();
+            }
         }
         FirstRunLaunchAtLoginAction::NotFirstRun => {
-            refresh_launch_at_login_plist_if_stale();
+            if is_launch_at_login_enabled() {
+                refresh_launch_at_login_plist_if_stale();
+            }
         }
     }
 }

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -24,7 +24,71 @@ pub const EXIT_CODE_ALREADY_UP_TO_DATE: i32 = 2;
 /// re-exec itself on this code (the current .app bundle is about to be
 /// replaced out from under us); instead it should exit cleanly so the
 /// updater can complete the swap and relaunch.
-pub const EXIT_CODE_BUNDLE_UPDATE_STAGED: i32 = 3;
+///
+/// Value 44 chosen to follow the existing WRAPPER_EXIT_* convention in
+/// service.rs (42 = update needed, 43 = already running) and to avoid
+/// collision with the exit-3 signal that `freenet service status` uses
+/// for "service not running" (which a caller might legitimately
+/// disambiguate from "update staged" by exit code alone).
+pub const EXIT_CODE_BUNDLE_UPDATE_STAGED: i32 = 44;
+
+/// Classified outcome of a `freenet update` subprocess invocation, from
+/// the wrapper's point of view. Pure function so the four existing
+/// dispatch sites in `service.rs` stay in sync: a typo like forgetting
+/// the `Some(...)` arm at one of them would route the wrapper into
+/// re-exec'ing a bundle that's about to be replaced out from under it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum UpdateSubprocessOutcome {
+    /// In-place binary replacement succeeded. Wrapper should re-exec via
+    /// `spawn_new_wrapper` so the tray reflects the new version.
+    BinaryReplaced,
+    /// macOS DMG-swap: the detached updater will finish the update and
+    /// relaunch the new bundle after this process exits. Wrapper MUST
+    /// exit cleanly without re-exec.
+    BundleUpdateStaged,
+    /// Update check ran; already on the latest version.
+    AlreadyUpToDate,
+    /// Update attempted but failed (spawn error, network error, or non-
+    /// zero exit other than `ALREADY_UP_TO_DATE` / `BUNDLE_UPDATE_STAGED`).
+    Failed,
+}
+
+/// Classify the exit status of a `freenet update` subprocess invocation.
+/// Pure over just the `io::Result<ExitStatus>` so it can be unit-tested
+/// with synthetic inputs.
+#[allow(dead_code)]
+pub fn classify_update_subprocess(
+    result: &std::io::Result<std::process::ExitStatus>,
+) -> UpdateSubprocessOutcome {
+    match result {
+        Ok(s) if s.success() => UpdateSubprocessOutcome::BinaryReplaced,
+        Ok(s) if s.code() == Some(EXIT_CODE_BUNDLE_UPDATE_STAGED) => {
+            UpdateSubprocessOutcome::BundleUpdateStaged
+        }
+        Ok(s) if s.code() == Some(EXIT_CODE_ALREADY_UP_TO_DATE) => {
+            UpdateSubprocessOutcome::AlreadyUpToDate
+        }
+        Ok(_) => UpdateSubprocessOutcome::Failed,
+        Err(_) => UpdateSubprocessOutcome::Failed,
+    }
+}
+
+/// Compute the macOS DMG asset filename for a given release tag. Strips
+/// a leading `v` if present (releases are tagged `v0.2.49` but the DMG
+/// filename embeds the bare version, per the release pipeline in
+/// `.github/workflows/cross-compile.yml`). Pure so the derivation is
+/// testable without a real `Release` fixture.
+#[allow(dead_code)]
+pub fn macos_dmg_asset_name(tag_name: &str) -> String {
+    // `strip_prefix` removes at most one leading `v`, unlike
+    // `trim_start_matches` which would eat multiple (e.g. a typo tag
+    // like `vv0.2.49` would silently double-strip and produce the wrong
+    // DMG name, then fail the asset lookup with a confusing "not
+    // found" rather than surfacing the bad tag).
+    let version = tag_name.strip_prefix('v').unwrap_or(tag_name);
+    format!("Freenet-{}.dmg", version)
+}
 
 #[derive(Args, Debug, Clone)]
 pub struct UpdateCommand {
@@ -100,8 +164,22 @@ impl UpdateCommand {
         // bundle once this process exits. See fn maybe_perform_bundle_update.
         #[cfg(target_os = "macos")]
         {
+            // Detect the bundle context once up front so the error arm
+            // can tell the difference between "not in a bundle, fall
+            // through to binary-replace" and "in a bundle, DMG-swap
+            // failed, abort to protect the signature". Falling through
+            // on error would overwrite Contents/MacOS/freenet-bin and
+            // invalidate the bundle's code signature, bricking the app
+            // on next Gatekeeper check (per Codex P1 and code-first
+            // review on this PR).
+            let running_in_bundle = std::env::current_exe()
+                .ok()
+                .and_then(|exe| super::service::macos_app_bundle_path(&exe))
+                .is_some();
+
             match self.maybe_perform_bundle_update(release).await {
                 Ok(true) => {
+                    tracing::info!("DMG-swap update staged for release {}", release.tag_name);
                     if !self.quiet {
                         println!("Bundle update staged. Freenet will relaunch shortly.");
                     }
@@ -112,11 +190,31 @@ impl UpdateCommand {
                     // binary install, dev build): fall through to the
                     // standard in-place binary replacement path below.
                 }
-                Err(e) => {
+                Err(e) if running_in_bundle => {
+                    // Running in a bundle AND the DMG-swap failed. Do
+                    // NOT fall through: binary-replace would corrupt the
+                    // signature and break Gatekeeper on next boot. Log
+                    // and return so the user stays on the working old
+                    // version; the next auto-update cycle can retry.
+                    tracing::warn!(
+                        "DMG-swap bundle update failed for {}: {}. Skipping update to preserve code signature.",
+                        release.tag_name,
+                        e
+                    );
                     if !self.quiet {
                         eprintln!(
-                            "Bundle update failed ({}). Falling back to in-place binary replacement.",
-                            e
+                            "Bundle update failed: {e}. Skipping update to avoid corrupting the signed bundle. Next attempt will retry."
+                        );
+                    }
+                    return Ok(());
+                }
+                Err(e) => {
+                    // Not in a bundle: safe to fall through to binary-
+                    // replace. Log the bundle-attempt failure for
+                    // diagnosability; continue with the standard path.
+                    if !self.quiet {
+                        eprintln!(
+                            "Bundle update check failed ({e}); continuing with in-place binary replacement."
                         );
                     }
                 }
@@ -450,13 +548,18 @@ impl UpdateCommand {
             return Ok(false);
         };
 
-        let version = release.tag_name.trim_start_matches('v');
-        let dmg_asset_name = format!("Freenet-{version}.dmg");
+        let dmg_asset_name = macos_dmg_asset_name(&release.tag_name);
         let dmg_asset = release
             .assets
             .iter()
             .find(|a| a.name == dmg_asset_name)
             .ok_or_else(|| anyhow::anyhow!("No DMG asset named {} in release", dmg_asset_name))?;
+
+        // Acquire a flock on a lockfile in the cache dir so two concurrent
+        // updates (e.g. tray "Check for Updates" racing with auto-update)
+        // can't stomp each other's staging directories and leave the user
+        // with no /Applications/Freenet.app (skeptical review H1).
+        let _update_lock = acquire_update_lock()?;
 
         let checksums = match release.assets.iter().find(|a| a.name == "SHA256SUMS.txt") {
             Some(a) => download_checksums(&a.browser_download_url).await.ok(),
@@ -467,38 +570,56 @@ impl UpdateCommand {
         let dmg_path = scratch.path().join(&dmg_asset_name);
         download_file(&dmg_asset.browser_download_url, &dmg_path, self.quiet).await?;
 
-        if let Some(checksums) = &checksums {
-            if let Some(expected) = checksums.get(&dmg_asset_name) {
-                verify_checksum(&dmg_path, expected)?;
-            } else if !self.quiet {
-                eprintln!(
-                    "Warning: no checksum for {dmg_asset_name}. Continuing without verification."
-                );
-            }
+        // Require checksum verification for bundle updates. Unverified
+        // DMG install is a supply-chain risk that macOS Gatekeeper alone
+        // should not have to mitigate. If SHA256SUMS.txt doesn't list
+        // the DMG, abort rather than silently proceed (code-first,
+        // skeptical M7).
+        match checksums.as_ref().and_then(|c| c.get(&dmg_asset_name)) {
+            Some(expected) => verify_checksum(&dmg_path, expected)?,
+            None => anyhow::bail!(
+                "No SHA256 checksum listed for {}; refusing unverified DMG install. \
+                 Check that the release uploaded SHA256SUMS.txt covering the DMG asset.",
+                dmg_asset_name
+            ),
         }
 
         let mount_point = scratch.path().join("mount");
         std::fs::create_dir_all(&mount_point)?;
         hdiutil_attach(&dmg_path, &mount_point)?;
+        // Scope guard: detach in every control-flow path below, including
+        // `?` early returns from `ditto` spawn failure. Without this, the
+        // volume stays mounted after the function returns and the tempdir
+        // drop tries to remove_dir_all under a live mount, which at best
+        // fails and at worst (if hdiutil is confused) could touch the
+        // mounted contents.
+        let detach_guard = MountDetachOnDrop {
+            mount_point: mount_point.clone(),
+        };
 
         let mounted_app = mount_point.join("Freenet.app");
         if !mounted_app.exists() {
-            let _ = hdiutil_detach(&mount_point);
+            drop(detach_guard);
             anyhow::bail!(
                 "DMG mounted at {} does not contain Freenet.app",
                 mount_point.display()
             );
         }
 
-        // Stage into a persistent location outside `scratch` (which is
-        // deleted as soon as this function returns). The updater script
-        // reads the staged bundle AFTER we exit, so it must survive.
-        let staging = staging_dir()?;
-        std::fs::create_dir_all(&staging)?;
-        let staged_app = staging.join("Freenet.app");
+        // Stage as a SIBLING of the target bundle, not in
+        // ~/Library/Caches. The final `rename(2)` the updater script
+        // performs must stay on the same APFS volume or the fallback
+        // cp+rm is not crash-safe (skeptical review H2). Using a
+        // hidden sibling also keeps the staging dir cleaned up even
+        // if the updater crashes mid-flight — any `/Applications/.Freenet.app.staging.*`
+        // leftover is obviously unrelated to the real install.
+        let staged_app = bundle_staging_path(&bundle_path)?;
         if staged_app.exists() {
             std::fs::remove_dir_all(&staged_app)
                 .context("Failed to clean previous staging directory")?;
+        }
+        if let Some(parent) = staged_app.parent() {
+            std::fs::create_dir_all(parent)?;
         }
 
         // `ditto` preserves HFS+/APFS metadata and extended attributes
@@ -510,7 +631,7 @@ impl UpdateCommand {
             .arg(&staged_app)
             .output()
             .context("Failed to spawn /usr/bin/ditto")?;
-        let _ = hdiutil_detach(&mount_point);
+        drop(detach_guard);
         if !ditto.status.success() {
             anyhow::bail!(
                 "ditto copy failed ({}): {}",
@@ -1243,9 +1364,10 @@ fn is_windows_wrapper_running() -> bool {
 
 // ── macOS DMG-swap update support ──
 
-/// Cache directory for staged bundles and the updater script. Separate
-/// sub-paths live under this root. Uses `dirs::cache_dir()` which on
-/// macOS resolves to `~/Library/Caches`.
+/// Cache directory for the updater script runtime + log. Staged bundles
+/// live beside the target (see `bundle_staging_path`) so `rename(2)`
+/// stays same-volume. Uses `dirs::cache_dir()` which on macOS resolves
+/// to `~/Library/Caches`.
 #[cfg(target_os = "macos")]
 fn bundle_updater_cache_root() -> Result<PathBuf> {
     dirs::cache_dir()
@@ -1253,14 +1375,73 @@ fn bundle_updater_cache_root() -> Result<PathBuf> {
         .context("Could not resolve user cache directory")
 }
 
+/// Path where we stage the new .app during an update. Must be on the
+/// same APFS volume as the target bundle so the final `rename(2)` the
+/// updater script performs is atomic (skeptical H2). We use a hidden
+/// sibling of the target named with our PID to avoid clashing with
+/// concurrent updates and to keep filesystem cleanup obvious.
 #[cfg(target_os = "macos")]
-fn staging_dir() -> Result<PathBuf> {
-    Ok(bundle_updater_cache_root()?.join("staging"))
+fn bundle_staging_path(target_bundle: &Path) -> Result<PathBuf> {
+    let parent = target_bundle
+        .parent()
+        .context("Target bundle has no parent directory")?;
+    let pid = std::process::id();
+    Ok(parent.join(format!(".Freenet.app.staging.{pid}")))
 }
 
 #[cfg(target_os = "macos")]
 fn updater_runtime_dir() -> Result<PathBuf> {
     Ok(bundle_updater_cache_root()?.join("updater"))
+}
+
+/// Lockfile-backed exclusion for concurrent update attempts. Returns a
+/// guard that holds the flock until dropped. Concurrent `freenet update`
+/// invocations (e.g. tray-triggered racing with auto-update-on-exit-42)
+/// must be serialized or they can stomp each other's staging and leave
+/// the user with no installed bundle (skeptical H1).
+#[cfg(target_os = "macos")]
+fn acquire_update_lock() -> Result<UpdateLock> {
+    use std::os::unix::io::AsRawFd;
+    let dir = updater_runtime_dir()?;
+    std::fs::create_dir_all(&dir)?;
+    let lock_path = dir.join("update.lock");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)
+        .context("Failed to open update lockfile")?;
+    // flock with LOCK_EX | LOCK_NB: fail fast instead of queueing. A
+    // parallel updater should bail rather than serialize behind us.
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc != 0 {
+        anyhow::bail!(
+            "Another Freenet update is already in progress (lockfile held: {})",
+            lock_path.display()
+        );
+    }
+    Ok(UpdateLock { _file: file })
+}
+
+#[cfg(target_os = "macos")]
+struct UpdateLock {
+    // Held only to keep the flock alive; dropped releases the lock.
+    _file: std::fs::File,
+}
+
+/// Scope guard that detaches an hdiutil-mounted volume when it goes out
+/// of scope. Ensures the mount is cleaned up on every exit path from
+/// `maybe_perform_bundle_update`, including `?` early-returns.
+#[cfg(target_os = "macos")]
+struct MountDetachOnDrop {
+    mount_point: PathBuf,
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for MountDetachOnDrop {
+    fn drop(&mut self) {
+        let _ = hdiutil_detach(&self.mount_point);
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -1333,16 +1514,117 @@ fn spawn_detached_updater(script: &Path, current_app: &Path, staged_app: &Path) 
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
-    // Put the updater in its own process group so the shell that spawned
-    // Freenet (or our own process-exit signal) can't accidentally sweep
-    // it up as a child. `setsid` is unavailable on macOS but `setpgid(0, 0)`
-    // via `before_exec` works.
+    // Detach the updater from the parent's session AND process group so
+    // it survives SIGHUP if the user closes a parent Terminal, and isn't
+    // swept up as our own child on exit. `setsid` makes a new session
+    // (which implicitly makes a new process group); the subsequent
+    // `setpgid(0, 0)` is redundant but cheap belt-and-braces. Without
+    // `setsid`, a terminal-parent session delivers SIGHUP to all
+    // descendants on close, killing the updater mid-swap (skeptical M5).
     unsafe {
         cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                // setsid fails if we're already a session leader.
+                // That's fine; the setpgid below still detaches us
+                // from the parent's process group.
+            }
             libc::setpgid(0, 0);
             Ok(())
         });
     }
     cmd.spawn().context("Failed to spawn detached updater")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Synthesize an ExitStatus with a specific numeric code. Uses the
+    // Unix-specific `ExitStatusExt::from_raw` so this test module is
+    // implicitly unix-only; that matches where the production classifier
+    // actually matters (Linux + macOS wrapper flow; Windows also hits
+    // these tests since it compiles the classifier).
+    #[cfg(unix)]
+    fn exit_with(code: i32) -> std::process::ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+        // wait()-style status bits: (code << 8) for a normal exit.
+        std::process::ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_update_subprocess_success() {
+        let result: std::io::Result<std::process::ExitStatus> = Ok(exit_with(0));
+        assert_eq!(
+            classify_update_subprocess(&result),
+            UpdateSubprocessOutcome::BinaryReplaced
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_update_subprocess_already_up_to_date() {
+        let result = Ok(exit_with(EXIT_CODE_ALREADY_UP_TO_DATE));
+        assert_eq!(
+            classify_update_subprocess(&result),
+            UpdateSubprocessOutcome::AlreadyUpToDate
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_update_subprocess_bundle_update_staged() {
+        let result = Ok(exit_with(EXIT_CODE_BUNDLE_UPDATE_STAGED));
+        assert_eq!(
+            classify_update_subprocess(&result),
+            UpdateSubprocessOutcome::BundleUpdateStaged
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_update_subprocess_arbitrary_failure() {
+        let result = Ok(exit_with(1));
+        assert_eq!(
+            classify_update_subprocess(&result),
+            UpdateSubprocessOutcome::Failed
+        );
+        let result = Ok(exit_with(42));
+        assert_eq!(
+            classify_update_subprocess(&result),
+            UpdateSubprocessOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn classify_update_subprocess_spawn_error() {
+        let result: std::io::Result<std::process::ExitStatus> =
+            Err(std::io::Error::new(std::io::ErrorKind::NotFound, "boom"));
+        assert_eq!(
+            classify_update_subprocess(&result),
+            UpdateSubprocessOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn macos_dmg_asset_name_strips_leading_v() {
+        assert_eq!(macos_dmg_asset_name("v0.2.49"), "Freenet-0.2.49.dmg");
+        assert_eq!(
+            macos_dmg_asset_name("v0.2.49-rc.1"),
+            "Freenet-0.2.49-rc.1.dmg"
+        );
+    }
+
+    #[test]
+    fn macos_dmg_asset_name_passes_through_bare_version() {
+        assert_eq!(macos_dmg_asset_name("0.2.49"), "Freenet-0.2.49.dmg");
+    }
+
+    #[test]
+    fn macos_dmg_asset_name_only_strips_one_leading_v() {
+        // A hypothetical tag like `vv0.2.49` (broken, but should not
+        // silently eat both leading chars): verify we strip just one.
+        assert_eq!(macos_dmg_asset_name("vv0.2.49"), "Freenet-v0.2.49.dmg");
+    }
 }

--- a/scripts/macos-bundle-updater.sh
+++ b/scripts/macos-bundle-updater.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # macOS DMG-swap updater. Launched detached by `freenet update` when the
 # running process is inside a .app bundle. Waits for the running Freenet
-# to exit (so /Applications/Freenet.app is no longer in use), atomically
-# swaps the bundle with the staged copy, then relaunches the new bundle.
+# to exit (so CURRENT_APP is no longer in use), atomically swaps the
+# bundle with the staged copy, then relaunches the new bundle.
 #
 # Usage (called from Rust):
 #   /bin/bash macos-bundle-updater.sh <current_app> <staged_app> <log_file>
@@ -10,15 +10,19 @@
 # where:
 #   current_app: absolute path of the installed bundle
 #                (e.g. /Applications/Freenet.app)
-#   staged_app:  absolute path of the newly-downloaded bundle
-#                (e.g. ~/Library/Caches/Freenet/staging/Freenet.app)
+#   staged_app:  absolute path of the new bundle, staged as a SIBLING of
+#                current_app so the final mv stays on one APFS volume
+#                (e.g. /Applications/.Freenet.app.staging.12345)
 #   log_file:    absolute path of a file to append diagnostic log lines
 #                to (e.g. ~/Library/Caches/Freenet/updater/updater.log)
 #
 # Exit codes:
 #   0  swap + relaunch succeeded
-#   1  swap failed; bundle has been restored from backup
-#   2  swap failed AND restore failed (user's install may be broken)
+#   1  refused to swap because Freenet was still running past deadline
+#      (the old bundle is untouched; user is not left without an install)
+#   2  swap failed; bundle has been restored from backup
+#   3  swap failed AND restore failed (user's install may be broken)
+#   4  swap succeeded but relaunch via /usr/bin/open failed
 
 set -u
 
@@ -35,25 +39,40 @@ if [[ -z "$CURRENT_APP" || -z "$STAGED_APP" ]]; then
     exit 1
 fi
 
-log "Updater started: CURRENT_APP=$CURRENT_APP STAGED_APP=$STAGED_APP"
+log "Updater started: CURRENT_APP=$CURRENT_APP STAGED_APP=$STAGED_APP pid=$$"
 
 # Wait for every freenet process whose executable lives under CURRENT_APP
 # to exit. Bounded deadline so a stuck child doesn't freeze the update
-# indefinitely. The regex matches both the shell wrapper CFBundleExecutable
-# (/.../Freenet.app/Contents/MacOS/Freenet) and the inner binary
-# (/.../Freenet.app/Contents/MacOS/freenet-bin), but NOT unrelated binaries
-# that happen to contain "Freenet" in their path.
+# indefinitely.
+#
+# The pattern uses pgrep's -f (match full command line) and ERE syntax.
+# Regex metacharacters in CURRENT_APP are escaped so a path like
+# `/Applications (Beta)/Freenet.app` doesn't break grouping.
+escape_ere() {
+    # Escape ERE metacharacters: \ . * + ? | ( ) [ ] { } ^ $
+    printf '%s' "$1" | sed 's/[][\\.*+?|(){}^$]/\\&/g'
+}
+CURRENT_APP_RE="$(escape_ere "$CURRENT_APP")"
+
 deadline=$(( $(date +%s) + 120 ))
 while (( $(date +%s) < deadline )); do
-    if ! pgrep -f "^${CURRENT_APP}/Contents/MacOS/" > /dev/null 2>&1; then
+    if ! pgrep -f "^${CURRENT_APP_RE}/Contents/MacOS/" > /dev/null 2>&1; then
         log "All Freenet processes under $CURRENT_APP have exited"
         break
     fi
     sleep 1
 done
 
-if pgrep -f "^${CURRENT_APP}/Contents/MacOS/" > /dev/null 2>&1; then
-    log "WARNING: timeout waiting for Freenet to exit; proceeding with swap anyway"
+if pgrep -f "^${CURRENT_APP_RE}/Contents/MacOS/" > /dev/null 2>&1; then
+    # REFUSE to swap. Historically this script would proceed anyway, but
+    # mv'ing the old bundle aside + later rm'ing it while a descendant
+    # still had libraries mmap'd from it would SEGV the running process
+    # (skeptical review M2). Better to leave the install untouched and
+    # let the next update attempt succeed once Freenet has exited.
+    log "ERROR: timeout waiting for Freenet to exit; aborting swap to avoid crashing the running instance"
+    # Clean up the staged bundle so the staging area doesn't accumulate.
+    rm -rf "$STAGED_APP" 2>>"$LOG_FILE" || true
+    exit 1
 fi
 
 if [[ ! -d "$STAGED_APP" ]]; then
@@ -61,27 +80,29 @@ if [[ ! -d "$STAGED_APP" ]]; then
     exit 1
 fi
 
-# Move the old bundle aside (atomic rename within the same filesystem).
-# Name includes a timestamp so concurrent updates don't collide, though
-# we expect at most one updater at a time.
+# Move the old bundle aside. Same-volume rename (APFS within the
+# /Applications tree) is atomic on the kernel side.
 BACKUP="${CURRENT_APP}.oldupdate.$$"
 if [[ -e "$CURRENT_APP" ]]; then
     if ! mv "$CURRENT_APP" "$BACKUP" 2>>"$LOG_FILE"; then
         log "ERROR: failed to move current bundle aside; aborting"
-        exit 1
+        rm -rf "$STAGED_APP" 2>>"$LOG_FILE" || true
+        exit 2
     fi
 fi
 
-# Move the staged bundle into place.
+# Move the staged bundle into place. Because STAGED_APP is a sibling of
+# CURRENT_APP (per bundle_staging_path in update.rs), both operands are
+# on the same APFS volume and rename(2) completes atomically.
 if ! mv "$STAGED_APP" "$CURRENT_APP" 2>>"$LOG_FILE"; then
     log "ERROR: failed to move staged bundle into place; attempting rollback"
     if [[ -d "$BACKUP" ]]; then
         if ! mv "$BACKUP" "$CURRENT_APP" 2>>"$LOG_FILE"; then
             log "CRITICAL: failed to restore backup; bundle is at $BACKUP"
-            exit 2
+            exit 3
         fi
     fi
-    exit 1
+    exit 2
 fi
 
 # Success. Remove the backup.
@@ -95,6 +116,10 @@ log "Bundle swap complete. Launching new bundle: $CURRENT_APP"
 # approval check, Gatekeeper re-scan of the stapled notarization, NSApp
 # setup, and (for LSUIElement apps) menu-bar status item registration.
 # This is why we can't just exec the inner binary directly.
-/usr/bin/open "$CURRENT_APP" 2>>"$LOG_FILE"
+if ! /usr/bin/open "$CURRENT_APP" 2>>"$LOG_FILE"; then
+    log "ERROR: /usr/bin/open failed; new bundle is installed but not running"
+    exit 4
+fi
 
 log "Updater complete"
+exit 0


### PR DESCRIPTION
Follow-up to #3930 which merged while the post-review fix-up was being written. This PR lands the convergent findings from all four internal reviewers plus Codex.

## Problem

PR #3930 landed the DMG-swap auto-update but the review cycle surfaced a set of correctness and safety issues that reviewers converged on across code-first, testing, skeptical, big-picture, and Codex. Several are user-visible failure modes (bricked signed bundle, non-atomic cross-volume swap, concurrent-update race).

## Changes

### Exit code (skeptical H4)
- `EXIT_CODE_BUNDLE_UPDATE_STAGED` changed from 3 to **44**. Value 3 was already used by `freenet service status` for "service not running". 44 follows the existing 42/43 convention in service.rs.

### Err-path safety (Codex P1, code-first Discrepancy #1, big-picture #1)
- On macOS bundle installs, return `Ok(())` instead of falling through to in-place binary replacement when DMG-swap fails. Overwriting `Contents/MacOS/freenet-bin` inside a signed bundle invalidates the code signature and bricks the app.
- Require SHA256 checksum verification for bundle updates. Missing-checksum no longer silently installs an unverified DMG (code-first #7, skeptical M7).

### Atomicity (skeptical H2)
- Stage the new bundle as a **sibling** of the target (e.g. `/Applications/.Freenet.app.staging.<pid>`) rather than in `~/Library/Caches/`. The cache and `/Applications` can live on different APFS volumes; cross-volume `rename(2)` returns EXDEV and `mv` falls back to cp+rm which isn't crash-safe.

### Concurrent-update safety (skeptical H1)
- Acquire `flock(LOCK_EX | LOCK_NB)` on a lockfile before staging. Second concurrent updater fails fast rather than stomping the first's staging dir.

### Detachment (skeptical M5)
- Add `setsid()` before `setpgid(0,0)` so SIGHUP from a parent terminal no longer kills the updater mid-swap.

### Resource cleanup (code-first #2, skeptical H3)
- `MountDetachOnDrop` scope guard: hdiutil detach runs on every exit path including `?` early-returns from `ditto` spawn failure.

### Legacy migration (Codex P2)
- First-run treats the legacy `org.freenet.node.plist` (install.sh era) as "already enabled", preventing a second plist from being layered on top. Previously migrating users got the duplicate-agent warning AND a freshly-created second plist.

### Updater script safety
- Refuse to swap past the 120s deadline (skeptical M2). Previously the script swapped anyway and rm'd the backup, which could SEGV a still-running process whose libraries were mmap'd from the old inode.
- Propagate `/usr/bin/open` exit status as new exit code 4 (code-first #3). Previously silent relaunch failures.
- Escape ERE metacharacters in `CURRENT_APP` before `pgrep -f` (code-first #6, skeptical M1).

### Observability (big-picture #2)
- `tracing::info!` on successful DMG-staging.

### Testing (testing review critical + big-picture #6)
- Extract `classify_update_subprocess` as a pure function with exhaustive tests over {Ok(0), Ok(2), Ok(44), Ok(1), Ok(42), Err}. Catches regressions in the exit-code contract.
- Extract `macos_dmg_asset_name` as a pure function with tests for tag formats (`v`-prefixed, bare, typo). Now uses `strip_prefix` to avoid silent double-stripping.

## Testing

- `cargo fmt` + `cargo clippy -- -D warnings` clean
- **68 unit tests passing** (was 60 at #3930 merge)
- Manual macOS end-to-end verification still deferred to first 0.2.49 → 0.2.50 release, per the deployment rule

## Related

- Follows up #3930 (merged). Addresses every "must-fix" finding from the four internal reviewers plus Codex.

[AI-assisted - Claude]