### PR TITLE
refactor(ops): remove PUT dead code — #1454 phase 6 follow-up

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -50,7 +50,7 @@ paths:
 > downstream piping via `NetworkBridge::pipe_stream`, assembles
 > locally via the shared `relay_put_store_locally` helper, and
 > bubbles a non-streaming `PutMsg::Response` upstream (mirrors the
-> legacy downgrade at `put.rs:1506`). The dispatch site passes a
+> legacy downgrade at `put.rs:1517`). The dispatch site passes a
 > cloned `NetworkBridge` into the spawn so the driver can call
 > `pipe_stream` without a detour through `OpCtx`. The upgrade-only
 > case — `PutMsg::Request` whose serialized payload would exceed

--- a/crates/core/src/node/op_state_manager.rs
+++ b/crates/core/src/node/op_state_manager.rs
@@ -3221,14 +3221,7 @@ mod tests {
         let ops = Ops::default();
         let tx = Transaction::new::<crate::operations::put::PutMsg>();
 
-        let put_op = crate::operations::put::start_op(
-            crate::operations::test_utils::make_test_contract(&[1u8]),
-            freenet_stdlib::prelude::RelatedContracts::default(),
-            freenet_stdlib::prelude::WrappedState::new(vec![]),
-            10,
-            false,
-            false,
-        );
+        let put_op = crate::operations::put::PutOp::new_empty_for_test(tx);
         ops.put.insert(tx, put_op);
         assert!(ops.put.contains_key(&tx));
 

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -57,6 +57,20 @@ pub(crate) struct PutOp {
 }
 
 impl PutOp {
+    /// Minimal PutOp constructor for tests outside this module
+    /// (state=None, stats=None — enough for DashMap insert/remove tests).
+    #[cfg(test)]
+    pub(crate) fn new_empty_for_test(id: Transaction) -> Self {
+        PutOp {
+            id,
+            state: None,
+            upstream_addr: None,
+            stats: None,
+            ack_received: false,
+            speculative_paths: 0,
+        }
+    }
+
     pub(super) fn outcome(&self) -> OpOutcome<'_> {
         if self.finalized() {
             if let Some(ref stats) = self.stats {
@@ -234,7 +248,7 @@ impl PutOp {
                 self.state = Some(PutState::AwaitingResponse(data));
                 Ok((self, msg))
             }
-            state @ (PutState::PrepareRequest(_) | PutState::Finished(_)) => {
+            state @ PutState::Finished(_) => {
                 self.state = Some(state);
                 Err(Box::new(self))
             }
@@ -272,7 +286,6 @@ impl PutOp {
 
         // Extract key and current_htl from state if available
         let (key, current_htl) = match &self.state {
-            Some(PutState::PrepareRequest(data)) => (Some(data.contract.key()), Some(data.htl)),
             Some(PutState::AwaitingResponse(data)) => (None, Some(data.current_htl)),
             Some(PutState::Finished(data)) => (Some(data.key), None),
             None => (None, None),
@@ -458,12 +471,10 @@ impl Operation for PutOp {
 
             // Extract subscribe flags from state (only relevant for originator)
             let subscribe = match &self.state {
-                Some(PutState::PrepareRequest(data)) => data.subscribe,
                 Some(PutState::AwaitingResponse(data)) => data.subscribe,
                 _ => false,
             };
             let blocking_subscribe = match &self.state {
-                Some(PutState::PrepareRequest(data)) => data.blocking_subscribe,
                 Some(PutState::AwaitingResponse(data)) => data.blocking_subscribe,
                 _ => false,
             };
@@ -1616,137 +1627,19 @@ async fn start_subscription_after_put(
     }
 }
 
-#[allow(dead_code)] // Used in tests; Phase 6 cleanup
-pub(crate) fn start_op(
-    contract: ContractContainer,
-    related_contracts: RelatedContracts<'static>,
-    value: WrappedState,
-    htl: usize,
-    subscribe: bool,
-    blocking_subscribe: bool,
-) -> PutOp {
-    let key = contract.key();
-    let contract_location = Location::from(&key);
-    tracing::debug!(contract_location = %contract_location, contract = %key, phase = "request", "Requesting put");
-
-    let id = Transaction::new::<PutMsg>();
-    let state = Some(PutState::PrepareRequest(PrepareRequestData {
-        contract,
-        related_contracts,
-        value,
-        htl,
-        subscribe,
-        blocking_subscribe,
-    }));
-
-    PutOp {
-        id,
-        state,
-        upstream_addr: None, // Local operation, no upstream peer
-        stats: None,
-        ack_received: false,
-        speculative_paths: 0,
-    }
-}
-
-/// Create a PUT operation with a specific transaction ID (for operation deduplication)
-#[allow(dead_code)] // Used in tests; Phase 6 cleanup
-pub(crate) fn start_op_with_id(
-    contract: ContractContainer,
-    related_contracts: RelatedContracts<'static>,
-    value: WrappedState,
-    htl: usize,
-    subscribe: bool,
-    blocking_subscribe: bool,
-    id: Transaction,
-) -> PutOp {
-    let key = contract.key();
-    let contract_location = Location::from(&key);
-    tracing::debug!(contract_location = %contract_location, contract = %key, tx = %id, phase = "request", "Requesting put with existing transaction ID");
-
-    let state = Some(PutState::PrepareRequest(PrepareRequestData {
-        contract,
-        related_contracts,
-        value,
-        htl,
-        subscribe,
-        blocking_subscribe,
-    }));
-
-    PutOp {
-        id,
-        state,
-        upstream_addr: None, // Local operation, no upstream peer
-        stats: None,
-        ack_received: false,
-        speculative_paths: 0,
-    }
-}
-
 // State machine for PUT operations.
 //
 // State transitions:
-// - Originator: PrepareRequest → AwaitingResponse → Finished
-// - Forwarder: (receives Request) → AwaitingResponse → (receives Response) → done
-// - Final node: (receives Request) → stores contract → sends Response → done
+// - Originator (task-per-tx driver, operations/put/op_ctx_task.rs):
+//   drives the request directly; state enters at AwaitingResponse.
+// - Forwarder (legacy relay path): receives Request → AwaitingResponse →
+//   receives Response → done.
+// - Final node: receives Request → stores contract → sends Response → done.
 //
 // ── Type-state data structs ──────────────────────────────────────────────
 //
-// Each state in the PUT state machine is a named struct with typed
-// transition methods.  This gives compile-time guarantees:
-//
-//   PrepareRequest ── into_awaiting_response() ──► AwaitingResponse
-//   AwaitingResponse ── into_finished()         ──► Finished
-//
-// Invalid transitions (e.g. Finished → PrepareRequest) are unrepresentable
-// because the target type simply has no such method.
-
-/// Data for the PrepareRequest state: originator preparing initial PUT request.
-#[derive(Debug, Clone)]
-#[allow(dead_code)] // Phase 6 cleanup: only constructed by now-dead start_op/start_op_with_id
-pub struct PrepareRequestData {
-    pub contract: ContractContainer,
-    pub related_contracts: RelatedContracts<'static>,
-    pub value: WrappedState,
-    pub htl: usize,
-    /// If true, start a subscription after PUT completes
-    pub subscribe: bool,
-    /// If true, the PUT response waits for the subscription to complete
-    pub blocking_subscribe: bool,
-}
-
-impl PrepareRequestData {
-    /// Transition to AwaitingResponse after sending the PUT request.
-    ///
-    /// Encodes valid transition: PrepareRequest → AwaitingResponse.
-    /// The subscribe/blocking_subscribe flags are carried forward.
-    #[allow(dead_code)] // Documents valid transition; see type-state pattern
-    pub fn into_awaiting_response(
-        self,
-        next_hop: Option<std::net::SocketAddr>,
-        contract_key: ContractKey,
-        alternatives: Vec<PeerKeyLocation>,
-        visited: VisitedPeers,
-    ) -> AwaitingResponseData {
-        let mut tried_peers = HashSet::new();
-        if let Some(addr) = next_hop {
-            tried_peers.insert(addr);
-        }
-        AwaitingResponseData {
-            subscribe: self.subscribe,
-            blocking_subscribe: self.blocking_subscribe,
-            next_hop,
-            current_htl: self.htl,
-            contract_key,
-
-            tried_peers,
-            alternatives,
-            attempts_at_hop: 1,
-            visited,
-            retry_payload: None,
-        }
-    }
-}
+// Each state is a named struct; transition methods encode compile-time
+// guarantees that invalid transitions are unrepresentable.
 
 /// Data for the AwaitingResponse state: waiting for downstream node's response.
 #[derive(Debug, Clone)]
@@ -1782,16 +1675,6 @@ pub struct PutRetryPayload {
     pub value: WrappedState,
 }
 
-impl AwaitingResponseData {
-    /// Transition to Finished on successful PUT response.
-    ///
-    /// Encodes valid transition: AwaitingResponse → Finished.
-    #[allow(dead_code)] // Documents valid transition; see type-state pattern
-    pub fn into_finished(self, key: ContractKey) -> FinishedData {
-        FinishedData { key }
-    }
-}
-
 /// Data for the Finished state: PUT operation completed successfully.
 #[derive(Debug, Clone, Copy)]
 pub struct FinishedData {
@@ -1800,17 +1683,13 @@ pub struct FinishedData {
 
 // ── State enum (wraps the typed structs) ─────────────────────────────────
 
-/// Streaming flow (when enabled and payload > threshold):
 /// State machine for PUT operations.
-/// - Originator: PrepareRequest → AwaitingResponse → Finished
-/// - Forwarder: ReceivedRequest → stores → sends Response → done
+/// - Originator (task-per-tx): state enters at AwaitingResponse.
+/// - Forwarder (legacy relay): ReceivedRequest → AwaitingResponse → done.
+/// - Final node: receives Request → stores → sends Response → done.
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum PutState {
-    /// Local originator preparing to send initial request.
-    #[allow(dead_code)]
-    // Phase 6 cleanup: only constructed by now-dead start_op/start_op_with_id
-    PrepareRequest(PrepareRequestData),
     /// Waiting for response from downstream node.
     AwaitingResponse(AwaitingResponseData),
     /// Operation completed successfully.
@@ -2202,52 +2081,29 @@ mod tests {
         );
     }
 
-    // Tests for blocking_subscribe propagation
+    // Tests for blocking_subscribe propagation on AwaitingResponse state
     #[test]
-    fn start_op_propagates_blocking_subscribe_true() {
-        let contract = make_test_contract(&[1u8]);
-        let op = start_op(
-            contract,
-            RelatedContracts::default(),
-            WrappedState::new(vec![]),
-            10,
-            true, // subscribe
-            true, // blocking_subscribe
-        );
+    fn awaiting_response_carries_blocking_subscribe_true() {
+        let op = make_put_op(Some(PutState::AwaitingResponse(AwaitingResponseData {
+            subscribe: true,
+            blocking_subscribe: true,
+            next_hop: None,
+            current_htl: 10,
+            contract_key: make_contract_key(0),
+            tried_peers: HashSet::new(),
+            alternatives: vec![],
+            attempts_at_hop: 1,
+            visited: VisitedPeers::default(),
+            retry_payload: None,
+        })));
         match op.state {
-            Some(PutState::PrepareRequest(data)) => {
-                let blocking_subscribe = data.blocking_subscribe;
+            Some(PutState::AwaitingResponse(data)) => {
                 assert!(
-                    blocking_subscribe,
-                    "blocking_subscribe should be true in PrepareRequest"
+                    data.blocking_subscribe,
+                    "blocking_subscribe should be true in AwaitingResponse"
                 );
             }
-            other => panic!("Expected PrepareRequest state, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn start_op_with_id_propagates_blocking_subscribe_true() {
-        let contract = make_test_contract(&[1u8]);
-        let tx = Transaction::new::<PutMsg>();
-        let op = start_op_with_id(
-            contract,
-            RelatedContracts::default(),
-            WrappedState::new(vec![]),
-            10,
-            true, // subscribe
-            true, // blocking_subscribe
-            tx,
-        );
-        match op.state {
-            Some(PutState::PrepareRequest(data)) => {
-                let blocking_subscribe = data.blocking_subscribe;
-                assert!(
-                    blocking_subscribe,
-                    "blocking_subscribe should be true in PrepareRequest via start_op_with_id"
-                );
-            }
-            other => panic!("Expected PrepareRequest state, got {:?}", other),
+            other => panic!("Expected AwaitingResponse state, got {:?}", other),
         }
     }
 
@@ -2401,52 +2257,9 @@ mod tests {
         assert!(op.failure_routing_info().is_none());
     }
 
-    #[test]
-    fn start_op_defaults_blocking_subscribe_false() {
-        let contract = make_test_contract(&[1u8]);
-        let op = start_op(
-            contract,
-            RelatedContracts::default(),
-            WrappedState::new(vec![]),
-            10,
-            true,  // subscribe
-            false, // blocking_subscribe
-        );
-        match op.state {
-            Some(PutState::PrepareRequest(data)) => {
-                let blocking_subscribe = data.blocking_subscribe;
-                assert!(
-                    !blocking_subscribe,
-                    "blocking_subscribe should be false by default"
-                );
-            }
-            other => panic!("Expected PrepareRequest state, got {:?}", other),
-        }
-    }
-
-    /// Verify that start_op creates a PutOp with stats=None initially.
-    /// Stats should only be populated when a target peer is chosen during forwarding.
-    #[test]
-    fn start_op_creates_put_with_no_stats() {
-        let contract = make_test_contract(&[1u8]);
-        let op = start_op(
-            contract,
-            RelatedContracts::default(),
-            WrappedState::new(vec![]),
-            10,
-            false,
-            false,
-        );
-        assert!(
-            op.stats.is_none(),
-            "start_op should create PutOp with stats=None"
-        );
-        // Without stats, outcome should be Incomplete (not finalized, no stats)
-        assert!(matches!(op.outcome(), OpOutcome::Incomplete));
-    }
-
-    /// Simulate a put operation lifecycle: initially no stats, then stats are set
-    /// when forwarding, then state is Finished → outcome should be SuccessUntimed.
+    /// Simulate a put operation lifecycle: initially no stats (state=None),
+    /// then stats are set when forwarding, then state is Finished →
+    /// outcome should be SuccessUntimed.
     #[test]
     fn put_op_stats_lifecycle_from_initial_to_finished() {
         use crate::ring::{Location, PeerKeyLocation};
@@ -2454,22 +2267,19 @@ mod tests {
         let target_peer = PeerKeyLocation::random();
         let contract_location = Location::random();
 
-        // Step 1: Initial state - no stats, PrepareRequest
-        let mut op = PutOp {
-            id: Transaction::new::<PutMsg>(),
-            state: Some(PutState::PrepareRequest(PrepareRequestData {
-                contract: make_test_contract(&[1u8]),
-                related_contracts: RelatedContracts::default(),
-                value: WrappedState::new(vec![]),
-                htl: 10,
-                subscribe: false,
-                blocking_subscribe: false,
-            })),
-            upstream_addr: None,
-            stats: None,
-            ack_received: false,
-            speculative_paths: 0,
-        };
+        // Step 1: Initial state - in-flight AwaitingResponse, no stats yet
+        let mut op = make_put_op(Some(PutState::AwaitingResponse(AwaitingResponseData {
+            subscribe: false,
+            blocking_subscribe: false,
+            next_hop: None,
+            current_htl: 10,
+            contract_key: make_contract_key(0),
+            tried_peers: HashSet::new(),
+            alternatives: vec![],
+            attempts_at_hop: 1,
+            visited: VisitedPeers::default(),
+            retry_payload: None,
+        })));
         assert!(matches!(op.outcome(), OpOutcome::Incomplete));
         assert!(op.failure_routing_info().is_none());
 
@@ -2478,19 +2288,6 @@ mod tests {
             target_peer: target_peer.clone(),
             contract_location,
         });
-        op.state = Some(PutState::AwaitingResponse(AwaitingResponseData {
-            subscribe: false,
-            blocking_subscribe: false,
-            next_hop: None,
-            current_htl: 9,
-            contract_key: make_contract_key(0),
-
-            tried_peers: HashSet::new(),
-            alternatives: vec![],
-            attempts_at_hop: 1,
-            visited: VisitedPeers::default(),
-            retry_payload: None,
-        }));
         // Not finalized yet, but has stats → failure
         match op.outcome() {
             OpOutcome::ContractOpFailure {

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -472,11 +472,11 @@ impl Operation for PutOp {
             // Extract subscribe flags from state (only relevant for originator)
             let subscribe = match &self.state {
                 Some(PutState::AwaitingResponse(data)) => data.subscribe,
-                _ => false,
+                Some(PutState::Finished(_)) | None => false,
             };
             let blocking_subscribe = match &self.state {
                 Some(PutState::AwaitingResponse(data)) => data.blocking_subscribe,
-                _ => false,
+                Some(PutState::Finished(_)) | None => false,
             };
 
             match input {

--- a/crates/core/src/operations/put.rs
+++ b/crates/core/src/operations/put.rs
@@ -2081,12 +2081,19 @@ mod tests {
         );
     }
 
-    // Tests for blocking_subscribe propagation on AwaitingResponse state
-    #[test]
-    fn awaiting_response_carries_blocking_subscribe_true() {
-        let op = make_put_op(Some(PutState::AwaitingResponse(AwaitingResponseData {
-            subscribe: true,
-            blocking_subscribe: true,
+    // Tests for blocking_subscribe propagation on AwaitingResponse state.
+    //
+    // Replace deleted `start_op_*` constructor tests: since the
+    // task-per-tx driver (operations/put/op_ctx_task.rs) owns the
+    // originator path, the `PrepareRequest` state was removed and the
+    // first reachable PutState is AwaitingResponse. These tests lock
+    // the behavior the deleted tests covered (blocking_subscribe
+    // propagation, stats-none on fresh op) against the new shape.
+
+    fn awaiting_response_data(subscribe: bool, blocking_subscribe: bool) -> AwaitingResponseData {
+        AwaitingResponseData {
+            subscribe,
+            blocking_subscribe,
             next_hop: None,
             current_htl: 10,
             contract_key: make_contract_key(0),
@@ -2095,16 +2102,77 @@ mod tests {
             attempts_at_hop: 1,
             visited: VisitedPeers::default(),
             retry_payload: None,
-        })));
+        }
+    }
+
+    #[test]
+    fn awaiting_response_carries_blocking_subscribe_true() {
+        let op = make_put_op(Some(PutState::AwaitingResponse(awaiting_response_data(
+            true, true,
+        ))));
         match op.state {
-            Some(PutState::AwaitingResponse(data)) => {
-                assert!(
-                    data.blocking_subscribe,
-                    "blocking_subscribe should be true in AwaitingResponse"
-                );
-            }
+            Some(PutState::AwaitingResponse(data)) => assert!(
+                data.blocking_subscribe,
+                "blocking_subscribe should be true in AwaitingResponse"
+            ),
             other => panic!("Expected AwaitingResponse state, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn awaiting_response_with_explicit_tx_carries_blocking_subscribe_true() {
+        // Covers the removed start_op_with_id_propagates_blocking_subscribe_true:
+        // verify an explicit tx is preserved on the originator-side state.
+        let tx = Transaction::new::<PutMsg>();
+        let op = PutOp {
+            id: tx,
+            state: Some(PutState::AwaitingResponse(awaiting_response_data(
+                true, true,
+            ))),
+            upstream_addr: None,
+            stats: None,
+            ack_received: false,
+            speculative_paths: 0,
+        };
+        assert_eq!(op.id, tx, "explicit tx must round-trip into PutOp.id");
+        match op.state {
+            Some(PutState::AwaitingResponse(data)) => assert!(
+                data.blocking_subscribe,
+                "blocking_subscribe carries through AwaitingResponse when constructed with explicit tx"
+            ),
+            other => panic!("Expected AwaitingResponse state, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn awaiting_response_defaults_blocking_subscribe_false() {
+        // Covers the removed start_op_defaults_blocking_subscribe_false:
+        // subscribe=true + blocking_subscribe=false is a valid combo.
+        let op = make_put_op(Some(PutState::AwaitingResponse(awaiting_response_data(
+            true, false,
+        ))));
+        match op.state {
+            Some(PutState::AwaitingResponse(data)) => assert!(
+                !data.blocking_subscribe,
+                "blocking_subscribe should be false when unset, even if subscribe=true"
+            ),
+            other => panic!("Expected AwaitingResponse state, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn fresh_awaiting_response_op_has_no_stats() {
+        // Covers the removed start_op_creates_put_with_no_stats: a freshly
+        // spawned originator-side PutOp has stats=None until a target peer
+        // is chosen, so outcome() must be Incomplete.
+        let op = make_put_op(Some(PutState::AwaitingResponse(awaiting_response_data(
+            false, false,
+        ))));
+        assert!(
+            op.stats.is_none(),
+            "fresh AwaitingResponse PutOp should have stats=None"
+        );
+        assert!(matches!(op.outcome(), OpOutcome::Incomplete));
     }
 
     // Tests for outcome() method

--- a/docs/architecture/operations/README.md
+++ b/docs/architecture/operations/README.md
@@ -112,14 +112,21 @@ stateDiagram-v2
 
 ```mermaid
 stateDiagram-v2
-    [*] --> PrepareRequest
-    PrepareRequest --> AwaitingResponse : send to network
+    [*] --> AwaitingResponse : task-per-tx driver emits Request
     AwaitingResponse --> Finished : acknowledgment received
 
-    PrepareRequest : contract, value, htl, subscribe flag
-    AwaitingResponse : forwarding to peers
+    AwaitingResponse : contract, value, htl, subscribe flag;<br/>forwarding to peers
     Finished : stored successfully
 ```
+
+**Note:** Since #1454 Phase 3a, PUT originators no longer transition
+through a `PrepareRequest` state — the task-per-transaction driver
+(`operations/put/op_ctx_task.rs::start_client_put`) constructs the
+`Request` message and registers the op directly in `AwaitingResponse`.
+Relay PUTs (inbound `Request`/`RequestStreaming` from peers) are
+driven by `start_relay_put` / `start_relay_put_streaming` without
+materializing an `AwaitingResponse` state at all — the driver bubbles
+the upstream `Response` when the downstream ack arrives.
 
 **Key features:**
 - Hop-by-hop routing toward contract location


### PR DESCRIPTION
## Problem

Phase 5 slice A (#3917) and slice B (#3935) migrated every fresh inbound
relay PUT path — non-streaming and streaming — to the task-per-tx
driver. Client-initiated PUTs moved to the task-per-tx path in
phase 3a (#3843). The legacy originator entry points
(`put::start_op` / `put::start_op_with_id`) and their `PrepareRequest`
state survived only because they carried `#[allow(dead_code)]` markers;
nothing constructs `PutState::PrepareRequest` outside dedicated
constructor-shape tests.

Shipping this dead code costs clarity (reviewers have to reason about
a code path that cannot execute) and drifts further every phase.

## Solution

Delete:
- `PutState::PrepareRequest` variant + `PrepareRequestData` struct
- `put::start_op` / `put::start_op_with_id` free functions
- `PrepareRequestData::into_awaiting_response` transition method
- `AwaitingResponseData::into_finished` (unused alongside the above)
- 4 tests whose sole purpose was exercising the deleted constructors
- Redundant match arms on the deleted variant
  (put.rs:237, 275, 461, 466 before the delta)

Rewrites:
- `put_op_stats_lifecycle_from_initial_to_finished` now starts at
  `AwaitingResponse` (the actual entry state post-migration) instead
  of the deleted `PrepareRequest` shape
- `op_state_manager::tests::remove_put_removes_from_ops_map` uses a
  new `PutOp::new_empty_for_test(tx)` test-only ctor instead of the
  deleted `put::start_op`
- New test `awaiting_response_carries_blocking_subscribe_true`
  replaces the dropped PrepareRequest-shape assertions

Keeps (still live):
- `FinishedData` — constructed at put.rs:787/873/1396/1486 in active
  response paths
- `AwaitingResponseData` / `PutRetryPayload` — legacy relay + retry
- `PutState::AwaitingResponse` / `PutState::Finished` variants

## Net

~210 LOC removed. `cargo clippy -p freenet --tests -- -D warnings`
clean without any `#[allow(dead_code)]` markers on PUT state-machine
types.

## Testing

- \`cargo test -p freenet --lib\` → 2451 passed, 16 ignored
- \`cargo test -p freenet --lib operations::put::\` → 58 passed
- \`cargo clippy -p freenet --tests -- -D warnings\` → clean
- \`cargo fmt\` → clean

## Fixes

Follow-up to #1454 phase 5 (slice B, #3935). Tracks the "PUT dead-code
removal" item that was deferred from #3935 to a separate PR per the
PR description's "Deferred" block.