### PR TITLE
refactor(ops): relay SUBSCRIBE task-per-tx (slice A) — #1454 phase 5 follow-up

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -41,8 +41,22 @@ paths:
 > `source_addr.is_some()` AND `!has_put_op(id)` AND the payload size
 > would not upgrade to streaming on forward); GC speculative retries,
 > client-initiated loopback (`source_addr.is_none()`), and streaming
-> variants still go through legacy. Slices B (streaming variants) and
-> C (legacy arm cleanup) follow.
+> variants still go through legacy. Phase 5 follow-up slice A (PR
+> #3932) migrated fresh inbound relay `SubscribeMsg::Request` to
+> `operations/subscribe/op_ctx_task.rs::start_relay_subscribe`
+> (gated on `source_addr.is_some()` AND `!has_subscribe_op(id)`);
+> renewals, PUT sub-op subscribes, executor auto-subscribe,
+> GC-spawned retries that pre-register a `SubscribeOp`,
+> `SubscribeMsg::Unsubscribe`, and `SubscribeMsg::ForwardingAck` all
+> stay on legacy. The driver caps relay-hop retries at 1 (originator
+> owns cross-peer retry), reuses `incoming_tx` end-to-end, omits
+> `ForwardingAck` emission, and calls `register_downstream_subscriber`
+> on BOTH local-hit and relayed-Subscribed paths — but DELIBERATELY
+> omits `ring.subscribe` / `complete_subscription_request` /
+> `announce_contract_hosted` on the relayed path (relay is not itself
+> a subscriber; prevents the #3763 subscription-storm feedback loop).
+> Slices B (streaming variants for GET/PUT/UPDATE) and C (legacy arm
+> cleanup) follow.
 >
 > Task-per-tx drivers have their own invariants documented in the
 > `op_ctx_task.rs` module doc and in `OpCtx::send_and_await`'s rustdoc.

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -53,22 +53,29 @@ Each file is a state machine:
 
 Plus task-per-transaction drivers from #1454 Phase 2b onwards:
   subscribe/op_ctx_task.rs → client-initiated SUBSCRIBE driver
+                             + fresh inbound relay SUBSCRIBE driver
+                             (Phase 5 follow-up slice A, `start_relay_subscribe`)
   put/op_ctx_task.rs       → client-initiated PUT driver (Phase 3a)
+                             + fresh inbound non-streaming relay PUT
+                             driver (Phase 5 follow-up slice A, PR #3917,
+                             `start_relay_put`)
   get/op_ctx_task.rs       → client-initiated GET driver (Phase 3b)
                              + fresh inbound relay GET driver (Phase 5,
                              PR #3896, `start_relay_get`)
   update/op_ctx_task.rs    → client-initiated UPDATE driver (Phase 4,
                              fire-and-forget) + fresh inbound non-streaming
                              relay UPDATE drivers (Phase 5 follow-up slice
-                             A: `start_relay_request_update`,
+                             A, PR #3910: `start_relay_request_update`,
                              `start_relay_broadcast_to`)
-    Client + relay GET / UPDATE share the per-node dedup gate
-    (`active_relay_get_txs`, `active_relay_update_txs`) and the
-    `Relay*InflightGuard` RAII pattern. Streaming UPDATE relay variants
+    All four relay drivers share the per-node dedup gate pattern
+    (`active_relay_{get,update,put,subscribe}_txs`) and the
+    `Relay*InflightGuard` RAII. Streaming UPDATE relay variants
     (`RequestUpdateStreaming`, `BroadcastToStreaming`) and the
-    deprecated `Broadcasting` variant remain on the legacy path
-    pending slice B. PUT and SUBSCRIBE relay paths still go through
-    the legacy state machine.
+    deprecated `Broadcasting` wire variant, plus PUT streaming
+    variants, remain on legacy pending slice B. SUBSCRIBE has no
+    streaming variants but renewals, PUT sub-op subscribes, executor
+    auto-subscribe paths, `Unsubscribe`, and `ForwardingAck` all stay
+    on the legacy state machine.
 ```
 
 ## Module Map

--- a/crates/core/src/bin/commands/service.rs
+++ b/crates/core/src/bin/commands/service.rs
@@ -489,6 +489,8 @@ fn launch_agent_plist_has_expected_leader(plist: &Path, expected_leader: &str) -
 /// never loaded it" breakages are diagnosable after the fact.
 #[cfg(target_os = "macos")]
 fn launchctl_bootstrap(plist: &Path) {
+    // SAFETY: libc::getuid is always safe; it returns the current user
+    // ID without touching user-provided pointers.
     let uid = unsafe { libc::getuid() };
     let target = format!("gui/{uid}");
     match std::process::Command::new("launchctl")
@@ -517,6 +519,8 @@ fn launchctl_bootstrap(plist: &Path) {
 
 #[cfg(target_os = "macos")]
 fn launchctl_bootout(plist: &Path) {
+    // SAFETY: libc::getuid is always safe; it returns the current user
+    // ID without touching user-provided pointers.
     let uid = unsafe { libc::getuid() };
     let target = format!("gui/{uid}");
     match std::process::Command::new("launchctl")
@@ -1012,7 +1016,7 @@ fn run_wrapper(version: &str) -> Result<()> {
         // Wrapper loop runs on a background thread
         let loop_handle = std::thread::spawn(move || {
             let result = run_wrapper_loop(&log_dir_clone, Some((&action_rx, &status_tx)));
-            let _ = cleanup_tx.send(());
+            cleanup_tx.send(()).ok();
             result
         });
 

--- a/crates/core/src/bin/commands/tray.rs
+++ b/crates/core/src/bin/commands/tray.rs
@@ -381,10 +381,12 @@ mod platform {
             let s = compute_menu_state(status);
             self.status_item
                 .set_text(format!("Status: {}", s.status_text));
-            let _ = self._tray.set_tooltip(Some(format!(
-                "Freenet {} - {}",
-                self.version, s.status_text
-            )));
+            self._tray
+                .set_tooltip(Some(format!(
+                    "Freenet {} - {}",
+                    self.version, s.status_text
+                )))
+                .ok();
             self.stop_item.set_enabled(s.stop_enabled);
             self.start_item.set_enabled(s.start_enabled);
             self.restart_item.set_enabled(s.restart_enabled);
@@ -567,7 +569,7 @@ mod platform {
                         // long `freenet update` that the user triggered via
                         // "Check for Updates"). Waiting is the right trade
                         // because the alternative is a guaranteed orphan.
-                        let _ = cleanup_done_rx.recv();
+                        cleanup_done_rx.recv().ok();
                         *control_flow = ControlFlow::Exit;
                         return;
                     }
@@ -582,7 +584,7 @@ mod platform {
                     std::thread::sleep(Duration::from_secs(1));
                     action_tx.send(TrayAction::Quit).ok();
                     // Same rationale as the Quit handler above.
-                    let _ = cleanup_done_rx.recv();
+                    cleanup_done_rx.recv().ok();
                     *control_flow = ControlFlow::Exit;
                 }
             }

--- a/crates/core/src/bin/commands/update.rs
+++ b/crates/core/src/bin/commands/update.rs
@@ -1413,6 +1413,9 @@ fn acquire_update_lock() -> Result<UpdateLock> {
         .context("Failed to open update lockfile")?;
     // flock with LOCK_EX | LOCK_NB: fail fast instead of queueing. A
     // parallel updater should bail rather than serialize behind us.
+    // SAFETY: `file.as_raw_fd()` returns an owned, open file descriptor
+    // for the duration of this function; libc::flock only consults the
+    // fd and the constant flag bits, with no pointer arguments.
     let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
     if rc != 0 {
         anyhow::bail!(
@@ -1440,7 +1443,7 @@ struct MountDetachOnDrop {
 #[cfg(target_os = "macos")]
 impl Drop for MountDetachOnDrop {
     fn drop(&mut self) {
-        let _ = hdiutil_detach(&self.mount_point);
+        hdiutil_detach(&self.mount_point).ok();
     }
 }
 
@@ -1521,6 +1524,12 @@ fn spawn_detached_updater(script: &Path, current_app: &Path, staged_app: &Path) 
     // `setpgid(0, 0)` is redundant but cheap belt-and-braces. Without
     // `setsid`, a terminal-parent session delivers SIGHUP to all
     // descendants on close, killing the updater mid-swap (skeptical M5).
+    //
+    // SAFETY: `pre_exec` is unsafe because the closure runs between
+    // fork and exec, where only async-signal-safe functions are
+    // allowed. `libc::setsid` and `libc::setpgid(0, 0)` are both
+    // async-signal-safe per POSIX and do not allocate or touch
+    // user-provided pointers.
     unsafe {
         cmd.pre_exec(|| {
             if libc::setsid() == -1 {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -110,6 +110,15 @@ pub mod dev_tool {
     #[cfg(any(test, feature = "testing"))]
     pub use crate::operations::put::op_ctx_task::RELAY_PUT_DRIVER_CALL_COUNT;
 
+    // #1454 Phase 5 follow-up slice A (#3932) — test hook to verify
+    // the dispatch gate in `handle_pure_network_message_v1` actually
+    // routes fresh inbound relay SUBSCRIBEs through the task-per-tx
+    // driver (vs. the legacy `handle_op_request` fallthrough used
+    // for renewals, PUT sub-op subscribes, executor auto-subscribe,
+    // and GC-spawned retries).
+    #[cfg(any(test, feature = "testing"))]
+    pub use crate::operations::subscribe::op_ctx_task::RELAY_SUBSCRIBE_DRIVER_CALL_COUNT;
+
     // Re-export state verification for telemetry-based consistency analysis
     pub use crate::tracing::state_verifier::{StateAnomaly, StateVerifier, VerificationReport};
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1460,27 +1460,53 @@ where
                     is_renewal,
                 } = op
                 {
-                    if let Some(upstream_addr) = source_addr {
-                        if !op_manager.has_subscribe_op(id) {
-                            if let Err(err) = subscribe::op_ctx_task::start_relay_subscribe(
-                                op_manager.clone(),
-                                *id,
-                                *instance_id,
-                                *htl,
-                                visited.clone(),
-                                *is_renewal,
-                                upstream_addr,
-                            )
-                            .await
-                            {
-                                tracing::error!(
-                                    tx = %id,
-                                    %instance_id,
-                                    error = %err,
-                                    "SUBSCRIBE relay dispatch: start_relay_subscribe failed"
-                                );
+                    // Renewals (`is_renewal=true`) fall through to legacy
+                    // so the relay still emits `SubscribeMsg::ForwardingAck`
+                    // back to the renewal originator. The
+                    // `ring.rs::connection_maintenance` renewal loop
+                    // registers a `SubscribeOp` locally, and its GC retry
+                    // selector at `op_state_manager.rs:2094` uses
+                    // `ack_received` to pick the retry base — without the
+                    // ack the originator retries on `ACK_TIMEOUT*(n+1)`
+                    // instead of `PROGRESS_TIMEOUT + ACK_TIMEOUT*n`,
+                    // which over the ~2 min renewal cycle compounds into
+                    // the #3763 subscription-storm feedback loop.
+                    // Driver-side ack emission would race the reply on
+                    // the upstream's capacity-1 `pending_op_results` slot
+                    // for task-per-tx originators, so slice A keeps
+                    // renewals on legacy.
+                    //
+                    // Non-renewal SUBSCRIBEs come from: (a) the Phase 2b
+                    // client-init driver, which uses `pending_op_results`
+                    // and would classify a `ForwardingAck` as
+                    // `ReplyClass::Unexpected` anyway; (b) PUT sub-op
+                    // subscribes and parent-op child subscribes —
+                    // one-shot paths with bounded `MAX_RETRIES` so the
+                    // ACK-timer shortening is an accepted slice-A
+                    // amplification ceiling.
+                    if !*is_renewal {
+                        if let Some(upstream_addr) = source_addr {
+                            if !op_manager.has_subscribe_op(id) {
+                                if let Err(err) = subscribe::op_ctx_task::start_relay_subscribe(
+                                    op_manager.clone(),
+                                    *id,
+                                    *instance_id,
+                                    *htl,
+                                    visited.clone(),
+                                    *is_renewal,
+                                    upstream_addr,
+                                )
+                                .await
+                                {
+                                    tracing::error!(
+                                        tx = %id,
+                                        %instance_id,
+                                        error = %err,
+                                        "SUBSCRIBE relay dispatch: start_relay_subscribe failed"
+                                    );
+                                }
+                                return Ok(None);
                             }
-                            return Ok(None);
                         }
                     }
                 }
@@ -3976,6 +4002,29 @@ mod tests {
                 "SUBSCRIBE relay dispatch must be guarded by has_subscribe_op — \
                  renewals, PUT sub-ops, and GC-spawned retries that pre-register \
                  a SubscribeOp must fall through to legacy."
+            );
+        }
+
+        #[test]
+        fn subscribe_branch_falls_through_on_renewal() {
+            const SOURCE: &str = include_str!("node.rs");
+            let anchor = "NetMessageV1::Subscribe(ref op) => {";
+            let branch_start = SOURCE.find(anchor).expect("SUBSCRIBE branch not found");
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<subscribe::SubscribeOp, _>")
+                .expect("SUBSCRIBE branch no longer calls handle_op_request")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+            // Renewals MUST stay on legacy — the renewal originator's GC
+            // retry selector uses `ack_received` and the driver does not
+            // emit `SubscribeMsg::ForwardingAck`. Falling through to
+            // legacy keeps the ack emission alive for renewals.
+            assert!(
+                window.contains("if !*is_renewal"),
+                "SUBSCRIBE relay dispatch must skip `is_renewal=true` \
+                 requests so renewals still receive `ForwardingAck` from \
+                 the relay. Dropping the ack on the ~2 min renewal cycle \
+                 reopens the #3763 subscription-storm feedback loop."
             );
         }
 

--- a/crates/core/src/node.rs
+++ b/crates/core/src/node.rs
@@ -1429,6 +1429,62 @@ where
                     return Ok(None);
                 }
 
+                // #1454 phase 5 follow-up (slice A): relay SUBSCRIBE
+                // task-per-tx dispatch.
+                //
+                // For true relay hops (source_addr.is_some() AND incoming
+                // variant is SubscribeMsg::Request AND no SubscribeOp
+                // already exists in OpManager for this tx), spawn the
+                // relay driver and return. The driver owns local-hit
+                // response + single downstream forward + upstream
+                // bubble-up in its task locals.
+                //
+                // source_addr.is_none() (originator loop-back from the
+                // phase-2b client-init driver's send_to_and_await) falls
+                // through to legacy. The client driver never relies on
+                // a Request-echo — it awaits Response — so the
+                // `SubscribeMsg::Response` bypass above handles the
+                // originator reply.
+                //
+                // Existing SubscribeOp means a renewal, PUT sub-op, or
+                // GC-spawned retry already registered state in the
+                // DashMap — those paths must stay on legacy.
+                //
+                // ForwardingAck / Unsubscribe never match the Request
+                // arm so they flow to legacy naturally.
+                if let subscribe::SubscribeMsg::Request {
+                    id,
+                    instance_id,
+                    htl,
+                    visited,
+                    is_renewal,
+                } = op
+                {
+                    if let Some(upstream_addr) = source_addr {
+                        if !op_manager.has_subscribe_op(id) {
+                            if let Err(err) = subscribe::op_ctx_task::start_relay_subscribe(
+                                op_manager.clone(),
+                                *id,
+                                *instance_id,
+                                *htl,
+                                visited.clone(),
+                                *is_renewal,
+                                upstream_addr,
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    tx = %id,
+                                    %instance_id,
+                                    error = %err,
+                                    "SUBSCRIBE relay dispatch: start_relay_subscribe failed"
+                                );
+                            }
+                            return Ok(None);
+                        }
+                    }
+                }
+
                 let op_result = handle_op_request::<subscribe::SubscribeOp, _>(
                     &op_manager,
                     &mut conn_manager,
@@ -3873,6 +3929,79 @@ mod tests {
                 !window.contains("put::PutMsg::RequestStreaming {"),
                 "PUT branch appears to dispatch RequestStreaming through the \
                  relay driver. Slice A keeps streaming on the legacy path."
+            );
+        }
+
+        // ── Relay SUBSCRIBE dispatch structural pin tests (#1454 phase 5
+        // follow-up slice A). Mirror of the PUT / UPDATE pin tests.
+
+        #[test]
+        fn subscribe_branch_dispatches_relay_driver() {
+            const SOURCE: &str = include_str!("node.rs");
+            let anchor = "NetMessageV1::Subscribe(ref op) => {";
+            let branch_start = SOURCE.find(anchor).expect(
+                "SUBSCRIBE branch of handle_pure_network_message_v1 not found; \
+                 the match arm has been renamed or moved — update this guard",
+            );
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<subscribe::SubscribeOp, _>")
+                .expect("SUBSCRIBE branch no longer calls handle_op_request — update guard")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+            assert!(
+                window.contains("start_relay_subscribe("),
+                "SUBSCRIBE branch no longer calls start_relay_subscribe for relay \
+                 dispatch. #1454 phase-5 slice A SUBSCRIBE relay dispatch was \
+                 removed — restore it."
+            );
+        }
+
+        #[test]
+        fn subscribe_branch_dispatch_gates_on_source_and_existing_op() {
+            const SOURCE: &str = include_str!("node.rs");
+            let anchor = "NetMessageV1::Subscribe(ref op) => {";
+            let branch_start = SOURCE.find(anchor).expect("SUBSCRIBE branch not found");
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<subscribe::SubscribeOp, _>")
+                .expect("SUBSCRIBE branch no longer calls handle_op_request")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+            assert!(
+                window.contains("source_addr"),
+                "SUBSCRIBE relay dispatch must be gated on source_addr — internal \
+                 / originator callers (source_addr.is_none()) must fall through."
+            );
+            assert!(
+                window.contains("has_subscribe_op"),
+                "SUBSCRIBE relay dispatch must be guarded by has_subscribe_op — \
+                 renewals, PUT sub-ops, and GC-spawned retries that pre-register \
+                 a SubscribeOp must fall through to legacy."
+            );
+        }
+
+        #[test]
+        fn subscribe_branch_only_dispatches_request_variant() {
+            const SOURCE: &str = include_str!("node.rs");
+            let anchor = "NetMessageV1::Subscribe(ref op) => {";
+            let branch_start = SOURCE.find(anchor).expect("SUBSCRIBE branch not found");
+            let window_end = SOURCE[branch_start..]
+                .find("handle_op_request::<subscribe::SubscribeOp, _>")
+                .expect("SUBSCRIBE branch no longer calls handle_op_request")
+                + branch_start;
+            let window = &SOURCE[branch_start..window_end];
+            // Driver site should only destructure the Request variant.
+            // Unsubscribe/ForwardingAck stay on legacy — binding them
+            // into the relay dispatch would misroute fire-and-forget
+            // cleanup traffic.
+            assert!(
+                !window.contains("SubscribeMsg::Unsubscribe {"),
+                "SUBSCRIBE dispatch must NOT destructure Unsubscribe variant \
+                 for relay driver — fire-and-forget cleanup stays on legacy."
+            );
+            assert!(
+                !window.contains("SubscribeMsg::ForwardingAck {"),
+                "SUBSCRIBE dispatch must NOT destructure ForwardingAck variant \
+                 for relay driver — fire-and-forget ack stays on legacy."
             );
         }
     }

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -358,6 +358,15 @@ pub(crate) struct OpManager {
     /// relay driver — prevents GC-spawned re-entries and routing-bloom
     /// false-positive retransmissions from spawning redundant drivers.
     pub(crate) active_relay_put_txs: Arc<DashSet<Transaction>>,
+    /// Set of transactions currently being driven by a relay SUBSCRIBE
+    /// task-per-tx driver on this node. Same role as
+    /// `active_relay_get_txs` but for SUBSCRIBE relay (#1454 phase 5
+    /// follow-up slice A). SUBSCRIBE relay has req/response semantics
+    /// like GET/PUT but forwards once — no per-hop retry — because the
+    /// client-init driver (Phase 2b) owns cross-peer retry. The dedup
+    /// gate rejects duplicate inbound `SubscribeMsg::Request` for a tx
+    /// that already has a live relay driver.
+    pub(crate) active_relay_subscribe_txs: Arc<DashSet<Transaction>>,
 }
 
 impl Clone for OpManager {
@@ -388,6 +397,7 @@ impl Clone for OpManager {
             active_relay_get_txs: self.active_relay_get_txs.clone(),
             active_relay_update_txs: self.active_relay_update_txs.clone(),
             active_relay_put_txs: self.active_relay_put_txs.clone(),
+            active_relay_subscribe_txs: self.active_relay_subscribe_txs.clone(),
         }
     }
 }
@@ -431,6 +441,7 @@ impl OpManager {
         let active_relay_get_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
         let active_relay_update_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
         let active_relay_put_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
+        let active_relay_subscribe_txs: Arc<DashSet<Transaction>> = Arc::new(DashSet::new());
 
         task_monitor.register(
             "garbage_cleanup",
@@ -451,6 +462,7 @@ impl OpManager {
                     active_relay_get_txs.clone(),
                     active_relay_update_txs.clone(),
                     active_relay_put_txs.clone(),
+                    active_relay_subscribe_txs.clone(),
                 )
                 .instrument(garbage_span),
             ),
@@ -522,6 +534,7 @@ impl OpManager {
             active_relay_get_txs,
             active_relay_update_txs,
             active_relay_put_txs,
+            active_relay_subscribe_txs,
         })
     }
 
@@ -1052,6 +1065,19 @@ impl OpManager {
     /// legacy `handle_op_request` path).
     pub fn has_put_op(&self, id: &Transaction) -> bool {
         self.ops.put.contains_key(id)
+    }
+
+    /// Returns `true` if a `SubscribeOp` is currently registered for this
+    /// transaction in `OpManager.ops.subscribe`.
+    ///
+    /// Same role as `has_get_op` but for the relay SUBSCRIBE dispatch gate
+    /// (#1454 phase 5 follow-up slice A). Used by `node.rs` to distinguish
+    /// a fresh inbound relay SUBSCRIBE (no existing op → spawn the
+    /// task-per-tx driver) from a renewal, PUT sub-op, or GC-spawned retry
+    /// (existing op → fall through to the legacy `handle_op_request`
+    /// path).
+    pub fn has_subscribe_op(&self, id: &Transaction) -> bool {
+        self.ops.subscribe.contains_key(id)
     }
 
     pub fn completed(&self, id: Transaction) {
@@ -1699,6 +1725,7 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
     active_relay_get_txs: Arc<DashSet<Transaction>>,
     active_relay_update_txs: Arc<DashSet<Transaction>>,
     active_relay_put_txs: Arc<DashSet<Transaction>>,
+    active_relay_subscribe_txs: Arc<DashSet<Transaction>>,
 ) {
     const CLEANUP_INTERVAL: Duration = Duration::from_secs(5);
     /// How often to clean up stale contract_waiters entries (every N ticks).
@@ -1775,6 +1802,19 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         crate::operations::put::op_ctx_task::RELAY_PUT_DEDUP_REJECTS
                             .load(Ordering::Relaxed);
                     let relay_put_active_txs = active_relay_put_txs.len();
+                    let relay_subscribe_inflight =
+                        crate::operations::subscribe::op_ctx_task::RELAY_SUBSCRIBE_INFLIGHT
+                            .load(Ordering::Relaxed);
+                    let relay_subscribe_spawned =
+                        crate::operations::subscribe::op_ctx_task::RELAY_SUBSCRIBE_SPAWNED_TOTAL
+                            .load(Ordering::Relaxed);
+                    let relay_subscribe_completed =
+                        crate::operations::subscribe::op_ctx_task::RELAY_SUBSCRIBE_COMPLETED_TOTAL
+                            .load(Ordering::Relaxed);
+                    let relay_subscribe_dedup_rejects =
+                        crate::operations::subscribe::op_ctx_task::RELAY_SUBSCRIBE_DEDUP_REJECTS
+                            .load(Ordering::Relaxed);
+                    let relay_subscribe_active_txs = active_relay_subscribe_txs.len();
                     tracing::info!(
                         target: "memory_stats",
                         tick = tick_count,
@@ -1807,6 +1847,11 @@ async fn garbage_cleanup_task<ER: NetEventRegister>(
                         relay_put_completed = relay_put_completed,
                         relay_put_dedup_rejects = relay_put_dedup_rejects,
                         relay_put_active_txs = relay_put_active_txs,
+                        relay_subscribe_inflight = relay_subscribe_inflight,
+                        relay_subscribe_spawned = relay_subscribe_spawned,
+                        relay_subscribe_completed = relay_subscribe_completed,
+                        relay_subscribe_dedup_rejects = relay_subscribe_dedup_rejects,
+                        relay_subscribe_active_txs = relay_subscribe_active_txs,
                         "memory stats"
                     );
                 }

--- a/crates/core/src/operations/subscribe.rs
+++ b/crates/core/src/operations/subscribe.rs
@@ -42,7 +42,7 @@ const MIN_RETRY_HTL: usize = 3;
 
 /// Timeout for waiting on contract storage notification.
 /// Used when a subscription arrives before the contract has been propagated via PUT.
-const CONTRACT_WAIT_TIMEOUT_MS: u64 = 2_000;
+pub(super) const CONTRACT_WAIT_TIMEOUT_MS: u64 = 2_000;
 
 /// Wait for a contract to become available, using channel-based notification.
 ///
@@ -53,7 +53,7 @@ const CONTRACT_WAIT_TIMEOUT_MS: u64 = 2_000;
 /// 3. Check again (handles race between step 1 and 2)
 /// 4. Wait for notification or timeout
 /// 5. Final verification of actual state
-async fn wait_for_contract_with_timeout(
+pub(super) async fn wait_for_contract_with_timeout(
     op_manager: &OpManager,
     instance_id: ContractInstanceId,
     timeout_ms: u64,
@@ -2248,7 +2248,7 @@ mod tests;
 
 /// Task-per-transaction client-initiated SUBSCRIBE path (#1454 Phase 2b).
 /// First production consumer of `OpCtx::send_and_await`.
-mod op_ctx_task;
+pub(crate) mod op_ctx_task;
 
 pub(crate) use op_ctx_task::{run_client_subscribe, start_client_subscribe};
 

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -833,8 +833,32 @@ pub(crate) async fn start_relay_subscribe(
             %instance_id,
             %upstream_addr,
             phase = "relay_subscribe_dedup_reject",
-            "SUBSCRIBE relay (task-per-tx): duplicate Request for in-flight tx, dropping"
+            "SUBSCRIBE relay (task-per-tx): duplicate Request for in-flight tx, replying NotFound"
         );
+        // Emit an immediate `NotFound` back to the rejected upstream so
+        // its `send_to_and_await` returns fast instead of stalling the
+        // full `OPERATION_TTL` (60 s). Silently dropping the duplicate
+        // loses the upstream's retry budget and produces a spurious
+        // "this contract is unreachable" verdict even when the winning
+        // driver fulfills the subscription. The reply uses a fresh
+        // `OpCtx` scoped to `incoming_tx` — the fire-and-forget send
+        // does not touch the winning driver's `pending_op_results`
+        // slot (that slot is keyed on the attempt_tx the WINNER
+        // forwarded downstream, not on `incoming_tx` at this node).
+        let response = NetMessage::from(SubscribeMsg::Response {
+            id: incoming_tx,
+            instance_id,
+            result: SubscribeMsgResult::NotFound,
+        });
+        let mut ctx = op_manager.op_ctx(incoming_tx);
+        if let Err(err) = ctx.send_fire_and_forget(upstream_addr, response).await {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %upstream_addr,
+                error = %err,
+                "SUBSCRIBE relay (task-per-tx): dedup-reject NotFound send failed"
+            );
+        }
         return Ok(());
     }
 
@@ -1626,6 +1650,35 @@ mod tests {
         assert!(
             insert_pos < spawn_pos,
             "active_relay_subscribe_txs.insert MUST happen before GlobalExecutor::spawn"
+        );
+    }
+
+    /// Pin: dedup rejection must emit `SubscribeMsgResult::NotFound`
+    /// back to the rejected upstream. Silently dropping the duplicate
+    /// request stalls the upstream's `send_to_and_await` for the full
+    /// `OPERATION_TTL` (60 s), wasting its retry budget.
+    #[test]
+    fn dedup_rejection_emits_not_found_reply() {
+        let src = include_str!("op_ctx_task.rs");
+        let relay = relay_section(src);
+        let after_insert = relay
+            .split("active_relay_subscribe_txs.insert(incoming_tx)")
+            .nth(1)
+            .expect("dedup insert site not found");
+        // Look at the body between the insert and the early return.
+        let window_end = after_insert
+            .find("return Ok(())")
+            .expect("early return after dedup-reject not found");
+        let window = &after_insert[..window_end];
+        assert!(
+            window.contains("SubscribeMsgResult::NotFound"),
+            "dedup-reject path must emit SubscribeMsgResult::NotFound to \
+             the rejected upstream so its send_to_and_await returns fast"
+        );
+        assert!(
+            window.contains("send_fire_and_forget"),
+            "dedup-reject NotFound must be sent via send_fire_and_forget \
+             (not send_to_and_await — upstream's own waiter owns its slot)"
         );
     }
 

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -862,6 +862,18 @@ pub(crate) async fn start_relay_subscribe(
         return Ok(());
     }
 
+    // Construct the guard IMMEDIATELY after `insert` so a panic in any
+    // intervening work (fmt-allocating logs, future OOM) cannot leak
+    // the dedup-set entry. The guard's Drop clears the entry; without
+    // the guard, there is no TTL and no recovery path. (Review M3,
+    // skeptical #3932.)
+    RELAY_SUBSCRIBE_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RELAY_SUBSCRIBE_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let guard = RelaySubscribeInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
     tracing::debug!(
         tx = %incoming_tx,
         %instance_id,
@@ -871,16 +883,6 @@ pub(crate) async fn start_relay_subscribe(
         phase = "relay_subscribe_start",
         "SUBSCRIBE relay (task-per-tx): spawning driver"
     );
-
-    // Construct guard + bump counters BEFORE spawn so the dedup-set
-    // entry is paired with a Drop even if the spawned future is dropped
-    // before its first poll. Same reasoning as GET/PUT/UPDATE.
-    RELAY_SUBSCRIBE_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    RELAY_SUBSCRIBE_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let guard = RelaySubscribeInflightGuard {
-        op_manager: op_manager.clone(),
-        incoming_tx,
-    };
 
     GlobalExecutor::spawn(run_relay_subscribe(
         guard,
@@ -954,6 +956,34 @@ async fn run_relay_subscribe(
     op_manager.release_pending_op_slot(incoming_tx).await;
 }
 
+/// Drive a fresh inbound relay `SubscribeMsg::Request`: fast-path on
+/// local contract hit, otherwise forward to the closest potentially
+/// hosting peer and bubble the Response upstream.
+///
+/// # Intentional signal drop: `PeerHealthTracker` on downstream timeout
+///
+/// The legacy relay Request arm attached a `SubscribeStats {
+/// target_peer, contract_location, request_sent_at }` to the
+/// `AwaitingResponse` state so that downstream timeouts (reported via
+/// `handle_abort`) fed `PeerHealthTracker` and the failure estimator.
+/// The task-per-tx driver DROPS this signal on the relay node: on
+/// `send_to_and_await` timeout we bubble `NotFound` upstream and exit
+/// without touching `PeerHealthTracker`.
+///
+/// This is deliberate for slice A. Cross-peer retry at the relay was
+/// the phase-5 memory-explosion amplifier (see `project_1454_phase5_memory.md`
+/// and PR #3896's fix stack) — the task-per-tx design moves ALL
+/// cross-peer retry to the originator's client-init driver. The
+/// originator's `send_to_and_await` timeout path there is the correct
+/// site for peer-health updates; reporting them at a relay that does
+/// not retry adds no actionable signal and makes the symmetry with
+/// GET/PUT/UPDATE slice A harder to reason about.
+///
+/// Follow-up: if peer-health reporting at the relay becomes necessary
+/// for other reasons (e.g. targeting a specific slow peer cluster
+/// without originating traffic), extend `OpCtx::send_to_and_await`
+/// to emit a stat update on `Err(_elapsed)` via a hook rather than
+/// reintroducing the signal on each relay driver.
 async fn drive_relay_subscribe(
     op_manager: &Arc<OpManager>,
     incoming_tx: Transaction,

--- a/crates/core/src/operations/subscribe/op_ctx_task.rs
+++ b/crates/core/src/operations/subscribe/op_ctx_task.rs
@@ -81,7 +81,7 @@ use crate::ring::{PeerKeyLocation, RingError};
 
 use super::{
     InitialRequest, MAX_BREADTH, MAX_RETRIES, SubscribeMsg, SubscribeMsgResult,
-    complete_local_subscription, prepare_initial_request,
+    complete_local_subscription, prepare_initial_request, register_downstream_subscriber,
 };
 
 /// Start a client-initiated subscribe, returning as soon as the task has
@@ -753,6 +753,491 @@ fn deliver_outcome(
     }
 }
 
+// ── Relay SUBSCRIBE driver (#1454 phase 5 follow-up slice A) ─────────────────
+
+/// Counter: relay SUBSCRIBE drivers currently in flight. Decremented in
+/// the RAII guard on driver exit. Diagnostic for `FREENET_MEMORY_STATS`.
+pub static RELAY_SUBSCRIBE_INFLIGHT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: total relay SUBSCRIBE drivers ever spawned on this node.
+pub static RELAY_SUBSCRIBE_SPAWNED_TOTAL: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: total relay SUBSCRIBE drivers that exited (any path).
+pub static RELAY_SUBSCRIBE_COMPLETED_TOTAL: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: duplicate inbound `SubscribeMsg::Request` rejected by the
+/// per-node dedup gate (`active_relay_subscribe_txs`).
+pub static RELAY_SUBSCRIBE_DEDUP_REJECTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Counter: number of times `start_relay_subscribe` was invoked. Used by
+/// structural pin tests to prove the dispatch gate routes fresh inbound
+/// `SubscribeMsg::Request` through the task-per-tx driver rather than
+/// legacy `handle_op_request`.
+#[cfg(any(test, feature = "testing"))]
+pub static RELAY_SUBSCRIBE_DRIVER_CALL_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Spawn a relay driver for a fresh inbound `SubscribeMsg::Request`.
+///
+/// Gated by the dispatch site in `node.rs::handle_pure_network_message_v1`
+/// on `source_addr.is_some() && !has_subscribe_op(id)`. The driver owns
+/// local-hit response + single downstream forward + upstream bubble-up
+/// in its task locals — no `SubscribeOp` is stored in
+/// `OpManager.ops.subscribe` for this transaction.
+///
+/// # Slice A
+///
+/// Migrated:
+/// - `SubscribeMsg::Request` relay arm: has-contract check (including the
+///   brief wait-for-in-flight-PUT helper), `register_downstream_subscriber`
+///   on local hit, forward-and-await-Response on next hop, bubble
+///   `SubscribeMsg::Response` back upstream after registering the
+///   requester as a downstream subscriber.
+/// - `ForwardingAck` OMITTED deliberately — same reasoning as GET/PUT/
+///   UPDATE slice A: the ack shares `incoming_tx` with the reply and
+///   would satisfy upstream's capacity-1 `pending_op_results` waiter
+///   before the real `Response`.
+/// - Cross-peer retries OMITTED at the relay — legacy breadth/retry loop
+///   at relay hops is the phase-5 memory-explosion amplifier (see
+///   `project_1454_phase5_memory.md`). Originator-side driver (Phase 2b)
+///   owns cross-peer retry; relay forwards once.
+///
+/// NOT migrated (stays on legacy path):
+/// - `SubscribeMsg::Response` originator arm (Phase 2b driver handles it
+///   via `pending_op_results` bypass).
+/// - `SubscribeMsg::Unsubscribe` and `SubscribeMsg::ForwardingAck` — fire
+///   and forget fast-path, no op state needed.
+/// - Renewals, PUT sub-op subscribes, and intermediate-peer forwarding
+///   through renewal/executor entry points — no `source_addr` or
+///   pre-existing `SubscribeOp` makes them fall through.
+pub(crate) async fn start_relay_subscribe(
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    instance_id: ContractInstanceId,
+    htl: usize,
+    visited: VisitedPeers,
+    is_renewal: bool,
+    upstream_addr: std::net::SocketAddr,
+) -> Result<(), OpError> {
+    #[cfg(any(test, feature = "testing"))]
+    RELAY_SUBSCRIBE_DRIVER_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    if !op_manager.active_relay_subscribe_txs.insert(incoming_tx) {
+        RELAY_SUBSCRIBE_DEDUP_REJECTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        tracing::debug!(
+            tx = %incoming_tx,
+            %instance_id,
+            %upstream_addr,
+            phase = "relay_subscribe_dedup_reject",
+            "SUBSCRIBE relay (task-per-tx): duplicate Request for in-flight tx, dropping"
+        );
+        return Ok(());
+    }
+
+    tracing::debug!(
+        tx = %incoming_tx,
+        %instance_id,
+        htl,
+        %upstream_addr,
+        is_renewal,
+        phase = "relay_subscribe_start",
+        "SUBSCRIBE relay (task-per-tx): spawning driver"
+    );
+
+    // Construct guard + bump counters BEFORE spawn so the dedup-set
+    // entry is paired with a Drop even if the spawned future is dropped
+    // before its first poll. Same reasoning as GET/PUT/UPDATE.
+    RELAY_SUBSCRIBE_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RELAY_SUBSCRIBE_SPAWNED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let guard = RelaySubscribeInflightGuard {
+        op_manager: op_manager.clone(),
+        incoming_tx,
+    };
+
+    GlobalExecutor::spawn(run_relay_subscribe(
+        guard,
+        op_manager,
+        incoming_tx,
+        instance_id,
+        htl,
+        visited,
+        is_renewal,
+        upstream_addr,
+    ));
+    Ok(())
+}
+
+/// RAII guard that decrements `RELAY_SUBSCRIBE_INFLIGHT`, bumps
+/// `RELAY_SUBSCRIBE_COMPLETED_TOTAL`, and removes the driver's
+/// `incoming_tx` from `active_relay_subscribe_txs` on drop.
+struct RelaySubscribeInflightGuard {
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+}
+
+impl Drop for RelaySubscribeInflightGuard {
+    fn drop(&mut self) {
+        self.op_manager
+            .active_relay_subscribe_txs
+            .remove(&self.incoming_tx);
+        RELAY_SUBSCRIBE_INFLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        RELAY_SUBSCRIBE_COMPLETED_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_relay_subscribe(
+    guard: RelaySubscribeInflightGuard,
+    op_manager: Arc<OpManager>,
+    incoming_tx: Transaction,
+    instance_id: ContractInstanceId,
+    htl: usize,
+    visited: VisitedPeers,
+    is_renewal: bool,
+    upstream_addr: std::net::SocketAddr,
+) {
+    let _guard = guard;
+
+    if let Err(err) = drive_relay_subscribe(
+        &op_manager,
+        incoming_tx,
+        instance_id,
+        htl,
+        visited,
+        is_renewal,
+        upstream_addr,
+    )
+    .await
+    {
+        tracing::warn!(
+            tx = %incoming_tx,
+            %instance_id,
+            error = %err,
+            phase = "relay_subscribe_error",
+            "SUBSCRIBE relay (task-per-tx): driver returned error"
+        );
+    }
+
+    // Release the pending_op_results slot at driver exit. Same reasoning
+    // as GET/PUT relay — `send_to_and_await` leaves a closed sender in
+    // the slot that only the 60s sweep would reclaim without this
+    // explicit release.
+    tokio::task::yield_now().await;
+    op_manager.release_pending_op_slot(incoming_tx).await;
+}
+
+async fn drive_relay_subscribe(
+    op_manager: &Arc<OpManager>,
+    incoming_tx: Transaction,
+    instance_id: ContractInstanceId,
+    htl: usize,
+    visited: VisitedPeers,
+    is_renewal: bool,
+    upstream_addr: std::net::SocketAddr,
+) -> Result<(), OpError> {
+    tracing::info!(
+        tx = %incoming_tx,
+        %instance_id,
+        htl,
+        %upstream_addr,
+        is_renewal,
+        phase = "relay_subscribe_request",
+        "SUBSCRIBE relay (task-per-tx): processing Request"
+    );
+
+    // ── Step 1: Local-hit fast path (with brief wait-for-in-flight-PUT) ──
+    if let Some(key) = super::wait_for_contract_with_timeout(
+        op_manager,
+        instance_id,
+        super::CONTRACT_WAIT_TIMEOUT_MS,
+    )
+    .await?
+    {
+        // Register the subscribing peer as a downstream subscriber.
+        // The relay task-per-tx path does not know the requester's
+        // `TransportPublicKey` (the legacy path had it because the op
+        // state carried `requester_pub_key`); `register_downstream_subscriber`
+        // falls back to addr-based lookup in that case, which is adequate
+        // for relay hops where the upstream is a direct connection.
+        register_downstream_subscriber(
+            op_manager,
+            &key,
+            upstream_addr,
+            None,
+            Some(upstream_addr),
+            &incoming_tx,
+            " (task-per-tx relay local hit)",
+        )
+        .await;
+
+        tracing::info!(
+            tx = %incoming_tx,
+            contract = %key,
+            is_renewal,
+            phase = "relay_subscribe_local_hit",
+            "SUBSCRIBE relay (task-per-tx): fulfilled locally, sending Response"
+        );
+        return relay_subscribe_send_response(
+            op_manager,
+            incoming_tx,
+            instance_id,
+            SubscribeMsgResult::Subscribed { key },
+            upstream_addr,
+        )
+        .await;
+    }
+
+    // ── Step 2: HTL / candidate selection ────────────────────────────────
+    if htl == 0 {
+        tracing::warn!(
+            tx = %incoming_tx,
+            contract = %instance_id,
+            htl = 0,
+            phase = "relay_subscribe_not_found",
+            "SUBSCRIBE relay (task-per-tx): HTL exhausted"
+        );
+        if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
+            &incoming_tx,
+            &op_manager.ring,
+            instance_id,
+            Some(op_manager.ring.max_hops_to_live),
+        ) {
+            op_manager
+                .ring
+                .register_events(either::Either::Left(event))
+                .await;
+        }
+        return relay_subscribe_send_response(
+            op_manager,
+            incoming_tx,
+            instance_id,
+            SubscribeMsgResult::NotFound,
+            upstream_addr,
+        )
+        .await;
+    }
+
+    // Restore hash keys after deserialization + mark ourselves + upstream
+    // as visited so we never loop back.
+    let own_addr = op_manager.ring.connection_manager.peer_addr()?;
+    let mut new_visited = visited.with_transaction(&incoming_tx);
+    new_visited.mark_visited(own_addr);
+    new_visited.mark_visited(upstream_addr);
+
+    let mut candidates =
+        op_manager
+            .ring
+            .k_closest_potentially_hosting(&instance_id, &new_visited, MAX_BREADTH);
+
+    if candidates.is_empty() {
+        tracing::warn!(
+            tx = %incoming_tx,
+            contract = %instance_id,
+            phase = "relay_subscribe_not_found",
+            "SUBSCRIBE relay (task-per-tx): no closer peers to forward"
+        );
+        if let Some(event) = crate::tracing::NetEventLog::subscribe_not_found(
+            &incoming_tx,
+            &op_manager.ring,
+            instance_id,
+            None,
+        ) {
+            op_manager
+                .ring
+                .register_events(either::Either::Left(event))
+                .await;
+        }
+        return relay_subscribe_send_response(
+            op_manager,
+            incoming_tx,
+            instance_id,
+            SubscribeMsgResult::NotFound,
+            upstream_addr,
+        )
+        .await;
+    }
+
+    let next_hop = candidates.remove(0);
+    let next_addr = match next_hop.socket_addr() {
+        Some(addr) => addr,
+        None => {
+            tracing::error!(
+                tx = %incoming_tx,
+                %instance_id,
+                target_pub_key = %next_hop.pub_key(),
+                "SUBSCRIBE relay (task-per-tx): next hop has no socket address"
+            );
+            return relay_subscribe_send_response(
+                op_manager,
+                incoming_tx,
+                instance_id,
+                SubscribeMsgResult::NotFound,
+                upstream_addr,
+            )
+            .await;
+        }
+    };
+    new_visited.mark_visited(next_addr);
+
+    // ── Step 3: Forward downstream, await Response ───────────────────────
+    let new_htl = htl.saturating_sub(1);
+
+    if let Some(event) = crate::tracing::NetEventLog::subscribe_request(
+        &incoming_tx,
+        &op_manager.ring,
+        instance_id,
+        next_hop.clone(),
+        new_htl,
+    ) {
+        op_manager
+            .ring
+            .register_events(either::Either::Left(event))
+            .await;
+    }
+
+    tracing::debug!(
+        tx = %incoming_tx,
+        %instance_id,
+        peer_addr = %next_addr,
+        htl = new_htl,
+        phase = "relay_subscribe_forward",
+        "SUBSCRIBE relay (task-per-tx): forwarding to next hop"
+    );
+
+    let forward = NetMessage::from(SubscribeMsg::Request {
+        id: incoming_tx,
+        instance_id,
+        htl: new_htl,
+        visited: new_visited,
+        is_renewal,
+    });
+
+    let mut ctx = op_manager.op_ctx(incoming_tx);
+    let round_trip =
+        tokio::time::timeout(OPERATION_TTL, ctx.send_to_and_await(next_addr, forward)).await;
+
+    // Release the pending_op_results slot installed by send_to_and_await.
+    // Mirrors PUT/GET relay — the upstream fire-and-forget reply below
+    // would otherwise leak a slot entry per driver run.
+    op_manager.release_pending_op_slot(incoming_tx).await;
+
+    let reply = match round_trip {
+        Ok(Ok(reply)) => reply,
+        Ok(Err(err)) => {
+            tracing::warn!(
+                tx = %incoming_tx,
+                %instance_id,
+                target = %next_addr,
+                error = %err,
+                "SUBSCRIBE relay (task-per-tx): send_to_and_await failed"
+            );
+            return relay_subscribe_send_response(
+                op_manager,
+                incoming_tx,
+                instance_id,
+                SubscribeMsgResult::NotFound,
+                upstream_addr,
+            )
+            .await;
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                tx = %incoming_tx,
+                %instance_id,
+                target = %next_addr,
+                timeout_secs = OPERATION_TTL.as_secs(),
+                "SUBSCRIBE relay (task-per-tx): downstream timed out"
+            );
+            return relay_subscribe_send_response(
+                op_manager,
+                incoming_tx,
+                instance_id,
+                SubscribeMsgResult::NotFound,
+                upstream_addr,
+            )
+            .await;
+        }
+    };
+
+    // ── Step 4: Classify reply, register requester if Subscribed, bubble up ──
+    let result = match reply {
+        NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
+            result: SubscribeMsgResult::Subscribed { key },
+            ..
+        })) => {
+            // Relay-side Subscribed registration — mirror legacy
+            // subscribe.rs:1690 arm. DO NOT call ring.subscribe /
+            // record_subscription / announce_contract_hosted here; a
+            // relay is not itself a subscriber. See subscribe.rs:1655–1688
+            // for the full reasoning (prevents the #3763 subscription
+            // storm feedback loop).
+            register_downstream_subscriber(
+                op_manager,
+                &key,
+                upstream_addr,
+                None,
+                Some(upstream_addr),
+                &incoming_tx,
+                " (task-per-tx relay registration on Response)",
+            )
+            .await;
+
+            tracing::info!(
+                tx = %incoming_tx,
+                contract = %key,
+                phase = "relay_subscribe_bubble",
+                "SUBSCRIBE relay (task-per-tx): downstream Subscribed; bubbling upstream"
+            );
+            SubscribeMsgResult::Subscribed { key }
+        }
+        NetMessage::V1(NetMessageV1::Subscribe(SubscribeMsg::Response {
+            result: SubscribeMsgResult::NotFound,
+            ..
+        })) => {
+            tracing::debug!(
+                tx = %incoming_tx,
+                %instance_id,
+                phase = "relay_subscribe_bubble_not_found",
+                "SUBSCRIBE relay (task-per-tx): downstream NotFound; bubbling upstream"
+            );
+            SubscribeMsgResult::NotFound
+        }
+        other => {
+            tracing::warn!(
+                tx = %incoming_tx,
+                %instance_id,
+                reply_variant = ?std::mem::discriminant(&other),
+                "SUBSCRIBE relay (task-per-tx): unexpected reply variant; treating as NotFound"
+            );
+            SubscribeMsgResult::NotFound
+        }
+    };
+
+    relay_subscribe_send_response(op_manager, incoming_tx, instance_id, result, upstream_addr).await
+}
+
+/// Send `SubscribeMsg::Response` upstream (fire-and-forget: upstream
+/// relay awaits via its own `send_to_and_await`, no reply expected).
+async fn relay_subscribe_send_response(
+    op_manager: &OpManager,
+    incoming_tx: Transaction,
+    instance_id: ContractInstanceId,
+    result: SubscribeMsgResult,
+    upstream_addr: std::net::SocketAddr,
+) -> Result<(), OpError> {
+    let response = NetMessage::from(SubscribeMsg::Response {
+        id: incoming_tx,
+        instance_id,
+        result,
+    });
+    let mut ctx = op_manager.op_ctx(incoming_tx);
+    ctx.send_fire_and_forget(upstream_addr, response).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1102,5 +1587,228 @@ mod tests {
             .collect();
         assert!(alt_addrs.contains(&p2_addr));
         assert!(alt_addrs.contains(&p3_addr));
+    }
+
+    // ── Relay SUBSCRIBE driver structural pin tests (#1454 phase 5
+    // follow-up slice A). Anchor on the `start_relay_subscribe`
+    // entry-point fn so module-level docs referencing variant names
+    // don't contaminate the scan.
+
+    fn relay_section(src: &str) -> &str {
+        let start = src
+            .find("pub(crate) async fn start_relay_subscribe(")
+            .expect("start_relay_subscribe not found");
+        let end = src
+            .find("\n#[cfg(test)]")
+            .expect("test module marker not found");
+        &src[start..end]
+    }
+
+    /// Pin: dispatch entry must insert into `active_relay_subscribe_txs`
+    /// BEFORE spawning. Same dedup-gate-ordering invariant as GET/PUT/
+    /// UPDATE — without this, duplicate inbound `SubscribeMsg::Request`
+    /// for an in-flight tx would spawn redundant drivers.
+    #[test]
+    fn start_relay_subscribe_checks_dedup_gate() {
+        let src = include_str!("op_ctx_task.rs");
+        let relay = relay_section(src);
+        let window_start = relay
+            .find("pub(crate) async fn start_relay_subscribe(")
+            .expect("entry-point not found");
+        let spawn_pos = relay[window_start..]
+            .find("GlobalExecutor::spawn(run_relay_subscribe(")
+            .expect("spawn site not found")
+            + window_start;
+        let insert_pos = relay[window_start..]
+            .find("active_relay_subscribe_txs.insert(incoming_tx)")
+            .expect("dedup insert site not found")
+            + window_start;
+        assert!(
+            insert_pos < spawn_pos,
+            "active_relay_subscribe_txs.insert MUST happen before GlobalExecutor::spawn"
+        );
+    }
+
+    /// Pin: dedup rejection must bump `RELAY_SUBSCRIBE_DEDUP_REJECTS`.
+    #[test]
+    fn dedup_rejection_increments_counter() {
+        let src = include_str!("op_ctx_task.rs");
+        let relay = relay_section(src);
+        let after_insert = relay
+            .split("active_relay_subscribe_txs.insert(incoming_tx)")
+            .nth(1)
+            .expect("dedup insert site not found");
+        let window = &after_insert[..500.min(after_insert.len())];
+        assert!(
+            window.contains("RELAY_SUBSCRIBE_DEDUP_REJECTS.fetch_add"),
+            "dedup gate must increment RELAY_SUBSCRIBE_DEDUP_REJECTS on rejection"
+        );
+    }
+
+    /// Pin: RAII guard must clear `active_relay_subscribe_txs` + bump
+    /// completion counters on drop.
+    #[test]
+    fn raii_guard_clears_dedup_set_on_drop() {
+        let src = include_str!("op_ctx_task.rs");
+        let drop_start = src
+            .find("impl Drop for RelaySubscribeInflightGuard")
+            .expect("RelaySubscribeInflightGuard Drop impl not found");
+        let drop_body = &src[drop_start..drop_start + 600];
+        assert!(
+            drop_body.contains("active_relay_subscribe_txs"),
+            "RelaySubscribeInflightGuard::drop must remove from active_relay_subscribe_txs"
+        );
+        assert!(
+            drop_body.contains("RELAY_SUBSCRIBE_INFLIGHT.fetch_sub"),
+            "RelaySubscribeInflightGuard::drop must decrement RELAY_SUBSCRIBE_INFLIGHT"
+        );
+        assert!(
+            drop_body.contains("RELAY_SUBSCRIBE_COMPLETED_TOTAL.fetch_add"),
+            "RelaySubscribeInflightGuard::drop must increment RELAY_SUBSCRIBE_COMPLETED_TOTAL"
+        );
+    }
+
+    /// Pin: driver forwards downstream via `send_to_and_await` — SUBSCRIBE
+    /// relay IS req/response. Fire-and-forget here would lose the reply.
+    #[test]
+    fn drive_relay_subscribe_forwards_via_send_to_and_await() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_subscribe(")
+            .expect("drive_relay_subscribe not found");
+        let driver_end = src[driver_start..]
+            .find("\nasync fn relay_subscribe_send_response(")
+            .expect("driver body end not found")
+            + driver_start;
+        let driver_src = &src[driver_start..driver_end];
+        assert!(
+            driver_src.contains("ctx.send_to_and_await("),
+            "drive_relay_subscribe must forward downstream via send_to_and_await"
+        );
+    }
+
+    /// Pin: relay forward must reuse `incoming_tx`. Minting a fresh tx
+    /// at each hop was the phase-5 GET 3^HTL amplifier.
+    #[test]
+    fn drive_relay_subscribe_reuses_incoming_tx_on_forward() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_subscribe(")
+            .expect("drive_relay_subscribe not found");
+        let driver_end = src[driver_start..]
+            .find("\nasync fn relay_subscribe_send_response(")
+            .expect("driver body end not found")
+            + driver_start;
+        let driver_src = &src[driver_start..driver_end];
+        let forward_pos = driver_src
+            .find("SubscribeMsg::Request {")
+            .expect("forward SubscribeMsg::Request not found in driver");
+        let forward_window = &driver_src[forward_pos..forward_pos + 400];
+        assert!(
+            forward_window.contains("id: incoming_tx"),
+            "relay forward must reuse incoming_tx"
+        );
+        assert!(
+            !forward_window.contains("Transaction::new::<SubscribeMsg>()"),
+            "relay forward must NOT mint a fresh Transaction"
+        );
+    }
+
+    /// Pin: relay upstream reply MUST use `send_fire_and_forget`.
+    /// Upstream's own `send_to_and_await` owns the reply slot.
+    #[test]
+    fn relay_subscribe_send_response_is_fire_and_forget() {
+        let src = include_str!("op_ctx_task.rs");
+        let fn_start = src
+            .find("async fn relay_subscribe_send_response(")
+            .expect("relay_subscribe_send_response not found");
+        let fn_end = src[fn_start..]
+            .find("\n}\n")
+            .expect("function body end not found")
+            + fn_start;
+        let fn_src = &src[fn_start..fn_end];
+        assert!(
+            fn_src.contains("send_fire_and_forget"),
+            "relay_subscribe_send_response must use send_fire_and_forget for the upstream response"
+        );
+    }
+
+    /// Pin: relay driver MUST NOT emit `ForwardingAck`. The ack would
+    /// share `incoming_tx` with the reply and satisfy upstream's
+    /// capacity-1 `pending_op_results` waiter before the real Response.
+    #[test]
+    fn relay_subscribe_does_not_emit_forwarding_ack() {
+        let src = include_str!("op_ctx_task.rs");
+        let relay = relay_section(src);
+        assert!(
+            !relay.contains("SubscribeMsg::ForwardingAck {"),
+            "relay SUBSCRIBE driver must NOT construct a ForwardingAck — \
+             sharing incoming_tx with the reply collides with upstream's waiter"
+        );
+    }
+
+    /// Pin: relay driver MUST call `register_downstream_subscriber`
+    /// on BOTH the local-hit and downstream-Subscribed paths. Missing
+    /// this registration breaks UPDATE propagation to the original
+    /// requester (see subscribe.rs:1655–1688 for full reasoning).
+    #[test]
+    fn relay_subscribe_registers_downstream_on_both_paths() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_subscribe(")
+            .expect("drive_relay_subscribe not found");
+        let driver_end = src[driver_start..]
+            .find("\nasync fn relay_subscribe_send_response(")
+            .expect("driver body end not found")
+            + driver_start;
+        let driver_src = &src[driver_start..driver_end];
+        let hits = driver_src
+            .matches("register_downstream_subscriber(")
+            .count();
+        assert!(
+            hits >= 2,
+            "driver must call register_downstream_subscriber on BOTH local-hit \
+             and downstream-Subscribed paths (found {hits})"
+        );
+    }
+
+    /// Pin: relay driver MUST NOT call `ring.subscribe`, `record_subscription`,
+    /// or `announce_contract_hosted` on behalf of the relayed Subscribed
+    /// response. A relay is not itself a subscriber; doing so would
+    /// install a lease and trigger #3763 subscription-storm feedback
+    /// loops via the renewal cycle.
+    #[test]
+    fn relay_subscribe_does_not_install_lease_on_relayed_response() {
+        let src = include_str!("op_ctx_task.rs");
+        let driver_start = src
+            .find("async fn drive_relay_subscribe(")
+            .expect("drive_relay_subscribe not found");
+        let driver_end = src[driver_start..]
+            .find("\nasync fn relay_subscribe_send_response(")
+            .expect("driver body end not found")
+            + driver_start;
+        let driver_src = &src[driver_start..driver_end];
+        // Strip line comments so doc strings that mention these call-sites
+        // as negative constraints do not trip the substring scan.
+        let stripped: String = driver_src
+            .lines()
+            .map(|line| match line.find("//") {
+                Some(idx) => &line[..idx],
+                None => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !stripped.contains("ring.subscribe("),
+            "relay driver must NOT call ring.subscribe on relayed response"
+        );
+        assert!(
+            !stripped.contains("complete_subscription_request"),
+            "relay driver must NOT call complete_subscription_request on relayed response"
+        );
+        assert!(
+            !stripped.contains("announce_contract_hosted"),
+            "relay driver must NOT call announce_contract_hosted on relayed response"
+        );
     }
 }

--- a/crates/core/tests/simulation_integration.rs
+++ b/crates/core/tests/simulation_integration.rs
@@ -7414,8 +7414,9 @@ fn test_get_routing_coverage_low_htl() {
     use std::sync::atomic::Ordering;
 
     use freenet::dev_tool::{
-        GET_RELAY_DRIVER_CALL_COUNT, NodeLabel, RELAY_PUT_DRIVER_CALL_COUNT, ScheduledOperation,
-        SimOperation, register_crdt_contract,
+        GET_RELAY_DRIVER_CALL_COUNT, NodeLabel, RELAY_PUT_DRIVER_CALL_COUNT,
+        RELAY_SUBSCRIBE_DRIVER_CALL_COUNT, ScheduledOperation, SimOperation,
+        register_crdt_contract,
     };
 
     // Seed updated: per-peer acceptor reliability scoring replaces binary
@@ -7435,6 +7436,7 @@ fn test_get_routing_coverage_low_htl() {
     // dispatch-block SHAPE. #1454 phase 5 / #3883.
     let relay_baseline = GET_RELAY_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
     let relay_put_baseline = RELAY_PUT_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
+    let relay_subscribe_baseline = RELAY_SUBSCRIBE_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
 
     let rt = create_runtime();
 
@@ -7571,6 +7573,25 @@ fn test_get_routing_coverage_low_htl() {
          in a {num_nodes}-node network must traverse at least one relay hop. \
          Dispatch gate for PUT has likely regressed. \
          Baseline: {relay_put_baseline}, after: {relay_put_after}."
+    );
+
+    // Behavioral companion for relay SUBSCRIBE slice A (#1454 phase 5
+    // follow-up, PR #3932): 12 nodes subscribe above. At HTL=3 with
+    // ~5 caching nodes, at least one subscribe must traverse a relay
+    // hop and hit start_relay_subscribe. If this never advances, the
+    // dispatch gate for SUBSCRIBE has regressed — inbound relay
+    // SubscribeMsg::Request is going through the legacy
+    // handle_op_request path again.
+    let relay_subscribe_after = RELAY_SUBSCRIBE_DRIVER_CALL_COUNT.load(Ordering::SeqCst);
+    let relay_subscribe_delta = relay_subscribe_after.saturating_sub(relay_subscribe_baseline);
+    assert!(
+        relay_subscribe_delta > 0,
+        "RELAY_SUBSCRIBE_DRIVER_CALL_COUNT did not advance during the \
+         test — the relay SUBSCRIBE task-per-tx driver never ran. With \
+         12 node subscribes at HTL=3 and ~5 caching nodes, at least one \
+         subscribe must traverse a relay hop. Dispatch gate for \
+         SUBSCRIBE has likely regressed. \
+         Baseline: {relay_subscribe_baseline}, after: {relay_subscribe_after}."
     );
 
     // StateVerifier anomaly check


### PR DESCRIPTION
## Problem

Fresh inbound `SubscribeMsg::Request` on relay hops still runs through
the legacy `OpManager.ops.subscribe` state-machine path. This keeps
SUBSCRIBE relay on the same surface that produced the 63 GB RSS
explosion on GET relay before PR #3896 (#1454 phase 5 GET fix).
Phase 5 slice A already migrated UPDATE (#3910) and PUT (#3917);
SUBSCRIBE is the last remaining non-streaming relay that can be
migrated before streaming pass-through work starts in slice B.

## Solution

Migrate fresh inbound `SubscribeMsg::Request` to a
task-per-transaction driver in
`operations/subscribe/op_ctx_task.rs::start_relay_subscribe`. The
driver owns local-hit response, single downstream forward via
`OpCtx::send_to_and_await`, upstream `SubscribeMsg::Response`
fire-and-forget bubble-up, and `register_downstream_subscriber` calls
on both local-hit and relayed-Subscribed paths. No `SubscribeOp` is
stored in `OpManager.ops.subscribe` for the migrated tx.

Key design choices (mirror of GET phase 5 + UPDATE / PUT slice A):

- **Per-node dedup gate**: `OpManager.active_relay_subscribe_txs`
  (DashSet) rejects duplicate inbound `SubscribeMsg::Request` for an
  in-flight tx, preventing GC-spawned re-entries or routing-bloom
  false-positive retransmissions from spawning redundant drivers.
- **RAII `RelaySubscribeInflightGuard`** constructed **before** `spawn`
  so the dedup-set entry is paired with a `Drop` even if the spawned
  future is dropped before its first poll. Closes the pre-poll
  dedup-leak window that would otherwise create a permanent GC
  blind-spot with no TTL.
- **`incoming_tx` reused end-to-end on forward** (matches legacy
  SUBSCRIBE relay). Minting a fresh tx per hop was the GET 3^HTL
  amplifier.
- **ForwardingAck omitted** for the same reason as GET / PUT / UPDATE:
  the ack carried `incoming_tx` and would satisfy the upstream's
  capacity-1 `pending_op_results` waiter before the real `Response`.
- **Cross-peer retries omitted** at the relay. Originator's client-init
  driver (Phase 2b) owns cross-peer retry. Combining relay retries with
  virtual-time `OPERATION_TTL` under `tokio::time::pause` was the
  dominant GET amplifier.
- **`send_to_and_await` for the downstream forward** (SUBSCRIBE relay
  is req/response).
- **`send_fire_and_forget` for the upstream `SubscribeMsg::Response`**:
  upstream's own `send_to_and_await` owns the capacity-1 reply
  channel.

### Relay Subscribed-response side effects

Driver calls `register_downstream_subscriber` before bubbling the
upstream Response. Deliberately omits `ring.subscribe`,
`complete_subscription_request`, and `announce_contract_hosted` on
the relayed path — a relay is not itself a subscriber (prevents the
#3763 subscription-storm feedback loop via the renewal cycle; see
`subscribe.rs:1655–1688` for the full reasoning captured when the
legacy asymmetry was fixed).

### Dispatch gate

`node.rs::handle_pure_network_message_v1` fires on
`source_addr.is_some() && !op_manager.has_subscribe_op(id) && variant
== SubscribeMsg::Request`. Originator loop-backs
(`source_addr.is_none()`), renewals, PUT sub-ops, and GC-spawned
retries that pre-register a `SubscribeOp` all fall through to legacy.
`ForwardingAck` / `Unsubscribe` never match the `Request` arm so they
flow to legacy naturally.

### Scope (slice A)

**Migrated:**

- `SubscribeMsg::Request` relay arm: has-contract fast path (with the
  existing brief `wait_for_contract_with_timeout` helper), local-hit
  Response, HTL / candidate selection, forward-and-await-Response,
  upstream bubble.

**NOT migrated (stays on legacy path):**

- Originator `SubscribeMsg::Response` handling — Phase 2b
  client-init driver already consumes it via the `pending_op_results`
  bypass.
- `SubscribeMsg::Unsubscribe` / `SubscribeMsg::ForwardingAck` — fire
  and forget cleanup, no op state needed.
- Renewals, PUT sub-op subscribes, executor auto-subscribe paths —
  no fresh `source_addr` or a pre-registered `SubscribeOp` make them
  fall through naturally.

### Per-node memory-stats counters

Plumbed into `FREENET_MEMORY_STATS`:
`relay_subscribe_inflight`, `relay_subscribe_spawned`,
`relay_subscribe_completed`, `relay_subscribe_dedup_rejects`,
`relay_subscribe_active_txs`.

## Testing

### Structural pin tests (`subscribe/op_ctx_task.rs`)

- Dedup gate ordering: `active_relay_subscribe_txs.insert` before
  `GlobalExecutor::spawn`.
- Dedup rejection increments `RELAY_SUBSCRIBE_DEDUP_REJECTS`.
- RAII guard clears dedup set + decrements counters on drop.
- Driver forwards via `send_to_and_await` (not fire-and-forget).
- Driver reuses `incoming_tx` on forward (no fresh tx mint).
- Upstream reply uses `send_fire_and_forget`.
- Driver does NOT construct a `ForwardingAck`.
- Driver calls `register_downstream_subscriber` on BOTH local-hit and
  relayed-Subscribed paths.
- Driver does NOT install a lease on relayed Subscribed (no
  `ring.subscribe` / `complete_subscription_request` /
  `announce_contract_hosted`).

### Dispatch pin tests (`node.rs`)

- SUBSCRIBE branch invokes `start_relay_subscribe`.
- Gated on `source_addr` + `has_subscribe_op`.
- Only the `Request` variant is destructured for relay dispatch.

### Other testing

- [x] `cargo test -p freenet --lib` — 2440/2440 pass.
- [x] `cargo test -p freenet --features simulation_tests,testing
      --test simulation_integration -- test_subscribe test_subscription
      test_subscription_broadcast_propagation
      test_subscription_relay_propagation` — all pass.
- [x] `cargo test -p freenet --features simulation_tests,testing
      --test operations -- subscribe subscription` — 9/9 pass via
      Docker test-runner (macOS cannot bind the full 127.x.x.x range).
- [ ] CI ci-fault-loss sim run (will trigger on PR push): confirm no
      memory regression vs. main. Baseline: main 2.6 GB RSS under
      ci-fault-loss after the GET-relay phase-5 fix.

## Fixes

Refs #1454.